### PR TITLE
Iss966 - Update container-interacting bash functions

### DIFF
--- a/.ldmxrc
+++ b/.ldmxrc
@@ -1,0 +1,20 @@
+###############################################################################
+# Default Configuration File for ldmx-sw Container Environment
+#   This file is "sourced" everytime the environment script is sourced.
+#   i.e. 'source scripts/ldmx-env.sh --> ldmx source .ldmxrc'
+#
+#   Think of this file like a '.bashrc'. You can put your custom container
+#   configuration directly in this file. 
+#
+#   Each line starting with '#' is ignored. 
+#   White space is ignored.
+#   All other lines are given to the 'ldmx' command.
+#   This file is sourced in the directory that it is in.
+###############################################################################
+
+# LDMX_BASE should be parent directory of our current directory by default
+base ..
+
+# Use dev/latest container by default
+use dev latest
+

--- a/README.md
+++ b/README.md
@@ -44,10 +44,14 @@ Command | Purpose
 
 The environment script defines several other shell commands to help configure and debug the container environment.
 
-- `ldmx-container-tags repo` : List the container tags that you could use with the input repository: `dev`, `pro`, or `local`
-- `ldmx-container-pull repo tag` : Setup the environment for the container 'ldmx/repo:tag' and pull down the newest version if the repo is remote
-- `ldmx-container-config` : Print out how the container environment is currently configured
-- `ldmx-has-required-engine` : Return 0 if computer has a supported container-running engine and 1 otherwise
+- `ldmx list repo` : List the container tags that you could use with the input repository: `dev`, `pro`, or `local`
+- `ldmx use repo tag` : Setup the environment for the container 'ldmx/repo:tag' and pull down the newest version if the repo is remote
+- `ldmx config` : Print out how the container environment is currently configured
+- `ldmx clean all` : Reset environment to a blank state
+
+Use `ldmx help` for a full listing of these commands.
+If we don't define a command outside of the container,
+then the command is given to the container to run inside the current directory.
 
 ## Maintainer 
 

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -242,7 +242,7 @@ function _ldmx_list() {
 }
 
 ###############################################################################
-# ldmx-container-config
+# _ldmx_config
 #   Print the configuration of the current setup
 ###############################################################################
 function _ldmx_config() {
@@ -255,7 +255,7 @@ function _ldmx_config() {
 
 ###############################################################################
 # _ldmx_is_mounted
-#   Check if the input directory is mounted to the container
+#   Check if the input directory will be accessible by the container
 ###############################################################################
 _ldmx_is_mounted() {
   local full=$(realpath "$1")
@@ -395,16 +395,6 @@ HELP
 }
 
 ###############################################################################
-# _ldmx_error
-#   Print help and short description of what went wrong.
-###############################################################################
-_ldmx_error() {
-  _ldmx_help
-  echo "ERROR: $@"
-  return 0
-}
-
-###############################################################################
 # ldmx
 #   The root command for users interacting with the ldmx container environment.
 #   This function is really just focused on parsing CLI and going to the
@@ -444,10 +434,10 @@ function ldmx() {
     pull)
       if [[ "$#" != "3" ]]; then
         _ldmx_help
-        echo "ERROR: ldmx ${_sub_command} takes two arguments: <repo> <tag>."
+        echo "ERROR: 'ldmx pull' takes two arguments: <repo> <tag>."
         return 1
       fi
-      _ldmx_${_sub_command} $_sub_command_args "YES_PULL"
+      _ldmx_use $_sub_command_args "PULL_NO_MATTER_WHAT"
       return $?
       ;;
     use)
@@ -469,6 +459,17 @@ function ldmx() {
       ;;
   esac
 }
+
+###############################################################################
+# DONE WITH NECESSARY PARTS
+#   Everything below here is icing on the usability cake.
+###############################################################################
+
+###############################################################################
+# Bash Tab Completion
+#   This next section is focused on setting up the infrastucture for smart
+#   tab completion with the ldmx command and its sub-commands.
+###############################################################################
 
 ###############################################################################
 # _ldmx_complete_directory
@@ -541,7 +542,6 @@ _ldmx_dont_complete() {
 #   COMP_WORDS - bash array of space-separated command line inputs including base command
 #   COMP_CWORD - index of current word in argument list
 #   COMPREPLY  - options available to user, if only one, auto completed
-#
 ###############################################################################
 _ldmx_complete() {
   # disable readline filename completion

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -419,6 +419,8 @@ _ldmx_help() {
       ldmx use (dev | pro | local) <tag>
     pull    : Pull down the input repo and tag of the container
       ldmx pull (dev | pro | local) <tag>
+    mount   : Attach the input directory to the container when running
+      ldmx mount <dir>
     run     : Run a command at an input location in the container
       ldmx run <directory> <sub-command> [<argument> ...]
     source  : Run the commands in the provided file through ldmx

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -21,7 +21,7 @@
 # All of this setup requires us to be in a bash shell.
 #   We add this check to make sure the user is in a bash shell.
 ###############################################################################
-if [[ "$0" != "bash" ]]; then
+if [[ "$0" != *"bash"* ]]; then
   echo "[ldmx-env.sh] [ERROR] You aren't in a bash shell. You are in '$0'."
   [[ "$SHELL" = *"bash"* ]] || echo "  You're default shell '$SHELL' isn't bash."
   return 1
@@ -325,7 +325,8 @@ _ldmx_mount() {
     return 0
   fi
 
-  export LDMX_CONTAINER_MOUNTS+=($(realpath "$_dir_to_mount"))
+  LDMX_CONTAINER_MOUNTS+=($(realpath "$_dir_to_mount"))
+  export LDMX_CONTAINER_MOUNTS
   return 0
 }
 

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -15,6 +15,15 @@
 ###############################################################################
 
 ###############################################################################
+# All of this setup requires us to be in a bash shell.
+#   We add this check to make sure the user is in a bash shell.
+###############################################################################
+if [[ "$0" != "bash" ]]; then
+  echo "[ldmx-env.sh] [ERROR] You aren't in a bash shell."
+  return 1
+fi
+
+###############################################################################
 # _ldmx_has_required_engine
 #   Checks if user has any of the supported engines for running containers
 ###############################################################################
@@ -30,7 +39,7 @@ _ldmx_has_required_engine() {
 
 # check if user has a required engine
 if ! _ldmx_has_required_engine; then
-  echo "You do not have docker or singularity installed!"
+  echo "[ldmx-env.sh] [ERROR] You do not have docker or singularity installed!"
   return 1
 fi
 
@@ -54,7 +63,7 @@ _ldmx_which_os() {
 }
 
 if ! _ldmx_which_os; then
-  echo "[ldmx-env.sh][WARN] : Unable to detect OS Type from '${OSTYPE}'"
+  echo "[ldmx-env.sh] [WARN] Unable to detect OS Type from '${OSTYPE}'"
   echo "    You will *not* be able to run display-connected programs."
 fi
 

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -19,7 +19,8 @@
 #   We add this check to make sure the user is in a bash shell.
 ###############################################################################
 if [[ "$0" != "bash" ]]; then
-  echo "[ldmx-env.sh] [ERROR] You aren't in a bash shell."
+  echo "[ldmx-env.sh] [ERROR] You aren't in a bash shell. You are in '$0'."
+  [[ "$SHELL" = *"bash"* ]] || echo "  You're default shell '$SHELL' isn't bash."
   return 1
 fi
 


### PR DESCRIPTION
Since PR #965 requires some tweaks to the environment script, I have developed this updated container interface on top of those changes.

This resolves #966 by implementing what was discussed there, not much else to it.

At the request of @jmmans , I've included the **great idea** of having a `.ldmxrc` to persist the local configuration of the ldmx-sw computing environment. In the tree currently is a default configuration as an example.

:thinking: Maybe I want to write my own shell. :thinking: We could call it `ldmxsh` :laughing: 

[Why end with "rc"](https://superuser.com/questions/173165/what-does-the-rc-in-bashrc-etc-mean). I am open to other naming conventions too.