### PR TITLE
Origin/test beam n tuppler

### DIFF
--- a/Recon/include/Recon/SequentialTrigger.h
+++ b/Recon/include/Recon/SequentialTrigger.h
@@ -1,0 +1,85 @@
+/**
+ * @file TriggerProcessor.h
+ * @brief Class that provides a trigger decision for recon using a TriggerResult
+ * object
+ * @author Josh Hiltbrand, University of Minnesota
+ * @author Lene Kristian Bryngemark, Stanford University
+ */
+
+#ifndef RECON_TRIGGER_SEQUENTIALTRIGGER_H_
+#define RECON_TRIGGER_SEQUENTIALTRIGGER_H_
+
+// LDMX
+#include "DetDescr/EcalHexReadout.h"
+#include "Ecal/Event/EcalHit.h"
+#include "Event/TriggerResult.h"
+#include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h"
+
+namespace recon {
+
+/**
+ * @class TriggerProcessor
+ * @brief Provides a trigger decision for recon using a TriggerResult object.
+ *
+ * @note
+ * TriggerProcessor takes in a set of parameters to be used in defining
+ * the trigger algorithm. An event is passed to the processor and the relevant
+ * algorithms are then run on the event (ECAL layer sum). A trigger decision is
+ * executed and the decision along with the algorithm name and relevant
+ * variables are stored in a TriggerResult object which is added to the
+ * collection.
+ */
+class SequentialTrigger : public framework::Producer {
+ public:
+  /**
+   * Class constructor.
+   */
+  SequentialTrigger(const std::string& name, framework::Process& process)
+      : framework::Producer(name, process) {}
+
+  /**
+   * Class destructor.
+   */
+  virtual ~SequentialTrigger() {}
+
+  /**
+   * Configure the processor using the given user specified parameters.
+   *
+   * @param parameters Set of parameters used to configure this processor.
+   */
+  void configure(framework::config::Parameters& parameters) final override;
+
+  /**
+   * Run the trigger algorithm and create a TriggerResult
+   * object to contain info about the trigger decision
+   * such as pass/fail, number of saved variables,
+   * etc.
+   * param event The event to run trigger algorithm on.
+   */
+  virtual void produce(framework::Event& event);
+
+ private:  
+  /** The name of the input collection of triggers */
+  std::vector<std::string> trigger_list_;
+
+  /**pass name of the triggers, should be uniform **/
+  std::vector<std::string> trigger_passNames_;
+
+  /** integer list corresponding to decimal values of binary masks which lead
+   * to a pass **/
+  std::vector<int> pass_masks_;
+
+  /** The name of hte input collection (events with all triggers) **/
+  std::string inputColl_;
+
+  /** The pass name of the input (the Ecal hits). */
+  std::string inputPass_;
+
+  /** The name of the output collection (the trigger decision). */
+  std::string outputColl_;
+};
+
+}  // namespace recon
+
+#endif

--- a/Recon/python/simpleSeqTrigger.py
+++ b/Recon/python/simpleSeqTrigger.py
@@ -1,0 +1,36 @@
+"""Configuration for TriggerProcessor
+
+Sets all parameters to reasonable defaults.
+
+Attributes:
+------------- 
+trigger_list
+    the collection of each trigger we perform sequential skimming with.
+
+trigger_passName
+    our input pass names for the multiple triggers. Should be the same for all
+
+pass_mask : int array
+    Collection of decimal converted binary masks which induce a pass
+
+seqtrigger_collection : string
+    Name of the output collection containing the trigger result
+
+"""
+
+from LDMX.Framework import ldmxcfg
+
+class SequentialTrigger(ldmxcfg.Producer) :
+    """Configuration for the (multi-electron aware but simple) sequential trigger on the ECal reco hits"""
+
+    def __init__(self,name) :
+        super().__init__(name,'recon::SequentialTrigger','Recon')
+
+        self.trigger_list = ["Trigger"]
+        self.trigger_passNames = ["reconSeq","reconSeq"] 
+        ANDList = [sum([2**i for i in range(len(self.trigger_list))])]
+        self.pass_mask = ANDList #[2,1];# This is OR
+        self.seqtrigger_collection = "SeqTrigger"
+
+simpleSeqTrigger = SequentialTrigger("simpleSeqTrigger")
+

--- a/Recon/src/Recon/SequentialTrigger.cxx
+++ b/Recon/src/Recon/SequentialTrigger.cxx
@@ -1,0 +1,39 @@
+
+#include "Recon/SequentialTrigger.h"
+#include "Recon/Event/TriggerResult.h"
+
+namespace recon {
+
+void SequentialTrigger::configure(framework::config::Parameters &ps) {
+  trigger_list_ = ps.getParameter<std::vector<std::string>>("trigger_list");
+  trigger_passNames_ = ps.getParameter<std::vector<std::string>>("trigger_passNames");
+  pass_masks_ = ps.getParameter<std::vector<int>>("pass_mask");
+  outputColl_ = ps.getParameter<std::string>("seqtrigger_collection");
+  return;
+}
+
+void SequentialTrigger::produce(framework::Event& event) {
+  /** Grab the Ecal hit collection for the given event */
+  bool hasPassed = false;
+  int  maskValue = 0; 
+  for (int i = 0; i<trigger_list_.size(); i++){
+    auto trigResult{event.getObject<ldmx::TriggerResult>(trigger_list_[i],
+                                                  trigger_passNames_[i])};
+    if(trigResult.passed()){
+        maskValue+=(int)pow(2,i);
+    }  
+  }  
+  for(int m : pass_masks_){
+    if(maskValue==m){hasPassed=true;}
+  }
+  event.add(outputColl_, hasPassed);
+  // mark the event
+  if (hasPassed)
+    setStorageHint(framework::hint_shouldKeep);
+  else
+    setStorageHint(framework::hint_shouldDrop);
+}
+
+}  // namespace dqm
+
+DECLARE_ANALYZER_NS(recon,SequentialTrigger);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

The pull request addresses issue #1085. 

The processor SequentialTrigger takes in mask list and a list of trigger collections and pass names, and runs through each event seeing if the combination of triggers from each collection lies in the mask list. For our purpose we have the AND mask list hard coded as a default, and in the two validation scripts (recoSkim2.py and recoSkim3.py) we have another OR mask list which can be optionally set.

## Check List

- [X] I successfully compiled _ldmx-sw_ with my developments

- [X] I ran my developments and the following shows that they are successful.

In recoSkim2.py I set the pass energy of a single electron in one trigger to 2750 and the other to 3750. Note 1 corresponds to pass, and we pass if the Ecal sum is less than the cut, so 3750 is always less harsh. This first lower threshold pass is blue (so harsher), the former red. We create a hard coded collection which is not just the keep Hint to test if this works, and for AND and or it is shown in black below.

![passstuff](https://user-images.githubusercontent.com/19932569/192053374-b9777a9f-0640-4da4-a70a-62630b271baa.JPG)

ORMask

![image](https://user-images.githubusercontent.com/19932569/192054106-00a0d28a-239b-4e12-90f2-1e39c20b38c7.png)

ANDMask

![image](https://user-images.githubusercontent.com/19932569/192054872-4f1da192-4aba-42ea-b766-3a9bfe2a7452.png)

The legend entry on this second entry is consistent with the logic of these skims (both are consistent, in the first image the legend corresponds to the latter I plotted).

Here are the Ecal Sums for the Two Triggers (GetSum()):

Trigger 1

![image](https://user-images.githubusercontent.com/19932569/192215868-9f8b3c54-11c9-4b2c-a084-983663ac6257.png)

Trigger 2

![image](https://user-images.githubusercontent.com/19932569/192215725-8e97a190-44e0-4d58-b0f3-aecc5a6bc0ff.png)

Here is the AND

![image](https://user-images.githubusercontent.com/19932569/192216082-ec69b04f-c8fc-4600-9bf8-a4ed61ad8874.png)

and the OR

![image](https://user-images.githubusercontent.com/19932569/192217457-e012de04-32e4-4921-a667-c584b218cbe6.png)

You can check the titles to see exactly how these were plotted w/ TBrowser commands.

_< put plots or some other proof that your developments work >_

- [X] I attached any sub-module related changes to this PR.

My modifications are on my own branch, but should not require a submodule PR because I think Recon inherits its branches from ldmx-sw proper (unlike TrigScint). Someone please educate me if that is not the case.
