### PR TITLE
Silicon sensors in ECal expected to be 300microns

### DIFF
--- a/Detectors/data/ldmx-det-v14/constants.gdml
+++ b/Detectors/data/ldmx-det-v14/constants.gdml
@@ -311,7 +311,7 @@ them in the bilayer loop
 -->
 <variable name="PCB_dz" value="1.666"/>
 <variable name="Glue_dz" value="0.1"/>
-<variable name="Si_dz" value="0.5"/>
+<variable name="Si_dz" value="0.3"/>
 <variable name="GlueThick_dz" value="0.2"/>
 <!-- thickness of motherboard assembly, must match what is extracted -->
 <variable name="MotherBoardAssembly_dz" value="8.166"/>

--- a/Detectors/util/ecal_layer_stack.py
+++ b/Detectors/util/ecal_layer_stack.py
@@ -58,7 +58,7 @@ class Layer :
         'Glue'   : ( 90.1  / 1.205 ) * 10
     }
 
-    SensDetThickness = 0.5
+    SensDetThickness = 0.3
 
     def __init__(self, name, thickness, sensitive = False) :
         self.name = name


### PR DESCRIPTION
There may be some other values lurking that will need to be found upon testing

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Previously, we hoped to get 500micron silicon sensors for the ECal, but it looks more likely that we will be constructing with a thinner sensor (probably 300 mircons).

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
- [x] I attached any sub-module related changes to this PR.
- [x] Visualize detector to make sure it looks correct
- [x] Ecal-internal overlap checks
- [x] Detector-wide overlap checks
- [x] Can the simulation run?
