### PR TITLE
Adding HcalTriggerID

### DIFF
--- a/DetDescr/include/DetDescr/HcalDigiID.h
+++ b/DetDescr/include/DetDescr/HcalDigiID.h
@@ -33,7 +33,7 @@ class HcalDigiID : public HcalAbstractID {
     if (!null() && bar_type() != Digi) {
       EXCEPTION_RAISE(
           "DetectorIDMismatch",
-          "Attempted to create HcalID from mismatched Hcal bar_type " +
+          "Attempted to create HcalDigiID from mismatched Hcal bar_type " +
               std::to_string(bar_type()));
     }
   }
@@ -45,7 +45,7 @@ class HcalDigiID : public HcalAbstractID {
     if (!null() && bar_type() != Digi) {
       EXCEPTION_RAISE(
           "DetectorIDMismatch",
-          "Attempted to create HcalID from mismatched Hcal bar_type " +
+          "Attempted to create HcalDigiID from mismatched Hcal bar_type " +
               std::to_string(bar_type()));
     }
   }

--- a/DetDescr/include/DetDescr/HcalDigiID.h
+++ b/DetDescr/include/DetDescr/HcalDigiID.h
@@ -12,13 +12,13 @@ namespace ldmx {
  */
 class HcalDigiID : public HcalAbstractID {
  public:
-  static const RawValue END_MASK{0x1}; // space for up to 2 ends of a strip
+  static const RawValue END_MASK{0x1};  // space for up to 2 ends of a strip
   static const RawValue END_SHIFT{19};
-  static const RawValue SECTION_MASK{0x7}; // space for up to 7 sections
+  static const RawValue SECTION_MASK{0x7};  // space for up to 7 sections
   static const RawValue SECTION_SHIFT{16};
-  static const RawValue LAYER_MASK{0xFF}; // space for up to 255 layers
+  static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
   static const RawValue LAYER_SHIFT{8};
-  static const RawValue STRIP_MASK{0xFF}; // space for 255 strips/layer
+  static const RawValue STRIP_MASK{0xFF};  // space for 255 strips/layer
   static const RawValue STRIP_SHIFT{0};
 
   /**
@@ -130,6 +130,6 @@ class HcalDigiID : public HcalAbstractID {
    */
   friend std::ostream &operator<<(std::ostream &, const ldmx::HcalDigiID &id);
 };
-} // namespace ldmx
+}  // namespace ldmx
 
 #endif

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -23,6 +23,8 @@ class HcalTriggerID : public HcalAbstractID {
    */
   enum HcalSection { BACK = 0, TOP = 1, BOTTOM = 2, LEFT = 4, RIGHT = 3 };
 
+  static const RawValue END_MASK{0x1}; // space for up to 2 ends of a strip
+  static const RawValue END_SHIFT{19};
   static const RawValue SECTION_MASK{0x7};  // space for up to 7 sections
   static const RawValue SECTION_SHIFT{18};
   static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
@@ -62,11 +64,13 @@ class HcalTriggerID : public HcalAbstractID {
   /**
    * Create from pieces
    */
-  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int superstrip)
+  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int superstrip,
+                 unsigned int end)
       : HcalAbstractID(Trigger, 0) {
     id_ |= (section & SECTION_MASK) << SECTION_SHIFT;
     id_ |= (layer & LAYER_MASK) << LAYER_SHIFT;
     id_ |= (superstrip & SUPERSTRIP_MASK) << SUPERSTRIP_SHIFT;
+    id_ |= (end & END_MASK) << END_SHIFT;
   }
 
   /*
@@ -104,7 +108,24 @@ class HcalTriggerID : public HcalAbstractID {
    * @return The value of 'superstrip' field.
    */
   int superstrip() const { return (id_ >> SUPERSTRIP_SHIFT) & SUPERSTRIP_MASK; }
-  
+
+  /**
+   * Get the value of the 'end' field from the ID.
+   * @return The value of the 'end' field.
+   */
+  int end() const { return (id_ >> END_SHIFT) & END_MASK; }
+
+  /**
+   * Get whether the 'end' field from the ID is negative.
+   * @return True if the end of the strip is negative
+   */
+  bool isNegativeEnd() const {
+    if (end() == 1)
+      return true;
+    else
+      return false;
+  }
+
   static void createInterpreters();
 };
 }  // namespace ldmx

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -105,18 +105,6 @@ class HcalTriggerID : public HcalAbstractID {
    */
   int superstrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
   
-  //  /**
-  //   * Get the value of the 'strip' field from the ID.
-  //   * @return The value of 'strip' field.
-  //   */
-  //  int getStrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
-  //
-  //  /**
-  //   * Get the value of the 'strip' field from the ID.
-  //   * @return The value of 'strip' field.
-  //   */
-  //  int strip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
-
   static void createInterpreters();
 };
 }  // namespace ldmx

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -23,13 +23,13 @@ class HcalTriggerID : public HcalAbstractID {
    */
   enum HcalSection { BACK = 0, TOP = 1, BOTTOM = 2, LEFT = 4, RIGHT = 3 };
 
-  static const RawValue END_MASK{0x2}; // space for 2 ends plus a combined TP
+  static const RawValue END_MASK{0x3};  // space for 2 ends plus a combined TP
   static const RawValue END_SHIFT{20};
   static const RawValue SECTION_MASK{0x7};  // space for up to 7 sections
-  static const RawValue SECTION_SHIFT{18};
+  static const RawValue SECTION_SHIFT{16};
   static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
-  static const RawValue LAYER_SHIFT{10};
-  static const RawValue SUPERSTRIP_MASK{0xFF};  // space for 255 superstrips/layer
+  static const RawValue LAYER_SHIFT{8};
+  static const RawValue SUPERSTRIP_MASK{0xFF};  // space for 255 strips/layer
   static const RawValue SUPERSTRIP_SHIFT{0};
 
   /**
@@ -64,8 +64,8 @@ class HcalTriggerID : public HcalAbstractID {
   /**
    * Create from pieces
    */
-  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int superstrip,
-                 unsigned int end)
+  HcalTriggerID(unsigned int section, unsigned int layer,
+                unsigned int superstrip, unsigned int end)
       : HcalAbstractID(Trigger, 0) {
     id_ |= (section & SECTION_MASK) << SECTION_SHIFT;
     id_ |= (layer & LAYER_MASK) << LAYER_SHIFT;
@@ -101,7 +101,9 @@ class HcalTriggerID : public HcalAbstractID {
    * Get the value of the 'superstrip' field from the ID.
    * @return The value of 'superstrip' field.
    */
-  int getSuperstrip() const { return (id_ >> SUPERSTRIP_SHIFT) & SUPERSTRIP_MASK; }
+  int getSuperstrip() const {
+    return (id_ >> SUPERSTRIP_SHIFT) & SUPERSTRIP_MASK;
+  }
 
   /**
    * Get the value of the 'superstrip' field from the ID.

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -1,0 +1,126 @@
+/**
+ * @file HcalTriggerID.h
+ * @brief Class that defines an HCal trigger cell detector ID
+ * @author Christian Herwig, Fermi National Accelerator Laboratory
+ */
+
+#ifndef DETDESCR_HCALTRIGGERID_H_
+#define DETDESCR_HCALTRIGGERID_H_
+
+// LDMX
+#include "DetDescr/HcalAbstractID.h"
+
+namespace ldmx {
+
+/**
+ * @class HcalTriggerID
+ * @brief Extension of DetectorID providing access to HCal trigger cell
+ */
+class HcalTriggerID : public HcalAbstractID {
+ public:
+  /**
+   * Encodes the section of the HCal based on the 'section' field value.
+   */
+  enum HcalSection { BACK = 0, TOP = 1, BOTTOM = 2, LEFT = 4, RIGHT = 3 };
+
+  static const RawValue SECTION_MASK{0x7};  // space for up to 7 sections
+  static const RawValue SECTION_SHIFT{18};
+  static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
+  static const RawValue LAYER_SHIFT{10};
+  static const RawValue STRIP_MASK{0xFF};  // space for 255 strips/layer
+  static const RawValue STRIP_SHIFT{0};
+
+  /**
+   * Empty HCAL trigger id (but not null!)
+   */
+  HcalTriggerID() : HcalAbstractID() {}
+
+  /**
+   * Create from raw number
+   */
+  HcalTriggerID(RawValue rawid) : HcalAbstractID(rawid) {
+    if (!null() && bar_type() != Trigger) {
+      EXCEPTION_RAISE(
+          "DetectorIDMismatch",
+          "Attempted to create HcalTriggerID from mismatched Hcal bar_type " +
+              std::to_string(bar_type()));
+    }
+  }
+
+  /**
+   * Create from a DetectorID, but check
+   */
+  HcalTriggerID(const HcalAbstractID id) : HcalAbstractID(id) {
+    if (!null() && bar_type() != Trigger) {
+      EXCEPTION_RAISE(
+          "DetectorIDMismatch",
+          "Attempted to create HcalTriggerID from mismatched Hcal bar_type " +
+              std::to_string(bar_type()));
+    }
+  }
+
+  /**
+   * Create from pieces
+   */
+  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int strip)
+      : HcalAbstractID(Trigger, 0) {
+    id_ |= (section & SECTION_MASK) << SECTION_SHIFT;
+    id_ |= (layer & LAYER_MASK) << LAYER_SHIFT;
+    id_ |= (strip & STRIP_MASK) << STRIP_SHIFT;
+  }
+
+  /*
+   * Get the value of the 'section' field from the ID.
+   * @return The value of the 'strip' field.
+   */
+  int getSection() const { return (id_ >> SECTION_SHIFT) & SECTION_MASK; }
+
+  /*
+   * Get the value of the 'section' field from the ID.
+   * @return The value of the 'strip' field.
+   */
+  int section() const { return (id_ >> SECTION_SHIFT) & SECTION_MASK; }
+
+  /**
+   * Get the value of the layer field from the ID.
+   * @return The value of the layer field.
+   */
+  int layer() const { return (id_ >> LAYER_SHIFT) & LAYER_MASK; }
+
+  /**
+   * Get the value of the layer field from the ID.
+   * @return The value of the layer field.
+   */
+  int getLayerID() const { return (id_ >> LAYER_SHIFT) & LAYER_MASK; }
+
+  /**
+   * Get the value of the 'superstrip' field from the ID.
+   * @return The value of 'superstrip' field.
+   */
+  int getSuperstrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+
+  /**
+   * Get the value of the 'superstrip' field from the ID.
+   * @return The value of 'superstrip' field.
+   */
+  int superstrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+  
+  //  /**
+  //   * Get the value of the 'strip' field from the ID.
+  //   * @return The value of 'strip' field.
+  //   */
+  //  int getStrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+  //
+  //  /**
+  //   * Get the value of the 'strip' field from the ID.
+  //   * @return The value of 'strip' field.
+  //   */
+  //  int strip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+
+  static void createInterpreters();
+};
+}  // namespace ldmx
+
+std::ostream& operator<<(std::ostream&, const ldmx::HcalTriggerID&);
+
+#endif

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -27,8 +27,8 @@ class HcalTriggerID : public HcalAbstractID {
   static const RawValue SECTION_SHIFT{18};
   static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
   static const RawValue LAYER_SHIFT{10};
-  static const RawValue STRIP_MASK{0xFF};  // space for 255 strips/layer
-  static const RawValue STRIP_SHIFT{0};
+  static const RawValue SUPERSTRIP_MASK{0xFF};  // space for 255 superstrips/layer
+  static const RawValue SUPERSTRIP_SHIFT{0};
 
   /**
    * Empty HCAL trigger id (but not null!)
@@ -62,22 +62,22 @@ class HcalTriggerID : public HcalAbstractID {
   /**
    * Create from pieces
    */
-  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int strip)
+  HcalTriggerID(unsigned int section, unsigned int layer, unsigned int superstrip)
       : HcalAbstractID(Trigger, 0) {
     id_ |= (section & SECTION_MASK) << SECTION_SHIFT;
     id_ |= (layer & LAYER_MASK) << LAYER_SHIFT;
-    id_ |= (strip & STRIP_MASK) << STRIP_SHIFT;
+    id_ |= (superstrip & SUPERSTRIP_MASK) << SUPERSTRIP_SHIFT;
   }
 
   /*
    * Get the value of the 'section' field from the ID.
-   * @return The value of the 'strip' field.
+   * @return The value of the 'section' field.
    */
   int getSection() const { return (id_ >> SECTION_SHIFT) & SECTION_MASK; }
 
   /*
    * Get the value of the 'section' field from the ID.
-   * @return The value of the 'strip' field.
+   * @return The value of the 'section' field.
    */
   int section() const { return (id_ >> SECTION_SHIFT) & SECTION_MASK; }
 
@@ -97,13 +97,13 @@ class HcalTriggerID : public HcalAbstractID {
    * Get the value of the 'superstrip' field from the ID.
    * @return The value of 'superstrip' field.
    */
-  int getSuperstrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+  int getSuperstrip() const { return (id_ >> SUPERSTRIP_SHIFT) & SUPERSTRIP_MASK; }
 
   /**
    * Get the value of the 'superstrip' field from the ID.
    * @return The value of 'superstrip' field.
    */
-  int superstrip() const { return (id_ >> STRIP_SHIFT) & STRIP_MASK; }
+  int superstrip() const { return (id_ >> SUPERSTRIP_SHIFT) & SUPERSTRIP_MASK; }
   
   static void createInterpreters();
 };

--- a/DetDescr/include/DetDescr/HcalTriggerID.h
+++ b/DetDescr/include/DetDescr/HcalTriggerID.h
@@ -23,8 +23,8 @@ class HcalTriggerID : public HcalAbstractID {
    */
   enum HcalSection { BACK = 0, TOP = 1, BOTTOM = 2, LEFT = 4, RIGHT = 3 };
 
-  static const RawValue END_MASK{0x1}; // space for up to 2 ends of a strip
-  static const RawValue END_SHIFT{19};
+  static const RawValue END_MASK{0x2}; // space for 2 ends plus a combined TP
+  static const RawValue END_SHIFT{20};
   static const RawValue SECTION_MASK{0x7};  // space for up to 7 sections
   static const RawValue SECTION_SHIFT{18};
   static const RawValue LAYER_MASK{0xFF};  // space for up to 255 layers
@@ -119,12 +119,13 @@ class HcalTriggerID : public HcalAbstractID {
    * Get whether the 'end' field from the ID is negative.
    * @return True if the end of the strip is negative
    */
-  bool isNegativeEnd() const {
-    if (end() == 1)
-      return true;
-    else
-      return false;
-  }
+  bool isNegativeEnd() const { return end() == 1; }
+
+  /**
+   * Get whether the ID is the composite of two bar ends.
+   * @return True if the ID corresponds to a composite TP.
+   */
+  bool isComposite() const { return end() == 2; }
 
   static void createInterpreters();
 };

--- a/DetDescr/src/DetDescr/HcalTriggerID.cxx
+++ b/DetDescr/src/DetDescr/HcalTriggerID.cxx
@@ -3,7 +3,7 @@
 
 std::ostream& operator<<(std::ostream& s, const ldmx::HcalTriggerID& id) {
   s << "HcalTrig(" << id.section() << ',' << id.layer() << ','
-    << id.superstrip() << ')';
+    << id.superstrip() << ',' << id.end() << ')';
   return s;
 }
 
@@ -21,6 +21,9 @@ void HcalTriggerID::createInterpreters() {
   fields.push_back(
       new IDField("superstrip", 3, SUPERSTRIP_SHIFT,
                   SUPERSTRIP_SHIFT + IDField::countOnes(SUPERSTRIP_MASK) - 1));
+  fields.push_back(
+      new IDField("end", 4, END_SHIFT,
+                  END_SHIFT + IDField::countOnes(END_MASK) - 1));
 
   DetectorIDInterpreter::registerInterpreter(
       SD_HCAL, HcalAbstractID::BAR_TYPE_MASK << HcalAbstractID::BAR_TYPE_SHIFT,

--- a/DetDescr/src/DetDescr/HcalTriggerID.cxx
+++ b/DetDescr/src/DetDescr/HcalTriggerID.cxx
@@ -1,4 +1,5 @@
 #include "DetDescr/HcalTriggerID.h"
+
 #include "DetDescr/DetectorIDInterpreter.h"
 
 std::ostream& operator<<(std::ostream& s, const ldmx::HcalTriggerID& id) {
@@ -21,9 +22,8 @@ void HcalTriggerID::createInterpreters() {
   fields.push_back(
       new IDField("superstrip", 3, SUPERSTRIP_SHIFT,
                   SUPERSTRIP_SHIFT + IDField::countOnes(SUPERSTRIP_MASK) - 1));
-  fields.push_back(
-      new IDField("end", 4, END_SHIFT,
-                  END_SHIFT + IDField::countOnes(END_MASK) - 1));
+  fields.push_back(new IDField("end", 4, END_SHIFT,
+                               END_SHIFT + IDField::countOnes(END_MASK) - 1));
 
   DetectorIDInterpreter::registerInterpreter(
       SD_HCAL, HcalAbstractID::BAR_TYPE_MASK << HcalAbstractID::BAR_TYPE_SHIFT,

--- a/DetDescr/src/DetDescr/HcalTriggerID.cxx
+++ b/DetDescr/src/DetDescr/HcalTriggerID.cxx
@@ -19,8 +19,8 @@ void HcalTriggerID::createInterpreters() {
       new IDField("layer", 2, LAYER_SHIFT,
                   LAYER_SHIFT + IDField::countOnes(LAYER_MASK) - 1));
   fields.push_back(
-      new IDField("strip", 3, STRIP_SHIFT,
-                  STRIP_SHIFT + IDField::countOnes(STRIP_MASK) - 1));
+      new IDField("superstrip", 3, SUPERSTRIP_SHIFT,
+                  SUPERSTRIP_SHIFT + IDField::countOnes(SUPERSTRIP_MASK) - 1));
 
   DetectorIDInterpreter::registerInterpreter(
       SD_HCAL, HcalAbstractID::BAR_TYPE_MASK << HcalAbstractID::BAR_TYPE_SHIFT,

--- a/DetDescr/src/DetDescr/HcalTriggerID.cxx
+++ b/DetDescr/src/DetDescr/HcalTriggerID.cxx
@@ -1,0 +1,30 @@
+#include "DetDescr/HcalTriggerID.h"
+#include "DetDescr/DetectorIDInterpreter.h"
+
+std::ostream& operator<<(std::ostream& s, const ldmx::HcalTriggerID& id) {
+  s << "HcalTrig(" << id.section() << ',' << id.layer() << ','
+    << id.superstrip() << ')';
+  return s;
+}
+
+namespace ldmx {
+
+void HcalTriggerID::createInterpreters() {
+  IDField::IDFieldList fields;
+  fields.push_back(new IDField("subdetector", 0, SUBDETECTORID_SHIFT, 31));
+  fields.push_back(
+      new IDField("section", 1, SECTION_SHIFT,
+                  SECTION_SHIFT + IDField::countOnes(SECTION_MASK) - 1));
+  fields.push_back(
+      new IDField("layer", 2, LAYER_SHIFT,
+                  LAYER_SHIFT + IDField::countOnes(LAYER_MASK) - 1));
+  fields.push_back(
+      new IDField("strip", 3, STRIP_SHIFT,
+                  STRIP_SHIFT + IDField::countOnes(STRIP_MASK) - 1));
+
+  DetectorIDInterpreter::registerInterpreter(
+      SD_HCAL, HcalAbstractID::BAR_TYPE_MASK << HcalAbstractID::BAR_TYPE_SHIFT,
+      HcalAbstractID::Trigger << HcalAbstractID::BAR_TYPE_SHIFT, fields);
+}
+
+}  // namespace ldmx

--- a/Recon/CMakeLists.txt
+++ b/Recon/CMakeLists.txt
@@ -25,6 +25,9 @@ if(BUILD_EVENT_ONLY)
                        register_event_object( module_path "Recon/Event" 
                          namespace "ldmx" class "HgcrocTrigDigi" 
                          type "collection" )
+                       register_event_object( module_path "Recon/Event" 
+                         namespace "ldmx" class "CaloTrigPrim" 
+                         type "collection" )
    setup_library(module Recon name Event
                  dependencies ROOT::Core
                  register_target)

--- a/Recon/include/Recon/Event/CaloTrigPrim.h
+++ b/Recon/include/Recon/Event/CaloTrigPrim.h
@@ -1,0 +1,122 @@
+#ifndef RECON_EVENT_CALOTRIGPRIM_H_
+#define RECON_EVENT_CALOTRIGPRIM_H_
+
+// ldmx-sw
+#include <stdint.h>  //uint32_t
+
+// ROOT
+#include "TObject.h"  //For ClassDef
+
+namespace ldmx {
+
+// Forward declaration needed by typedef
+class CaloTrigPrim;
+
+/**
+ * Define the type of collection for trig digis
+ */
+typedef std::vector<CaloTrigPrim> CaloTrigPrimCollection;
+
+/**
+ * @class CaloTrigPrim
+ * @brief Contains the trigger output for generic calo objects
+ */
+class CaloTrigPrim {
+ public:
+  /**
+   * Default Constructor
+   *
+   * Needed for ROOT dictionary definition,
+   * suggested to not use this constructor.
+   */
+  CaloTrigPrim() = default;
+
+  /**
+   * Preferred Constructor
+   *
+   * Defines the trigger group ID and
+   * the trigger primitive value.
+   *
+   * @param[in] tid raw trigger group ID
+   * @param[in] tp trigger primitive value
+   */
+  CaloTrigPrim(uint32_t tid, uint32_t tp = 0);
+
+  /**
+   * Destructor
+   *
+   * Needs to be defined for ROOT
+   * dictionary definition, does
+   * nothing right now.
+   */
+  virtual ~CaloTrigPrim() = default;
+
+  /**
+   * Sort the collection to trig digis
+   * by the raw ID.
+   *
+   * @param[in] d another digi to compare against
+   * @returns true if this ID is less than the other ID
+   */
+  bool operator<(const CaloTrigPrim &digi) { return tid_ < digi.tid_; }
+
+  /**
+   * Get the id of the digi
+   * @returns raw trigger ID
+   */
+  uint32_t getId() const { return tid_; }
+
+  /**
+   * Set the trigger primitive (7 bits) for the given link on a channel
+   * @params[in] tp the value of the trigger primitive
+   */
+  void setPrimitive(uint32_t tp) { tp_ = tp; }
+
+  /**
+   * Get the trigger primitive (7 bits) for the given link on a channel
+   * @returns the value of the trigger primitive
+   */
+  uint32_t getPrimitive() const { return tp_; }
+
+  /**
+   * Print a description of this object.
+   */
+  void Print() const;
+
+  /**
+   * Stream the input digi
+   *
+   * In one line, prints out the ID (in hex),
+   * the primitive (in hex), and the linearized
+   * primitive (in dec).
+   *
+   * @param[in] o ostream to write to
+   * @param[in] d digi to write out
+   * @returns modified ostream
+   */
+  friend std::ostream &operator<<(std::ostream &o, const CaloTrigPrim &d);
+
+  /**
+   * Stream the input digi collection
+   *
+   * Prints out each digi member of the collection
+   * on a new line.
+   *
+   * @param[in] o ostream to write to
+   * @param[in] c collection to write out
+   * @returns modified ostream
+   */
+  friend std::ostream &operator<<(std::ostream &o,
+                                  const CaloTrigPrimCollection &c);
+
+ private:
+  /// the raw ID for this trigger channel
+  uint32_t tid_{0};
+  /// the compressed 7bit trigger primitive value for this channel
+  uint32_t tp_{0};
+  /// ROOT Dictionary class definition macro
+  ClassDef(CaloTrigPrim, 1);
+};
+}  // namespace ldmx
+
+#endif  // RECON_EVENT_CALOTRIGPRIM_H_

--- a/Recon/include/Recon/Event/CaloTrigPrim.h
+++ b/Recon/include/Recon/Event/CaloTrigPrim.h
@@ -13,7 +13,7 @@ namespace ldmx {
 class CaloTrigPrim;
 
 /**
- * Define the type of collection for trig digis
+ * Define the type of collection for trig primitives
  */
 typedef std::vector<CaloTrigPrim> CaloTrigPrimCollection;
 
@@ -52,28 +52,28 @@ class CaloTrigPrim {
   virtual ~CaloTrigPrim() = default;
 
   /**
-   * Sort the collection to trig digis
+   * Sort the collection of CaloTPs
    * by the raw ID.
    *
-   * @param[in] d another digi to compare against
+   * @param[in] c another CaloTP to compare against
    * @returns true if this ID is less than the other ID
    */
-  bool operator<(const CaloTrigPrim &digi) { return tid_ < digi.tid_; }
+  bool operator<(const CaloTrigPrim &c) { return tid_ < c.tid_; }
 
   /**
-   * Get the id of the digi
+   * Get the id of the CaloTP
    * @returns raw trigger ID
    */
   uint32_t getId() const { return tid_; }
 
   /**
-   * Set the trigger primitive (7 bits) for the given link on a channel
+   * Set the trigger primitive value for the given channel
    * @params[in] tp the value of the trigger primitive
    */
   void setPrimitive(uint32_t tp) { tp_ = tp; }
 
   /**
-   * Get the trigger primitive (7 bits) for the given link on a channel
+   * Get the trigger primitive value for the given channel
    * @returns the value of the trigger primitive
    */
   uint32_t getPrimitive() const { return tp_; }
@@ -84,35 +84,34 @@ class CaloTrigPrim {
   void Print() const;
 
   /**
-   * Stream the input digi
+   * Stream the input CaloTP
    *
    * In one line, prints out the ID (in hex),
-   * the primitive (in hex), and the linearized
-   * primitive (in dec).
+   * the primitive (in hex).
    *
-   * @param[in] o ostream to write to
-   * @param[in] d digi to write out
+   * @param[in] s ostream to write to
+   * @param[in] d tp to write out
    * @returns modified ostream
    */
-  friend std::ostream &operator<<(std::ostream &o, const CaloTrigPrim &d);
+  friend std::ostream &operator<<(std::ostream &s, const CaloTrigPrim &c);
 
   /**
-   * Stream the input digi collection
+   * Stream the input tp collection
    *
-   * Prints out each digi member of the collection
+   * Prints out each tp member of the collection
    * on a new line.
    *
-   * @param[in] o ostream to write to
+   * @param[in] s ostream to write to
    * @param[in] c collection to write out
    * @returns modified ostream
    */
-  friend std::ostream &operator<<(std::ostream &o,
+  friend std::ostream &operator<<(std::ostream &s,
                                   const CaloTrigPrimCollection &c);
 
  private:
   /// the raw ID for this trigger channel
   uint32_t tid_{0};
-  /// the compressed 7bit trigger primitive value for this channel
+  /// the integer trigger primitive value for this channel
   uint32_t tp_{0};
   /// ROOT Dictionary class definition macro
   ClassDef(CaloTrigPrim, 1);

--- a/Recon/src/Recon/Event/CaloTrigPrim.cxx
+++ b/Recon/src/Recon/Event/CaloTrigPrim.cxx
@@ -1,0 +1,27 @@
+#include "Recon/Event/CaloTrigPrim.h"
+
+#include <iostream>
+
+ClassImp(ldmx::CaloTrigPrim)
+
+    namespace ldmx {
+  CaloTrigPrim::CaloTrigPrim(uint32_t tid, uint32_t tp) : tid_(tid), tp_{tp} {}
+
+  void CaloTrigPrim::Print() const { std::cout << *this << std::endl; }
+
+  std::ostream &operator<<(std::ostream &s, const ldmx::CaloTrigPrim &digi) {
+    s << "CaloTrigPrim { "
+      << "(id : 0x" << std::hex << digi.getId() << std::dec << ") ";
+    s << "0x" << std::hex << int(digi.getPrimitive()) << " } ";
+    return s;
+  }
+
+  std::ostream &operator<<(std::ostream &s,
+                           const ldmx::CaloTrigPrimCollection &digis) {
+    s << "CaloTrigPrimCollection { " << std::endl;
+    for (auto digi : digis) s << "  " << digi << std::endl;
+    s << "}";
+    return s;
+  }
+
+}  // namespace ldmx

--- a/Recon/src/Recon/Event/CaloTrigPrim.cxx
+++ b/Recon/src/Recon/Event/CaloTrigPrim.cxx
@@ -9,17 +9,17 @@ ClassImp(ldmx::CaloTrigPrim)
 
   void CaloTrigPrim::Print() const { std::cout << *this << std::endl; }
 
-  std::ostream &operator<<(std::ostream &s, const ldmx::CaloTrigPrim &digi) {
+  std::ostream &operator<<(std::ostream &s, const ldmx::CaloTrigPrim &c) {
     s << "CaloTrigPrim { "
-      << "(id : 0x" << std::hex << digi.getId() << std::dec << ") ";
-    s << "0x" << std::hex << int(digi.getPrimitive()) << " } ";
+      << "(id : 0x" << std::hex << c.getId() << std::dec << ") ";
+    s << "0x" << std::hex << int(c.getPrimitive()) << " } ";
     return s;
   }
 
   std::ostream &operator<<(std::ostream &s,
-                           const ldmx::CaloTrigPrimCollection &digis) {
+                           const ldmx::CaloTrigPrimCollection &cs) {
     s << "CaloTrigPrimCollection { " << std::endl;
-    for (auto digi : digis) s << "  " << digi << std::endl;
+    for (auto c : cs) s << "  " << c << std::endl;
     s << "}";
     return s;
   }


### PR DESCRIPTION
I am updating _ldmx-sw_ to include an HcalTriggerID class, resolving #1013.
This development is related to (but does not depend on) a PR to the Hcal repo adding a producer for the trigger primitive objects.