### PR TITLE
Increase HGCROC noise threshold by one ADC count

### DIFF
--- a/Tools/python/HgcrocEmulator.py
+++ b/Tools/python/HgcrocEmulator.py
@@ -67,7 +67,7 @@ class HgcrocEmulator() :
         self.noiseRMS         = 0. #mV - useless default
         self.setNoise( 700. , 25. ) #depends on readoutPadCapacitance
 
-        self.readoutThreshold = self.pedestal + 2. #ADC Counts
+        self.readoutThreshold = self.pedestal + 3. #ADC Counts
 
         self.toaThreshold     = 0. #mV - useless default
         self.totThreshold     = 0. #mV - useless default


### PR DESCRIPTION
This moves the threshold from ~3.2 sigma noise to ~4.8 sigma noise
hopefully decreasing the number of noise hits per event

This is a patch that really helps the ECal avoid generating too many noise hits.