### PR TITLE
remove additional 0.5mm shift

### DIFF
--- a/Detectors/data/ldmx-det-v12/scoring_planes.gdml
+++ b/Detectors/data/ldmx-det-v12/scoring_planes.gdml
@@ -24,7 +24,7 @@
         <constant name="sp_thickness" value="0.001*mm"/>
 
         <!-- Surround the ecal with scoring planes -->
-        <variable name="sp_ecal_front_z" value="ecal_front_z + (ecal_envelope_z - ECal_dz)/2 - sp_thickness/2 + clearance" /> 
+        <variable name="sp_ecal_front_z" value="ecal_front_z - sp_thickness/2 + clearance" /> 
         <variable name="sp_ecal_back_z"  value="ecal_front_z + ECal_dz + (ecal_envelope_z - ECal_dz)/2 + sp_thickness/2" />
         <variable name="sp_ecal_top_y"   value="ECal_dy/2 + sp_thickness/2" />
         <variable name="sp_ecal_bot_y"   value="-ECal_dy/2 - sp_thickness/2" />


### PR DESCRIPTION
the difference between the envelope and the actual z-thickness of the ECal is 1mm, half of that difference is the erroneous 0.5mm. Now the front ecal scoring plane for v12 is at 240mm

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1032 .

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments (no code changes).
- [x] I ran my developments and the following shows that they are successful.
- [x] NA ~I attached any sub-module related changes to this PR.~