### PR TITLE
hgcroc v2 DOES NOT pack TOT from 12 bits to 10 bits

### DIFF
--- a/Recon/include/Recon/Event/HgcrocDigiCollection.h
+++ b/Recon/include/Recon/Event/HgcrocDigiCollection.h
@@ -142,11 +142,11 @@ class HgcrocDigiCollection {
      * @return 12-bit measurement of TOT
      */
     int tot() const {
-      int meas = secon();
       if (version_ == 2) {
-        meas = first();
+        return first();
       }
 
+      int meas = secon();
       if (meas > 512) meas = (meas - 512) * 8;
       return meas;
     }


### PR DESCRIPTION
its only 10 bits, so just return that field

### What are the issues that this addresses?
Very small and sneaky bug that we only found upon further investigation of the TOT.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
- [x] NA ~I attached any sub-module related changes to this PR.~