### PR TITLE
Integrate WSL into display

### DIFF
--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -267,7 +267,9 @@ function _ldmx_list() {
 ###############################################################################
 function _ldmx_config() {
   echo "LDMX base directory: ${LDMX_BASE}"
-  echo "Display Port (empty means your OS not supported): ${LDMX_CONTAINER_DISPLAY}"
+  echo "uname: $(uname -a)"
+  echo "OSTYPE: ${OSTYPE}"
+  echo "Display Port: ${LDMX_CONTAINER_DISPLAY}"
   echo "Container Mounts: ${LDMX_CONTAINER_MOUNTS[@]}"
   _ldmx_container_config
   return $?

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -56,7 +56,7 @@ fi
 ###############################################################################
 export LDMX_CONTAINER_DISPLAY=""
 _ldmx_which_os() {
-  if false; then
+  if uname -a | grep -q microsoft; then
     # Windoze Subsystem for Linux
     export LDMX_CONTAINER_DISPLAY=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf 2>/dev/null)    
     return 0
@@ -74,7 +74,7 @@ _ldmx_which_os() {
 }
 
 if ! _ldmx_which_os; then
-  echo "[ldmx-env.sh] [WARN] Unable to detect OS Type from '${OSTYPE}'"
+  echo "[ldmx-env.sh] [WARN] Unable to detect OS Type from '${OSTYPE}' or '$(uname -a)'"
   echo "    You will *not* be able to run display-connected programs."
 fi
 

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -56,12 +56,17 @@ fi
 ###############################################################################
 export LDMX_CONTAINER_DISPLAY=""
 _ldmx_which_os() {
-  if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "freebsd"* ]]; then
+  if false; then
+    # Windoze Subsystem for Linux
     export LDMX_CONTAINER_DISPLAY=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf 2>/dev/null)    
     return 0
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OSX
     export LDMX_CONTAINER_DISPLAY="docker.for.mac.host.internal"
+    return 0
+  elif [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "freebsd"* ]]; then
+    # Linux distribution
+    export LDMX_CONTAINER_DISPLAY=""
     return 0
   fi
 

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -51,11 +51,13 @@ fi
 # _ldmx_which_os
 #   Check what OS we are hosting the container on.
 #   Taken from https://stackoverflow.com/a/8597411
+#   and to integrate Windoze Subsystem for Linux: 
+#     https://wiki.ubuntu.com/WSL#Running_Graphical_Applications
 ###############################################################################
 export LDMX_CONTAINER_DISPLAY=""
 _ldmx_which_os() {
   if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "freebsd"* ]]; then
-    export LDMX_CONTAINER_DISPLAY=""        
+    export LDMX_CONTAINER_DISPLAY=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf 2>/dev/null)    
     return 0
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OSX
@@ -260,7 +262,7 @@ function _ldmx_list() {
 ###############################################################################
 function _ldmx_config() {
   echo "LDMX base directory: ${LDMX_BASE}"
-  echo "Display Port (empty on Linux): ${LDMX_CONTAINER_DISPLAY}"
+  echo "Display Port (empty means your OS not supported): ${LDMX_CONTAINER_DISPLAY}"
   echo "Container Mounts: ${LDMX_CONTAINER_MOUNTS[@]}"
   _ldmx_container_config
   return $?


### PR DESCRIPTION
https://wiki.ubuntu.com/WSL#Running_Graphical_Applications for the details.

Essentially, we are assuming that an X server is running somewhere and we point our container directly to the IP of that server. On linux systems, the X server (probably) requires no setup while on Windoze, the user will need to install some X server for WSL to connect to. We didn't have this problem before because the `DISPLAY` variable on Linux systems is set to `:0` and some other nonsense can automagically connect to the X server. WSL can't do that.

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #996 by pointing our container directly to the X server that is running.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful. @D-Covey09 
- [x] ~~I attached any sub-module related changes to this PR.~~ NA
