### PR TITLE
require children of PN gamma to be saved for it to be deduced

### DIFF
--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -51,6 +51,7 @@ const ldmx::SimParticle* getPNGamma(
         // photo-nuclear reaction, and its energy is above threshold,
         // then tag it as the PN gamma.
         return (
+            particleMap.find(daughter.getDaughters().front()) != particleMap.end() &&
             (particleMap.at(daughter.getDaughters().front()).getProcessType() ==
              ldmx::SimParticle::ProcessType::photonNuclear) &&
             (daughter.getEnergy() >= energyThreshold));

--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -45,13 +45,15 @@ const ldmx::SimParticle* getPNGamma(
         auto daughter{particleMap.at(id)};
 
         // If the particle doesn't have any daughters, return false
-        if (daughter.getDaughters().size() == 0) return false;
+        if (daughter.getDaughters().size() == 0
+            or 
+            particleMap.find(daughter.getDaughters().front()) != particleMap.end()
+           ) return false;
 
         // If the particle has daughters that were a result of a
         // photo-nuclear reaction, and its energy is above threshold,
         // then tag it as the PN gamma.
         return (
-            particleMap.find(daughter.getDaughters().front()) != particleMap.end() &&
             (particleMap.at(daughter.getDaughters().front()).getProcessType() ==
              ldmx::SimParticle::ProcessType::photonNuclear) &&
             (daughter.getEnergy() >= energyThreshold));


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1069 by adding an additional requirement.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
Previous error as detailed in issue was that an unchecked map::at call was terminating the program. Adding a simple requirement that the children of the PN photon exist within the particle map resolves this termination.
- [x] ~~I attached any sub-module related changes to this PR.~~ NA
