### PR TITLE
v2 of hgcroc uses 12 bits for TOT and not 10

### DIFF
--- a/Recon/include/Recon/Event/HgcrocDigiCollection.h
+++ b/Recon/include/Recon/Event/HgcrocDigiCollection.h
@@ -143,7 +143,7 @@ class HgcrocDigiCollection {
      */
     int tot() const {
       if (version_ == 2) {
-        return first();
+        return 0xfff & (word_ >> FIRSTMEAS_POS);
       }
 
       int meas = secon();


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1081 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
- [x] NA ~I attached any sub-module related changes to this PR.~
