### PR TITLE
Ensuring output tree exists before attempting to drop collection

### DIFF
--- a/Framework/src/EventFile.cxx
+++ b/Framework/src/EventFile.cxx
@@ -113,7 +113,13 @@ namespace ldmx {
             parent_->tree_->SetBranchStatus(srule.c_str(),1);
             tree_->SetBranchStatus(srule.c_str(),1);
         } else if( isDrop ){
-            parent_->tree_->SetBranchStatus(srule.c_str(),0);
+	  if (! tree_) { 
+	    //this prevents creating a "ghost" branch in the output tree from the enabled branch in the input tree 
+	    parent_->tree_->SetBranchStatus(srule.c_str(),0);
+	    tree_ = parent_->tree_->CloneTree(0);
+	  }
+	  tree_->SetBranchStatus(srule.c_str(),0);
+	  parent_->tree_->SetBranchStatus(srule.c_str(),1);
         } else if( isIgnore ){
             parent_->tree_->SetBranchAddress(srule.c_str(),0);
         } else 
@@ -126,7 +132,9 @@ namespace ldmx {
             if (!parent_->tree_) {
                 EXCEPTION_RAISE("EventFile", "No event tree in the file");
             }
-            tree_ = parent_->tree_->CloneTree(0);
+	    if ( isOutputFile_ && !tree_) {
+	      tree_ = parent_->tree_->CloneTree(0);
+	    }
             event_->setInputTree(parent_->tree_);
             event_->setOutputTree(tree_);
         }


### PR DESCRIPTION
This fix avoids the seg fault that happens otherwise when a collection is flagged to be dropped 
from the output tree only (case: drop).
The collection can still be dropped already from the input tree (case: ignore).

The use case of regenerating an existing reco collection should have its own
flag "regenerate" where the input file collection is disabled and output
collection enabled, with the same name. Suggest new ticket for that.

As a sanity check, I have verified that the PE distribution etc is unaffected by dropping the HcalSimHits_sim collection from the reco file. So the input collection is kept and used as it should.

This pull request is in response to issue #555 (forgot to set the branch name accordingly). 