### PR TITLE
Ntuplize hgcroc digis

### DIFF
--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -162,11 +162,13 @@ class NtuplizeHgcrocDigiCollection(ldmxcfg.Analyzer) :
             # deduce if using eid based on presence of HcalDetectorMap in conditions system
             from LDMX.Framework import ldmxcfg
             from LDMX.Hcal.DetectorMap import HcalDetectorMap
-            self.using_eid = True
+            using_eid = True
             for cop in ldmxcfg.Process.lastProcess.conditionsObjectProviders :
                 if isinstance(cop,HcalDetectorMap) :
-                    self.using_eid = False
+                    using_eid = False
                     break
+
+        self.using_eid = using_eid
 
         from LDMX.Conditions.SimpleCSVTableProvider import SimpleCSVIntegerTableProvider
         if pedestal_table is None :

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -152,6 +152,20 @@ class HCalRawDigi(ldmxcfg.Analyzer) :
         self.input_name = input_name
         self.input_pass = ''
 
+class NtuplizeHgcrocDigiCollection(ldmxcfg.Analyzer) :
+    def __init__(self,input_name, pedestal_table = 'NO_PEDESTALS', input_pass = '', name = 'ntuplizehgcroc') :
+        super().__init__(name,'dqm::NtuplizeHgcrocDigiCollection','DQM')
+        self.input_name = input_name
+        self.input_pass = input_pass
+        self.pedestal_table = pedestal_table
+
+        from LDMX.Conditions.SimpleCSVTableProvider import SimpleCSVIntegerTableProvider
+        t = SimpleCSVIntegerTableProvider(pedestal_table,["PEDESTAL"])
+        if pedestal_table == 'NO_PEDESTALS' :
+            t.validForAllRows([0])
+        else :
+            t.validForever(f'file://{pedestal_table}')
+
 class PhotoNuclearDQM(ldmxcfg.Analyzer) :
     """Configured PhotoNuclearDQM python object
     

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -153,17 +153,19 @@ class HCalRawDigi(ldmxcfg.Analyzer) :
         self.input_pass = ''
 
 class NtuplizeHgcrocDigiCollection(ldmxcfg.Analyzer) :
-    def __init__(self,input_name, pedestal_table = 'NO_PEDESTALS', input_pass = '', name = 'ntuplizehgcroc') :
+    def __init__(self,input_name, pedestal_table = None, input_pass = '', name = 'ntuplizehgcroc') :
         super().__init__(name,'dqm::NtuplizeHgcrocDigiCollection','DQM')
         self.input_name = input_name
         self.input_pass = input_pass
-        self.pedestal_table = pedestal_table
 
         from LDMX.Conditions.SimpleCSVTableProvider import SimpleCSVIntegerTableProvider
-        t = SimpleCSVIntegerTableProvider(pedestal_table,["PEDESTAL"])
-        if pedestal_table == 'NO_PEDESTALS' :
+        if pedestal_table is None :
+            self.pedestal_table = 'NO_PEDESTALS'
+            t = SimpleCSVIntegerTableProvider('NO_PEDESTALS',["PEDESTAL"])
             t.validForAllRows([0])
         else :
+            self.pedestal_table = pedestal_table
+            t = SimpleCSVIntegerTableProvider(pedestal_table,["PEDESTAL"])
             t.validForever(f'file://{pedestal_table}')
 
 class PhotoNuclearDQM(ldmxcfg.Analyzer) :

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -153,10 +153,20 @@ class HCalRawDigi(ldmxcfg.Analyzer) :
         self.input_pass = ''
 
 class NtuplizeHgcrocDigiCollection(ldmxcfg.Analyzer) :
-    def __init__(self,input_name, pedestal_table = None, input_pass = '', name = 'ntuplizehgcroc') :
+    def __init__(self,input_name, pedestal_table = None, input_pass = '', using_eid = None, name = 'ntuplizehgcroc') :
         super().__init__(name,'dqm::NtuplizeHgcrocDigiCollection','DQM')
         self.input_name = input_name
         self.input_pass = input_pass
+
+        if using_eid is None :
+            # deduce if using eid based on presence of HcalDetectorMap in conditions system
+            from LDMX.Framework import ldmxcfg
+            from LDMX.Hcal.DetectorMap import HcalDetectorMap
+            self.using_eid = True
+            for cop in ldmxcfg.Process.lastProcess.conditionsObjectProviders :
+                if isinstance(cop,HcalDetectorMap) :
+                    self.using_eid = False
+                    break
 
         from LDMX.Conditions.SimpleCSVTableProvider import SimpleCSVIntegerTableProvider
         if pedestal_table is None :

--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -1,0 +1,73 @@
+
+#include "DetDescr/HcalElectronicsID.h"
+#include "Framework/EventProcessor.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+#include "Conditions/SimpleTableCondition.h"
+
+namespace dqm {
+
+class NtuplizeHgcrocDigiCollection : public framework::Analyzer {
+  std::string input_name_, input_pass_, pedestal_table_;
+  int raw_id_, fpga_, link_, channel_, index_, adc_, raw_adc_, i_sample_, event_;
+  TTree* flat_tree_;
+
+ public:
+  NtuplizeHgcrocDigiCollection(std::string const& n, framework::Process& p)
+      : framework::Analyzer(n, p) {}
+  ~NtuplizeHgcrocDigiCollection() {}
+
+  void configure(framework::config::Parameters& ps) final override {
+    input_name_ = ps.getParameter<std::string>("input_name");
+    input_pass_ = ps.getParameter<std::string>("input_pass");
+    pedestal_table_ = ps.getParameter<std::string>("pedestal_table");
+  }
+
+  void onProcessStart() final override {
+    getHistoDirectory();
+    // cleaned up when histogram file is closed
+    flat_tree_ = new TTree("adc", "adc");
+
+    flat_tree_->Branch("fpga", &fpga_);
+    flat_tree_->Branch("raw_id", &raw_id_);
+    flat_tree_->Branch("link", &link_);
+    flat_tree_->Branch("channel", &channel_);
+    flat_tree_->Branch("index", &index_);
+    flat_tree_->Branch("adc", &adc_);
+    flat_tree_->Branch("raw_adc", &raw_adc_);
+    flat_tree_->Branch("i_sample", &i_sample_);
+    flat_tree_->Branch("event", &event_);
+  }
+
+  void analyze(const framework::Event& event) final override;
+};
+
+void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
+  // get the reconstruction parameters 
+  auto pedestal_table{getCondition<conditions::IntegerTableCondition>(pedestal_table_)};
+
+  event_ = event.getEventNumber();
+
+  auto const& digis{
+      event.getObject<ldmx::HgcrocDigiCollection>(input_name_, input_pass_)};
+  for (std::size_t i_digi{0}; i_digi < digis.size(); i_digi++) {
+    auto d{digis.getDigi(i_digi)};
+    ldmx::HcalElectronicsID eid(d.id());
+    // undo hardcoded shifts in hcal raw decoder
+    fpga_ = eid.fiber() + 5;
+    link_ = eid.elink(); // leave shifted to align with link number
+    channel_ = eid.channel() + 1;
+    index_ = eid.index();
+    raw_id_ = static_cast<int>(d.id());
+
+    for (i_sample_ = 0; i_sample_ < digis.getNumSamplesPerDigi(); i_sample_++) {
+      int adc_t = d.at(i_sample_).adc_t();
+      raw_adc_ = adc_t;
+      adc_ =  adc_t - pedestal_table.get(d.id(), 0);
+      flat_tree_->Fill();
+    }
+  }
+}
+
+}  // namespace dqm
+
+DECLARE_ANALYZER_NS(dqm, NtuplizeHgcrocDigiCollection);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Standardizes expanding the compressed HgcrocDigiCollection into a flattened TTree to make investigation of raw data easier and more centralized. This ntuplizer includes the event number, sample index, raw ID number, adc, tot, toa, and the two flags determining the mode of the sample. Each entry in the ttree is one sample of one channel. The raw ID number is decoded based on the configuration of the processor either using `HcalElectronicsID` or `HcalDigiID`.
