### PR TITLE
need to bump digi coll version to preserve decoding

### DIFF
--- a/Recon/include/Recon/Event/HgcrocDigiCollection.h
+++ b/Recon/include/Recon/Event/HgcrocDigiCollection.h
@@ -529,7 +529,7 @@ class HgcrocDigiCollection {
   /**
    * The ROOT class definition.
    */
-  ClassDef(HgcrocDigiCollection, 3);
+  ClassDef(HgcrocDigiCollection, 4);
 };
 }  // namespace ldmx
 


### PR DESCRIPTION
forgot to bump the root class def version when changing
the type of data that was stored on disk, this has led
to some issues decoding a data-on-disk
