### PR TITLE
more refinement of ecal geometry

### DIFF
--- a/Detectors/data/ldmx-det-v14/constants.gdml
+++ b/Detectors/data/ldmx-det-v14/constants.gdml
@@ -333,6 +333,7 @@ them in the bilayer loop
 <variable name="Glue_dz" value="0.1"/>
 <variable name="Si_dz" value="0.3"/>
 <variable name="GlueThick_dz" value="0.2"/>
+<variable name="CarbonBasePlate_dz" value="0.79"/>
 <!-- thickness of motherboard assembly, must match what is extracted -->
 <variable name="MotherBoardAssembly_dz" value="8.166"/>
 <!-- the carbon cooling plane is 1mm+3/16 inch thick (about) -->
@@ -349,7 +350,7 @@ them in the bilayer loop
   sensitive silicon, and the thicker glue mounting it to the
   absorber (or carbon cooling plane in the pre-shower case)
 -->
-<variable name="Flower_dz" value="PCB_dz+Glue_dz+Si_dz+GlueThick_dz"/>
+<variable name="Flower_dz" value="PCB_dz+Glue_dz+Si_dz+GlueThick_dz+CarbonBasePlate_dz"/>
 
 <!-- 
     Air separating sheets of Al or W with PCB motherboard, limited by 

--- a/Detectors/data/ldmx-det-v14/constants.gdml
+++ b/Detectors/data/ldmx-det-v14/constants.gdml
@@ -325,7 +325,9 @@ them in the bilayer loop
     all values in mm
 
   PCB_dz - needs to match the thickness of the PCB in the motherboards
-  extracted from CAD drawings
+  extracted from CAD drawings. Leave it **larger** than the design
+  specifications by O(10)s of um for tolerance. This mismatch is
+  **on purpose**.
 -->
 <variable name="PCB_dz" value="1.666"/>
 <variable name="Glue_dz" value="0.1"/>

--- a/Detectors/data/ldmx-det-v14/ecal.gdml
+++ b/Detectors/data/ldmx-det-v14/ecal.gdml
@@ -442,10 +442,12 @@
     <!--
       The sensitive hexagons stack
 
-      We model the hexaboards with three-layers:
-      1. The sensitive Silicon 
-      2. The glue holding the silicon to the hosting board
-      3. The hosting board made out of PCB
+      We model the hexaboards with five-layers:
+      1. The readout board made of PCB
+      2. Glue
+      3. The sensitive Silicon 
+      4. The glue holding the silicon to the hosting board
+      5. carbon fiber base plate
     -->
     <polyhedra aunit="deg" deltaphi="360" lunit="mm" name="PCB_hexagon" numsides="6" startphi="90">
       <zplane rmax="Hex_radius" rmin="0" z="0"/>
@@ -465,6 +467,11 @@
     <polyhedra aunit="deg" deltaphi="360" lunit="mm" name="GlueThick_hexagon" numsides="6" startphi="90">
       <zplane rmax="Hex_radius" rmin="0" z="0"/>
       <zplane rmax="Hex_radius" rmin="0" z="GlueThick_dz"/>
+    </polyhedra>
+
+    <polyhedra aunit="deg" deltaphi="360" lunit="mm" name="CarbonBasePlate_hexagon" numsides="6" startphi="90">
+      <zplane rmax="Hex_radius" rmin="0" z="0"/>
+      <zplane rmax="Hex_radius" rmin="0" z="CarbonBasePlate_dz"/>
     </polyhedra>
 
     <!--
@@ -531,6 +538,12 @@
       <solidref ref="GlueThick_hexagon"/>
     </volume>
 
+    <volume name="CarbonBasePlate_volume">
+      <materialref ref="CarbonEpoxyComposite"/>
+      <solidref ref="CarbonBasePlate_hexagon"/>
+      <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid" />-->
+    </volume>
+
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
     <loop for="bilayer" from="1" to="num_bilayers-1" step="1">
       <volume name="strongback_bar_volume[bilayer]">
@@ -571,11 +584,13 @@
                       - - Hex PCB
             Flower    |   Thin Glue
             (even)    |   Sensitive Silicon
-                      - - Thick Glue
+                      |   Thick Glue
+                      - - Carbon Base Plate
                           Cooling Absorber
                           Carbon Cooling Plane
                           Cooling Absorber
-                      - - Thick Glue
+                      - - Carbon Base Plate
+                      |   Thick Glue
             Flower    |   Sensitive Silicon
             (odd)     |   Thin Glue
                       - - Hex PCB
@@ -636,6 +651,12 @@
           x="0" y="-support_box_shift" 
           z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz"/>
       </physvol>
+      <physvol>
+        <volumeref ref="CarbonBasePlate_volume"/>
+        <position name="CarbonBasePlate_volume_rel_to_hexaboard"
+          x="0" y="-support_box_shift"
+          z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz + GlueThick_dz"/>
+      </physvol>
       <loop for="module" from="1" to="6" step="1">
         <physvol>
           <volumeref ref="PCB_volume"/>
@@ -664,6 +685,13 @@
             x="(2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
             y="- support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
             z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz"/>
+        </physvol>
+        <physvol>
+          <volumeref ref="CarbonBasePlate_volume"/>
+          <position name="CarbonBasePlate_volume_rel_to_hexaboard"
+            x="(2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
+            y="- support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
+            z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz + GlueThick_dz"/>
         </physvol>
       </loop>
 
@@ -696,41 +724,56 @@
       </physvol>
 
       <physvol>
+        <volumeref ref="CarbonBasePlate_volume"/>
+        <position name="CarbonBasePlate_volume_PS_pos1_0"
+          x="shift_x" y="shift_y-support_box_shift" 
+          z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
+            + preshower_extra_air + CarbonCoolingPlane_dz"/>
+      </physvol>
+      <physvol>
         <volumeref ref="GlueThick_volume"/>
         <position name="GlueThick_volume_PS_pos1_0"
           x="shift_x" y="shift_y-support_box_shift" 
           z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-            + preshower_extra_air + CarbonCoolingPlane_dz"/>
+            + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz"/>
       </physvol>
       <physvol copynumber="7*1 + 0">
         <volumeref ref="Si_volume"/>
         <position name="Si_volume_rel_to_hexaboard"
           x="shift_x" y="shift_y-support_box_shift" 
           z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-            + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz"/>
+            + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz"/>
       </physvol>
       <physvol>
         <volumeref ref="Glue_volume"/>
         <position name="Glue_volume_rel_to_hexaboard"
           x="shift_x" y="shift_y-support_box_shift" 
           z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-            + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz + Si_dz"/>
+            + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz + Si_dz"/>
       </physvol>
       <physvol>
         <volumeref ref="PCB_volume"/>
         <position name="PS_flower_pos1"
           x="shift_x" y="shift_y-support_box_shift" 
           z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-            + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz + Si_dz + Glue_dz"/>
+            + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz + Si_dz + Glue_dz"/>
       </physvol>
       <loop for="module" from="1" to="6" step="1">
+        <physvol>
+          <volumeref ref="CarbonBasePlate_volume"/>
+          <position name="CarbonBasePlate_volume_PS_pos1_0"
+            x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
+            y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
+            z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
+              + preshower_extra_air + CarbonCoolingPlane_dz"/>
+        </physvol>
         <physvol>
           <volumeref ref="GlueThick_volume"/>
           <position name="GlueThick_volume_PS_pos1_0"
             x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
             y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
             z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-              + preshower_extra_air + CarbonCoolingPlane_dz"/>
+              + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz"/>
         </physvol>
         <physvol copynumber="7*1 + module">
           <volumeref ref="Si_volume"/>
@@ -738,7 +781,7 @@
             x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
             y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
             z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-              + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz"/>
+              + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz"/>
         </physvol>
         <physvol>
           <volumeref ref="Glue_volume"/>
@@ -746,7 +789,7 @@
             x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
             y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
             z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-              + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz + Si_dz"/>
+              + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz + Si_dz"/>
         </physvol>
         <physvol>
           <volumeref ref="PCB_volume"/>
@@ -754,7 +797,7 @@
             x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
             y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
             z="bilayer_start + FrontTolerance + PCB_dz + PCB_Motherboard_Gap + Flower_dz 
-              + preshower_extra_air + CarbonCoolingPlane_dz + GlueThick_dz + Si_dz + Glue_dz"/>
+              + preshower_extra_air + CarbonCoolingPlane_dz + CarbonBasePlate_dz + GlueThick_dz + Si_dz + Glue_dz"/>
         </physvol>
       </loop>
 
@@ -838,6 +881,17 @@
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz"/>
         </physvol>
+        <physvol>
+          <volumeref ref="CarbonBasePlate_volume"/>
+          <position name="CarbonBasePlate_volume_rel_to_hexaboard"
+            x="0" y="-support_box_shift" 
+            z="bilayer_start + sampling_section_offset
+              + bilayer_noabsorber_thickness*bilayer 
+              + bilayer_absorber_cumulative[bilayer]
+              + BackTolerance
+              + front_tungsten_dz[bilayer] + FrontTolerance 
+              + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz + GlueThick_dz"/>
+        </physvol>
         <loop for="module" from="1" to="6" step="1">
           <physvol>
             <volumeref ref="PCB_volume"/>
@@ -886,6 +940,18 @@
               + BackTolerance
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz"/>
+          </physvol>
+          <physvol>
+            <volumeref ref="CarbonBasePlate_volume"/>
+            <position name="CarbonBasePlate_volume_even_pos[bilayer][module]"
+              x="(2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
+              y="- support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
+            z="bilayer_start + sampling_section_offset
+              + bilayer_noabsorber_thickness*bilayer 
+              + bilayer_absorber_cumulative[bilayer]
+              + BackTolerance
+              + front_tungsten_dz[bilayer] + FrontTolerance 
+              + PCB_dz + PCB_Motherboard_Gap + PCB_dz + Glue_dz + Si_dz + GlueThick_dz"/>
           </physvol>
         </loop>
 
@@ -944,6 +1010,18 @@
         </physvol>
   
         <physvol>
+          <volumeref ref="CarbonBasePlate_volume"/>
+          <position name="CarbonBasePlate_volume_odd_pos0[bilayer]"
+            x="shift_x" y="shift_y-support_box_shift" 
+            z="bilayer_start + sampling_section_offset
+              + bilayer_noabsorber_thickness*bilayer
+              + bilayer_absorber_cumulative[bilayer]
+              + BackTolerance
+              + front_tungsten_dz[bilayer] + FrontTolerance 
+              + PCB_dz + PCB_Motherboard_Gap + Flower_dz
+              + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]"/>
+        </physvol>
+        <physvol>
           <volumeref ref="GlueThick_volume"/>
           <position name="GlueThick_volume_odd_pos0[bilayer]"
             x="shift_x" y="shift_y-support_box_shift" 
@@ -953,7 +1031,8 @@
               + BackTolerance
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + Flower_dz
-              + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]"/>
+              + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
+              + CarbonBasePlate_dz"/>
         </physvol>
         <physvol copynumber="7*(2*bilayer + 1) + 0">
           <volumeref ref="Si_volume"/>
@@ -966,7 +1045,7 @@
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + Flower_dz
               + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-              + GlueThick_dz"/>
+              + CarbonBasePlate_dz + GlueThick_dz"/>
         </physvol>
         <physvol>
           <volumeref ref="Glue_volume"/>
@@ -979,7 +1058,7 @@
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + Flower_dz
               + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-              + GlueThick_dz + Si_dz"/>
+              + CarbonBasePlate_dz + GlueThick_dz + Si_dz"/>
         </physvol>
         <physvol>
           <volumeref ref="PCB_volume"/>
@@ -992,9 +1071,22 @@
               + front_tungsten_dz[bilayer] + FrontTolerance 
               + PCB_dz + PCB_Motherboard_Gap + Flower_dz
               + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-              + GlueThick_dz + Si_dz + Glue_dz"/>
+              + CarbonBasePlate_dz + GlueThick_dz + Si_dz + Glue_dz"/>
         </physvol>
         <loop for="module" from="1" to="6" step="1">
+          <physvol>
+            <volumeref ref="CarbonBasePlate_volume"/>
+            <position name="CarbonBasePlate_volume_odd[bilayer][module]"
+              x="shift_x + (2.*Hex_radius + hexagon_gap) * cos((module-1)*pi/3)" 
+              y="shift_y - support_box_shift - (2.*Hex_radius + hexagon_gap) * sin((module-1)*pi/3)" 
+              z="bilayer_start + sampling_section_offset
+                + bilayer_noabsorber_thickness*bilayer
+                + bilayer_absorber_cumulative[bilayer]
+                + BackTolerance
+                + front_tungsten_dz[bilayer] + FrontTolerance 
+                + PCB_dz + PCB_Motherboard_Gap + Flower_dz
+                + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]" />
+          </physvol>
           <physvol>
             <volumeref ref="GlueThick_volume"/>
             <position name="GlueThick_volume_odd[bilayer][module]"
@@ -1006,7 +1098,8 @@
                 + BackTolerance
                 + front_tungsten_dz[bilayer] + FrontTolerance 
                 + PCB_dz + PCB_Motherboard_Gap + Flower_dz
-                + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]" />
+                + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
+                + CarbonBasePlate_dz"/>
           </physvol>
           <physvol copynumber="7*(2*bilayer + 1) + module">
             <volumeref ref="Si_volume"/>
@@ -1020,7 +1113,7 @@
                 + front_tungsten_dz[bilayer] + FrontTolerance 
                 + PCB_dz + PCB_Motherboard_Gap + Flower_dz
                 + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-                + GlueThick_dz" />
+                + CarbonBasePlate_dz + GlueThick_dz" />
           </physvol>
           <physvol>
             <volumeref ref="Glue_volume"/>
@@ -1034,7 +1127,7 @@
                 + front_tungsten_dz[bilayer] + FrontTolerance 
                 + PCB_dz + PCB_Motherboard_Gap + Flower_dz
                 + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-                + GlueThick_dz + Si_dz" />
+                + CarbonBasePlate_dz + GlueThick_dz + Si_dz" />
           </physvol>
           <physvol>
             <volumeref ref="PCB_volume"/>
@@ -1048,7 +1141,7 @@
                 + front_tungsten_dz[bilayer] + FrontTolerance 
                 + PCB_dz + PCB_Motherboard_Gap + Flower_dz
                 + cooling_tungsten_dz[bilayer] + CarbonCoolingPlane_dz + cooling_tungsten_dz[bilayer]
-                + GlueThick_dz + Si_dz + Glue_dz"/>
+                + CarbonBasePlate_dz + GlueThick_dz + Si_dz + Glue_dz"/>
           </physvol>
         </loop>
   

--- a/Detectors/data/ldmx-det-v14/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-det-v14/ecal_motherboard5_assembly.gdml
@@ -2,505 +2,285 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
   <define>
-    <position name="motherboard5_assembly_v0" unit="mm" x="197.0682" y="8.166" z="380.9181"/>
-    <position name="motherboard5_assembly_v1" unit="mm" x="97.69203" y="8.166" z="437.1063"/>
-    <position name="motherboard5_assembly_v2" unit="mm" x="197.0682" y="6.666" z="380.9181"/>
-    <position name="motherboard5_assembly_v3" unit="mm" x="97.69203" y="6.666" z="437.1063"/>
-    <position name="motherboard5_assembly_v4" unit="mm" x="247.8682" y="8.166" z="410.2475"/>
-    <position name="motherboard5_assembly_v5" unit="mm" x="247.8682" y="6.666" z="410.2475"/>
-    <position name="motherboard5_assembly_v6" unit="mm" x="298.6682" y="8.166" z="380.9181"/>
-    <position name="motherboard5_assembly_v7" unit="mm" x="298.6682" y="6.666" z="380.9181"/>
-    <position name="motherboard5_assembly_v8" unit="mm" x="298.6682" y="8.166" z="322.2594"/>
-    <position name="motherboard5_assembly_v9" unit="mm" x="298.6682" y="6.666" z="322.2594"/>
-    <position name="motherboard5_assembly_v10" unit="mm" x="247.8682" y="8.166" z="292.93"/>
-    <position name="motherboard5_assembly_v11" unit="mm" x="247.8682" y="6.666" z="292.93"/>
-    <position name="motherboard5_assembly_v12" unit="mm" x="214.6958" y="8.166" z="235.4737"/>
-    <position name="motherboard5_assembly_v13" unit="mm" x="214.6958" y="6.666" z="235.4737"/>
-    <position name="motherboard5_assembly_v14" unit="mm" x="214.6958" y="8.166" z="176.8149"/>
-    <position name="motherboard5_assembly_v15" unit="mm" x="214.6958" y="6.666" z="176.8149"/>
-    <position name="motherboard5_assembly_v16" unit="mm" x="247.8682" y="8.166" z="119.3586"/>
-    <position name="motherboard5_assembly_v17" unit="mm" x="247.8682" y="6.666" z="119.3586"/>
-    <position name="motherboard5_assembly_v18" unit="mm" x="298.6682" y="8.166" z="90.02922"/>
-    <position name="motherboard5_assembly_v19" unit="mm" x="298.6682" y="6.666" z="90.02922"/>
-    <position name="motherboard5_assembly_v20" unit="mm" x="298.6682" y="8.166" z="31.37043"/>
-    <position name="motherboard5_assembly_v21" unit="mm" x="298.6682" y="6.666" z="31.37043"/>
-    <position name="motherboard5_assembly_v22" unit="mm" x="247.8682" y="8.166" z="2.041042"/>
-    <position name="motherboard5_assembly_v23" unit="mm" x="247.8682" y="6.666" z="2.041042"/>
-    <position name="motherboard5_assembly_v24" unit="mm" x="197.0682" y="8.166" z="31.37043"/>
-    <position name="motherboard5_assembly_v25" unit="mm" x="197.0682" y="6.666" z="31.37043"/>
-    <position name="motherboard5_assembly_v26" unit="mm" x="197.0682" y="8.166" z="90.02922"/>
-    <position name="motherboard5_assembly_v27" unit="mm" x="197.0682" y="6.666" z="90.02922"/>
-    <position name="motherboard5_assembly_v28" unit="mm" x="163.8958" y="8.166" z="147.4855"/>
-    <position name="motherboard5_assembly_v29" unit="mm" x="163.8958" y="6.666" z="147.4855"/>
-    <position name="motherboard5_assembly_v30" unit="mm" x="113.0958" y="8.166" z="176.8149"/>
-    <position name="motherboard5_assembly_v31" unit="mm" x="113.0958" y="6.666" z="176.8149"/>
-    <position name="motherboard5_assembly_v32" unit="mm" x="113.0958" y="8.166" z="235.4737"/>
-    <position name="motherboard5_assembly_v33" unit="mm" x="113.0958" y="6.666" z="235.4737"/>
-    <position name="motherboard5_assembly_v34" unit="mm" x="15.03572" y="8.166" z="290.9177"/>
-    <position name="motherboard5_assembly_v35" unit="mm" x="15.03572" y="6.666" z="290.9177"/>
-    <position name="motherboard5_assembly_v36" unit="mm" x="162.6396" y="8.166" z="309.3318"/>
-    <position name="motherboard5_assembly_v37" unit="mm" x="162.4949" y="8.166" z="307.6778"/>
-    <position name="motherboard5_assembly_v38" unit="mm" x="162.0651" y="8.166" z="306.074"/>
-    <position name="motherboard5_assembly_v39" unit="mm" x="143.7343" y="8.166" z="310.9858"/>
-    <position name="motherboard5_assembly_v40" unit="mm" x="143.5896" y="8.166" z="309.3318"/>
-    <position name="motherboard5_assembly_v41" unit="mm" x="143.7343" y="8.166" z="307.6778"/>
-    <position name="motherboard5_assembly_v42" unit="mm" x="160.4111" y="8.166" z="303.2092"/>
-    <position name="motherboard5_assembly_v43" unit="mm" x="161.3635" y="8.166" z="304.5693"/>
-    <position name="motherboard5_assembly_v44" unit="mm" x="148.3521" y="8.166" z="301.0829"/>
-    <position name="motherboard5_assembly_v45" unit="mm" x="149.8568" y="8.166" z="300.3812"/>
-    <position name="motherboard5_assembly_v46" unit="mm" x="162.4949" y="8.166" z="310.9858"/>
-    <position name="motherboard5_assembly_v47" unit="mm" x="162.0651" y="8.166" z="312.5895"/>
-    <position name="motherboard5_assembly_v48" unit="mm" x="161.3635" y="8.166" z="314.0943"/>
-    <position name="motherboard5_assembly_v49" unit="mm" x="160.4111" y="8.166" z="315.4543"/>
-    <position name="motherboard5_assembly_v50" unit="mm" x="159.2371" y="8.166" z="316.6284"/>
-    <position name="motherboard5_assembly_v51" unit="mm" x="157.8771" y="8.166" z="317.5807"/>
-    <position name="motherboard5_assembly_v52" unit="mm" x="153.1146" y="8.166" z="318.8568"/>
-    <position name="motherboard5_assembly_v53" unit="mm" x="154.7686" y="8.166" z="318.7121"/>
-    <position name="motherboard5_assembly_v54" unit="mm" x="156.3723" y="8.166" z="318.2824"/>
-    <position name="motherboard5_assembly_v55" unit="mm" x="151.4606" y="8.166" z="318.7121"/>
-    <position name="motherboard5_assembly_v56" unit="mm" x="149.8568" y="8.166" z="318.2824"/>
-    <position name="motherboard5_assembly_v57" unit="mm" x="148.3521" y="8.166" z="317.5807"/>
-    <position name="motherboard5_assembly_v58" unit="mm" x="144.8657" y="8.166" z="314.0943"/>
-    <position name="motherboard5_assembly_v59" unit="mm" x="144.164" y="8.166" z="312.5895"/>
-    <position name="motherboard5_assembly_v60" unit="mm" x="146.992" y="8.166" z="316.6284"/>
-    <position name="motherboard5_assembly_v61" unit="mm" x="145.818" y="8.166" z="315.4543"/>
-    <position name="motherboard5_assembly_v62" unit="mm" x="146.992" y="8.166" z="302.0352"/>
-    <position name="motherboard5_assembly_v63" unit="mm" x="144.164" y="8.166" z="306.074"/>
-    <position name="motherboard5_assembly_v64" unit="mm" x="144.8657" y="8.166" z="304.5693"/>
-    <position name="motherboard5_assembly_v65" unit="mm" x="145.818" y="8.166" z="303.2092"/>
-    <position name="motherboard5_assembly_v66" unit="mm" x="151.4606" y="8.166" z="299.9515"/>
-    <position name="motherboard5_assembly_v67" unit="mm" x="153.1146" y="8.166" z="299.8068"/>
-    <position name="motherboard5_assembly_v68" unit="mm" x="154.7686" y="8.166" z="299.9515"/>
-    <position name="motherboard5_assembly_v69" unit="mm" x="156.3723" y="8.166" z="300.3812"/>
-    <position name="motherboard5_assembly_v70" unit="mm" x="157.8771" y="8.166" z="301.0829"/>
-    <position name="motherboard5_assembly_v71" unit="mm" x="159.2371" y="8.166" z="302.0352"/>
-    <position name="motherboard5_assembly_v72" unit="mm" x="143.7343" y="6.666" z="307.6778"/>
-    <position name="motherboard5_assembly_v73" unit="mm" x="143.5896" y="6.666" z="309.3318"/>
-    <position name="motherboard5_assembly_v74" unit="mm" x="144.164" y="6.666" z="306.074"/>
-    <position name="motherboard5_assembly_v75" unit="mm" x="149.8568" y="6.666" z="300.3812"/>
-    <position name="motherboard5_assembly_v76" unit="mm" x="148.3521" y="6.666" z="301.0829"/>
-    <position name="motherboard5_assembly_v77" unit="mm" x="162.6396" y="6.666" z="309.3318"/>
-    <position name="motherboard5_assembly_v78" unit="mm" x="162.4949" y="6.666" z="307.6778"/>
-    <position name="motherboard5_assembly_v79" unit="mm" x="162.0651" y="6.666" z="306.074"/>
-    <position name="motherboard5_assembly_v80" unit="mm" x="161.3635" y="6.666" z="304.5693"/>
-    <position name="motherboard5_assembly_v81" unit="mm" x="146.992" y="6.666" z="302.0352"/>
-    <position name="motherboard5_assembly_v82" unit="mm" x="145.818" y="6.666" z="303.2092"/>
-    <position name="motherboard5_assembly_v83" unit="mm" x="144.8657" y="6.666" z="304.5693"/>
-    <position name="motherboard5_assembly_v84" unit="mm" x="143.7343" y="6.666" z="310.9858"/>
-    <position name="motherboard5_assembly_v85" unit="mm" x="144.164" y="6.666" z="312.5895"/>
-    <position name="motherboard5_assembly_v86" unit="mm" x="144.8657" y="6.666" z="314.0943"/>
-    <position name="motherboard5_assembly_v87" unit="mm" x="145.818" y="6.666" z="315.4543"/>
-    <position name="motherboard5_assembly_v88" unit="mm" x="160.4111" y="6.666" z="303.2092"/>
-    <position name="motherboard5_assembly_v89" unit="mm" x="159.2371" y="6.666" z="302.0352"/>
-    <position name="motherboard5_assembly_v90" unit="mm" x="157.8771" y="6.666" z="301.0829"/>
-    <position name="motherboard5_assembly_v91" unit="mm" x="156.3723" y="6.666" z="300.3812"/>
-    <position name="motherboard5_assembly_v92" unit="mm" x="154.7686" y="6.666" z="299.9515"/>
-    <position name="motherboard5_assembly_v93" unit="mm" x="153.1146" y="6.666" z="299.8068"/>
-    <position name="motherboard5_assembly_v94" unit="mm" x="151.4606" y="6.666" z="299.9515"/>
-    <position name="motherboard5_assembly_v95" unit="mm" x="146.992" y="6.666" z="316.6284"/>
-    <position name="motherboard5_assembly_v96" unit="mm" x="148.3521" y="6.666" z="317.5807"/>
-    <position name="motherboard5_assembly_v97" unit="mm" x="149.8568" y="6.666" z="318.2824"/>
-    <position name="motherboard5_assembly_v98" unit="mm" x="156.3723" y="6.666" z="318.2824"/>
-    <position name="motherboard5_assembly_v99" unit="mm" x="157.8771" y="6.666" z="317.5807"/>
-    <position name="motherboard5_assembly_v100" unit="mm" x="161.3635" y="6.666" z="314.0943"/>
-    <position name="motherboard5_assembly_v101" unit="mm" x="162.0651" y="6.666" z="312.5895"/>
-    <position name="motherboard5_assembly_v102" unit="mm" x="162.4949" y="6.666" z="310.9858"/>
-    <position name="motherboard5_assembly_v103" unit="mm" x="159.2371" y="6.666" z="316.6284"/>
-    <position name="motherboard5_assembly_v104" unit="mm" x="160.4111" y="6.666" z="315.4543"/>
-    <position name="motherboard5_assembly_v105" unit="mm" x="151.4606" y="6.666" z="318.7121"/>
-    <position name="motherboard5_assembly_v106" unit="mm" x="153.1146" y="6.666" z="318.8568"/>
-    <position name="motherboard5_assembly_v107" unit="mm" x="154.7686" y="6.666" z="318.7121"/>
-    <position name="motherboard5_assembly_v108" unit="mm" x="47.04064" y="1.666" z="371.9038"/>
-    <position name="motherboard5_assembly_v109" unit="mm" x="116.68" y="1.666" z="332.5291"/>
-    <position name="motherboard5_assembly_v110" unit="mm" x="47.04064" y="0.066" z="371.9038"/>
-    <position name="motherboard5_assembly_v111" unit="mm" x="116.68" y="0.066" z="332.5291"/>
-    <position name="motherboard5_assembly_v112" unit="mm" x="86.41532" y="1.666" z="441.5431"/>
-    <position name="motherboard5_assembly_v113" unit="mm" x="86.41532" y="0.066" z="441.5431"/>
-    <position name="motherboard5_assembly_v114" unit="mm" x="156.0546" y="1.666" z="402.1684"/>
-    <position name="motherboard5_assembly_v115" unit="mm" x="156.0546" y="0.066" z="402.1684"/>
-    <position name="motherboard5_assembly_v116" unit="mm" x="103.6998" y="6.666" z="350.2072"/>
-    <position name="motherboard5_assembly_v117" unit="mm" x="110.6637" y="6.666" z="346.2697"/>
-    <position name="motherboard5_assembly_v118" unit="mm" x="103.6998" y="1.666" z="350.2072"/>
-    <position name="motherboard5_assembly_v119" unit="mm" x="110.6637" y="1.666" z="346.2697"/>
-    <position name="motherboard5_assembly_v120" unit="mm" x="134.2152" y="6.666" z="404.1777"/>
-    <position name="motherboard5_assembly_v121" unit="mm" x="134.2152" y="1.666" z="404.1777"/>
-    <position name="motherboard5_assembly_v122" unit="mm" x="141.1791" y="6.666" z="400.2402"/>
-    <position name="motherboard5_assembly_v123" unit="mm" x="141.1791" y="1.666" z="400.2402"/>
-    <position name="motherboard5_assembly_v124" unit="mm" x="85.87688" y="4.666" z="382.6856"/>
-    <position name="motherboard5_assembly_v125" unit="mm" x="105.8982" y="4.666" z="371.3653"/>
-    <position name="motherboard5_assembly_v126" unit="mm" x="85.87688" y="1.666" z="382.6856"/>
-    <position name="motherboard5_assembly_v127" unit="mm" x="105.8982" y="1.666" z="371.3653"/>
-    <position name="motherboard5_assembly_v128" unit="mm" x="97.1971" y="4.666" z="402.7069"/>
-    <position name="motherboard5_assembly_v129" unit="mm" x="97.1971" y="1.666" z="402.7069"/>
-    <position name="motherboard5_assembly_v130" unit="mm" x="117.2184" y="4.666" z="391.3866"/>
-    <position name="motherboard5_assembly_v131" unit="mm" x="117.2184" y="1.666" z="391.3866"/>
-    <position name="motherboard5_assembly_v132" unit="mm" x="61.91619" y="6.666" z="373.832"/>
-    <position name="motherboard5_assembly_v133" unit="mm" x="68.88013" y="6.666" z="369.8945"/>
-    <position name="motherboard5_assembly_v134" unit="mm" x="61.91619" y="1.666" z="373.832"/>
-    <position name="motherboard5_assembly_v135" unit="mm" x="68.88013" y="1.666" z="369.8945"/>
-    <position name="motherboard5_assembly_v136" unit="mm" x="92.43157" y="6.666" z="427.8025"/>
-    <position name="motherboard5_assembly_v137" unit="mm" x="92.43157" y="1.666" z="427.8025"/>
-    <position name="motherboard5_assembly_v138" unit="mm" x="99.3955" y="6.666" z="423.865"/>
-    <position name="motherboard5_assembly_v139" unit="mm" x="99.3955" y="1.666" z="423.865"/>
-    <position name="motherboard5_assembly_v140" unit="mm" x="3.285533" y="1.666" z="294.5171"/>
-    <position name="motherboard5_assembly_v141" unit="mm" x="72.92485" y="1.666" z="255.1424"/>
-    <position name="motherboard5_assembly_v142" unit="mm" x="3.285533" y="0.066" z="294.5171"/>
-    <position name="motherboard5_assembly_v143" unit="mm" x="72.92485" y="0.066" z="255.1424"/>
-    <position name="motherboard5_assembly_v144" unit="mm" x="42.66021" y="1.666" z="364.1564"/>
-    <position name="motherboard5_assembly_v145" unit="mm" x="42.66021" y="0.066" z="364.1564"/>
-    <position name="motherboard5_assembly_v146" unit="mm" x="112.2995" y="1.666" z="324.7817"/>
-    <position name="motherboard5_assembly_v147" unit="mm" x="112.2995" y="0.066" z="324.7817"/>
-    <position name="motherboard5_assembly_v148" unit="mm" x="59.94467" y="6.666" z="272.8205"/>
-    <position name="motherboard5_assembly_v149" unit="mm" x="66.90861" y="6.666" z="268.883"/>
-    <position name="motherboard5_assembly_v150" unit="mm" x="59.94467" y="1.666" z="272.8205"/>
-    <position name="motherboard5_assembly_v151" unit="mm" x="66.90861" y="1.666" z="268.883"/>
-    <position name="motherboard5_assembly_v152" unit="mm" x="90.46005" y="6.666" z="326.791"/>
-    <position name="motherboard5_assembly_v153" unit="mm" x="90.46005" y="1.666" z="326.791"/>
-    <position name="motherboard5_assembly_v154" unit="mm" x="97.42398" y="6.666" z="322.8535"/>
-    <position name="motherboard5_assembly_v155" unit="mm" x="97.42398" y="1.666" z="322.8535"/>
-    <position name="motherboard5_assembly_v156" unit="mm" x="42.12177" y="4.666" z="305.2989"/>
-    <position name="motherboard5_assembly_v157" unit="mm" x="62.14307" y="4.666" z="293.9787"/>
-    <position name="motherboard5_assembly_v158" unit="mm" x="42.12177" y="1.666" z="305.2989"/>
-    <position name="motherboard5_assembly_v159" unit="mm" x="62.14307" y="1.666" z="293.9787"/>
-    <position name="motherboard5_assembly_v160" unit="mm" x="53.44199" y="4.666" z="325.3202"/>
-    <position name="motherboard5_assembly_v161" unit="mm" x="53.44199" y="1.666" z="325.3202"/>
-    <position name="motherboard5_assembly_v162" unit="mm" x="73.46329" y="4.666" z="314.0"/>
-    <position name="motherboard5_assembly_v163" unit="mm" x="73.46329" y="1.666" z="314.0"/>
-    <position name="motherboard5_assembly_v164" unit="mm" x="18.16108" y="6.666" z="296.4453"/>
-    <position name="motherboard5_assembly_v165" unit="mm" x="25.12501" y="6.666" z="292.5078"/>
-    <position name="motherboard5_assembly_v166" unit="mm" x="18.16108" y="1.666" z="296.4453"/>
-    <position name="motherboard5_assembly_v167" unit="mm" x="25.12501" y="1.666" z="292.5078"/>
-    <position name="motherboard5_assembly_v168" unit="mm" x="48.67646" y="6.666" z="350.4158"/>
-    <position name="motherboard5_assembly_v169" unit="mm" x="48.67646" y="1.666" z="350.4158"/>
-    <position name="motherboard5_assembly_v170" unit="mm" x="55.64039" y="6.666" z="346.4783"/>
-    <position name="motherboard5_assembly_v171" unit="mm" x="55.64039" y="1.666" z="346.4783"/>
+    <position name="nohole_motherboard5_assembly_v0" unit="mm" x="197.0682" y="8.166" z="380.9181"/>
+    <position name="nohole_motherboard5_assembly_v1" unit="mm" x="97.69203" y="8.166" z="437.1063"/>
+    <position name="nohole_motherboard5_assembly_v2" unit="mm" x="197.0682" y="6.666" z="380.9181"/>
+    <position name="nohole_motherboard5_assembly_v3" unit="mm" x="97.69203" y="6.666" z="437.1063"/>
+    <position name="nohole_motherboard5_assembly_v4" unit="mm" x="247.8682" y="8.166" z="410.2475"/>
+    <position name="nohole_motherboard5_assembly_v5" unit="mm" x="247.8682" y="6.666" z="410.2475"/>
+    <position name="nohole_motherboard5_assembly_v6" unit="mm" x="298.6682" y="8.166" z="380.9181"/>
+    <position name="nohole_motherboard5_assembly_v7" unit="mm" x="298.6682" y="6.666" z="380.9181"/>
+    <position name="nohole_motherboard5_assembly_v8" unit="mm" x="298.6682" y="8.166" z="322.2594"/>
+    <position name="nohole_motherboard5_assembly_v9" unit="mm" x="298.6682" y="6.666" z="322.2594"/>
+    <position name="nohole_motherboard5_assembly_v10" unit="mm" x="247.8682" y="8.166" z="292.93"/>
+    <position name="nohole_motherboard5_assembly_v11" unit="mm" x="247.8682" y="6.666" z="292.93"/>
+    <position name="nohole_motherboard5_assembly_v12" unit="mm" x="214.6958" y="8.166" z="235.4737"/>
+    <position name="nohole_motherboard5_assembly_v13" unit="mm" x="214.6958" y="6.666" z="235.4737"/>
+    <position name="nohole_motherboard5_assembly_v14" unit="mm" x="214.6958" y="8.166" z="176.8149"/>
+    <position name="nohole_motherboard5_assembly_v15" unit="mm" x="214.6958" y="6.666" z="176.8149"/>
+    <position name="nohole_motherboard5_assembly_v16" unit="mm" x="247.8682" y="8.166" z="119.3586"/>
+    <position name="nohole_motherboard5_assembly_v17" unit="mm" x="247.8682" y="6.666" z="119.3586"/>
+    <position name="nohole_motherboard5_assembly_v18" unit="mm" x="298.6682" y="8.166" z="90.02922"/>
+    <position name="nohole_motherboard5_assembly_v19" unit="mm" x="298.6682" y="6.666" z="90.02922"/>
+    <position name="nohole_motherboard5_assembly_v20" unit="mm" x="298.6682" y="8.166" z="31.37043"/>
+    <position name="nohole_motherboard5_assembly_v21" unit="mm" x="298.6682" y="6.666" z="31.37043"/>
+    <position name="nohole_motherboard5_assembly_v22" unit="mm" x="247.8682" y="8.166" z="2.041042"/>
+    <position name="nohole_motherboard5_assembly_v23" unit="mm" x="247.8682" y="6.666" z="2.041042"/>
+    <position name="nohole_motherboard5_assembly_v24" unit="mm" x="197.0682" y="8.166" z="31.37043"/>
+    <position name="nohole_motherboard5_assembly_v25" unit="mm" x="197.0682" y="6.666" z="31.37043"/>
+    <position name="nohole_motherboard5_assembly_v26" unit="mm" x="197.0682" y="8.166" z="90.02922"/>
+    <position name="nohole_motherboard5_assembly_v27" unit="mm" x="197.0682" y="6.666" z="90.02922"/>
+    <position name="nohole_motherboard5_assembly_v28" unit="mm" x="163.8958" y="8.166" z="147.4855"/>
+    <position name="nohole_motherboard5_assembly_v29" unit="mm" x="163.8958" y="6.666" z="147.4855"/>
+    <position name="nohole_motherboard5_assembly_v30" unit="mm" x="113.0958" y="8.166" z="176.8149"/>
+    <position name="nohole_motherboard5_assembly_v31" unit="mm" x="113.0958" y="6.666" z="176.8149"/>
+    <position name="nohole_motherboard5_assembly_v32" unit="mm" x="113.0958" y="8.166" z="235.4737"/>
+    <position name="nohole_motherboard5_assembly_v33" unit="mm" x="113.0958" y="6.666" z="235.4737"/>
+    <position name="nohole_motherboard5_assembly_v34" unit="mm" x="15.03572" y="8.166" z="290.9177"/>
+    <position name="nohole_motherboard5_assembly_v35" unit="mm" x="15.03572" y="6.666" z="290.9177"/>
+    <position name="nohole_motherboard5_assembly_v36" unit="mm" x="3.285533" y="1.666" z="294.5171"/>
+    <position name="nohole_motherboard5_assembly_v37" unit="mm" x="72.92485" y="1.666" z="255.1424"/>
+    <position name="nohole_motherboard5_assembly_v38" unit="mm" x="3.285533" y="0.066" z="294.5171"/>
+    <position name="nohole_motherboard5_assembly_v39" unit="mm" x="72.92485" y="0.066" z="255.1424"/>
+    <position name="nohole_motherboard5_assembly_v40" unit="mm" x="42.66021" y="1.666" z="364.1564"/>
+    <position name="nohole_motherboard5_assembly_v41" unit="mm" x="42.66021" y="0.066" z="364.1564"/>
+    <position name="nohole_motherboard5_assembly_v42" unit="mm" x="112.2995" y="1.666" z="324.7817"/>
+    <position name="nohole_motherboard5_assembly_v43" unit="mm" x="112.2995" y="0.066" z="324.7817"/>
+    <position name="nohole_motherboard5_assembly_v44" unit="mm" x="42.12177" y="4.666" z="305.2989"/>
+    <position name="nohole_motherboard5_assembly_v45" unit="mm" x="62.14307" y="4.666" z="293.9787"/>
+    <position name="nohole_motherboard5_assembly_v46" unit="mm" x="42.12177" y="1.666" z="305.2989"/>
+    <position name="nohole_motherboard5_assembly_v47" unit="mm" x="62.14307" y="1.666" z="293.9787"/>
+    <position name="nohole_motherboard5_assembly_v48" unit="mm" x="53.44199" y="4.666" z="325.3202"/>
+    <position name="nohole_motherboard5_assembly_v49" unit="mm" x="53.44199" y="1.666" z="325.3202"/>
+    <position name="nohole_motherboard5_assembly_v50" unit="mm" x="73.46329" y="4.666" z="314.0"/>
+    <position name="nohole_motherboard5_assembly_v51" unit="mm" x="73.46329" y="1.666" z="314.0"/>
+    <position name="nohole_motherboard5_assembly_v52" unit="mm" x="59.94467" y="6.666" z="272.8205"/>
+    <position name="nohole_motherboard5_assembly_v53" unit="mm" x="66.90861" y="6.666" z="268.883"/>
+    <position name="nohole_motherboard5_assembly_v54" unit="mm" x="59.94467" y="1.666" z="272.8205"/>
+    <position name="nohole_motherboard5_assembly_v55" unit="mm" x="66.90861" y="1.666" z="268.883"/>
+    <position name="nohole_motherboard5_assembly_v56" unit="mm" x="90.46005" y="6.666" z="326.791"/>
+    <position name="nohole_motherboard5_assembly_v57" unit="mm" x="90.46005" y="1.666" z="326.791"/>
+    <position name="nohole_motherboard5_assembly_v58" unit="mm" x="97.42398" y="6.666" z="322.8535"/>
+    <position name="nohole_motherboard5_assembly_v59" unit="mm" x="97.42398" y="1.666" z="322.8535"/>
+    <position name="nohole_motherboard5_assembly_v60" unit="mm" x="18.16108" y="6.666" z="296.4453"/>
+    <position name="nohole_motherboard5_assembly_v61" unit="mm" x="25.12501" y="6.666" z="292.5078"/>
+    <position name="nohole_motherboard5_assembly_v62" unit="mm" x="18.16108" y="1.666" z="296.4453"/>
+    <position name="nohole_motherboard5_assembly_v63" unit="mm" x="25.12501" y="1.666" z="292.5078"/>
+    <position name="nohole_motherboard5_assembly_v64" unit="mm" x="48.67646" y="6.666" z="350.4158"/>
+    <position name="nohole_motherboard5_assembly_v65" unit="mm" x="48.67646" y="1.666" z="350.4158"/>
+    <position name="nohole_motherboard5_assembly_v66" unit="mm" x="55.64039" y="6.666" z="346.4783"/>
+    <position name="nohole_motherboard5_assembly_v67" unit="mm" x="55.64039" y="1.666" z="346.4783"/>
+    <position name="nohole_motherboard5_assembly_v68" unit="mm" x="47.04064" y="1.666" z="371.9038"/>
+    <position name="nohole_motherboard5_assembly_v69" unit="mm" x="116.68" y="1.666" z="332.5291"/>
+    <position name="nohole_motherboard5_assembly_v70" unit="mm" x="47.04064" y="0.066" z="371.9038"/>
+    <position name="nohole_motherboard5_assembly_v71" unit="mm" x="116.68" y="0.066" z="332.5291"/>
+    <position name="nohole_motherboard5_assembly_v72" unit="mm" x="86.41532" y="1.666" z="441.5431"/>
+    <position name="nohole_motherboard5_assembly_v73" unit="mm" x="86.41532" y="0.066" z="441.5431"/>
+    <position name="nohole_motherboard5_assembly_v74" unit="mm" x="156.0546" y="1.666" z="402.1684"/>
+    <position name="nohole_motherboard5_assembly_v75" unit="mm" x="156.0546" y="0.066" z="402.1684"/>
+    <position name="nohole_motherboard5_assembly_v76" unit="mm" x="85.87688" y="4.666" z="382.6856"/>
+    <position name="nohole_motherboard5_assembly_v77" unit="mm" x="105.8982" y="4.666" z="371.3653"/>
+    <position name="nohole_motherboard5_assembly_v78" unit="mm" x="85.87688" y="1.666" z="382.6856"/>
+    <position name="nohole_motherboard5_assembly_v79" unit="mm" x="105.8982" y="1.666" z="371.3653"/>
+    <position name="nohole_motherboard5_assembly_v80" unit="mm" x="97.1971" y="4.666" z="402.7069"/>
+    <position name="nohole_motherboard5_assembly_v81" unit="mm" x="97.1971" y="1.666" z="402.7069"/>
+    <position name="nohole_motherboard5_assembly_v82" unit="mm" x="117.2184" y="4.666" z="391.3866"/>
+    <position name="nohole_motherboard5_assembly_v83" unit="mm" x="117.2184" y="1.666" z="391.3866"/>
+    <position name="nohole_motherboard5_assembly_v84" unit="mm" x="103.6998" y="6.666" z="350.2072"/>
+    <position name="nohole_motherboard5_assembly_v85" unit="mm" x="110.6637" y="6.666" z="346.2697"/>
+    <position name="nohole_motherboard5_assembly_v86" unit="mm" x="103.6998" y="1.666" z="350.2072"/>
+    <position name="nohole_motherboard5_assembly_v87" unit="mm" x="110.6637" y="1.666" z="346.2697"/>
+    <position name="nohole_motherboard5_assembly_v88" unit="mm" x="134.2152" y="6.666" z="404.1777"/>
+    <position name="nohole_motherboard5_assembly_v89" unit="mm" x="134.2152" y="1.666" z="404.1777"/>
+    <position name="nohole_motherboard5_assembly_v90" unit="mm" x="141.1791" y="6.666" z="400.2402"/>
+    <position name="nohole_motherboard5_assembly_v91" unit="mm" x="141.1791" y="1.666" z="400.2402"/>
+    <position name="nohole_motherboard5_assembly_v92" unit="mm" x="61.91619" y="6.666" z="373.832"/>
+    <position name="nohole_motherboard5_assembly_v93" unit="mm" x="68.88013" y="6.666" z="369.8945"/>
+    <position name="nohole_motherboard5_assembly_v94" unit="mm" x="61.91619" y="1.666" z="373.832"/>
+    <position name="nohole_motherboard5_assembly_v95" unit="mm" x="68.88013" y="1.666" z="369.8945"/>
+    <position name="nohole_motherboard5_assembly_v96" unit="mm" x="92.43157" y="6.666" z="427.8025"/>
+    <position name="nohole_motherboard5_assembly_v97" unit="mm" x="92.43157" y="1.666" z="427.8025"/>
+    <position name="nohole_motherboard5_assembly_v98" unit="mm" x="99.3955" y="6.666" z="423.865"/>
+    <position name="nohole_motherboard5_assembly_v99" unit="mm" x="99.3955" y="1.666" z="423.865"/>
   </define>
 
   <solids>
-    <tessellated aunit="deg" lunit="mm" name="motherboard5_assembly-SOL">
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v1" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v1" vertex3="motherboard5_assembly_v3"/>
-       <triangular vertex1="motherboard5_assembly_v4" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v5"/>
-       <triangular vertex1="motherboard5_assembly_v5" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v6" vertex2="motherboard5_assembly_v4" vertex3="motherboard5_assembly_v7"/>
-       <triangular vertex1="motherboard5_assembly_v7" vertex2="motherboard5_assembly_v4" vertex3="motherboard5_assembly_v5"/>
-       <triangular vertex1="motherboard5_assembly_v8" vertex2="motherboard5_assembly_v6" vertex3="motherboard5_assembly_v9"/>
-       <triangular vertex1="motherboard5_assembly_v9" vertex2="motherboard5_assembly_v6" vertex3="motherboard5_assembly_v7"/>
-       <triangular vertex1="motherboard5_assembly_v10" vertex2="motherboard5_assembly_v8" vertex3="motherboard5_assembly_v11"/>
-       <triangular vertex1="motherboard5_assembly_v11" vertex2="motherboard5_assembly_v8" vertex3="motherboard5_assembly_v9"/>
-       <triangular vertex1="motherboard5_assembly_v12" vertex2="motherboard5_assembly_v10" vertex3="motherboard5_assembly_v13"/>
-       <triangular vertex1="motherboard5_assembly_v13" vertex2="motherboard5_assembly_v10" vertex3="motherboard5_assembly_v11"/>
-       <triangular vertex1="motherboard5_assembly_v14" vertex2="motherboard5_assembly_v12" vertex3="motherboard5_assembly_v15"/>
-       <triangular vertex1="motherboard5_assembly_v15" vertex2="motherboard5_assembly_v12" vertex3="motherboard5_assembly_v13"/>
-       <triangular vertex1="motherboard5_assembly_v16" vertex2="motherboard5_assembly_v14" vertex3="motherboard5_assembly_v17"/>
-       <triangular vertex1="motherboard5_assembly_v17" vertex2="motherboard5_assembly_v14" vertex3="motherboard5_assembly_v15"/>
-       <triangular vertex1="motherboard5_assembly_v18" vertex2="motherboard5_assembly_v16" vertex3="motherboard5_assembly_v19"/>
-       <triangular vertex1="motherboard5_assembly_v19" vertex2="motherboard5_assembly_v16" vertex3="motherboard5_assembly_v17"/>
-       <triangular vertex1="motherboard5_assembly_v20" vertex2="motherboard5_assembly_v18" vertex3="motherboard5_assembly_v21"/>
-       <triangular vertex1="motherboard5_assembly_v21" vertex2="motherboard5_assembly_v18" vertex3="motherboard5_assembly_v19"/>
-       <triangular vertex1="motherboard5_assembly_v22" vertex2="motherboard5_assembly_v20" vertex3="motherboard5_assembly_v23"/>
-       <triangular vertex1="motherboard5_assembly_v23" vertex2="motherboard5_assembly_v20" vertex3="motherboard5_assembly_v21"/>
-       <triangular vertex1="motherboard5_assembly_v24" vertex2="motherboard5_assembly_v22" vertex3="motherboard5_assembly_v25"/>
-       <triangular vertex1="motherboard5_assembly_v25" vertex2="motherboard5_assembly_v22" vertex3="motherboard5_assembly_v23"/>
-       <triangular vertex1="motherboard5_assembly_v26" vertex2="motherboard5_assembly_v24" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v24" vertex3="motherboard5_assembly_v25"/>
-       <triangular vertex1="motherboard5_assembly_v28" vertex2="motherboard5_assembly_v26" vertex3="motherboard5_assembly_v29"/>
-       <triangular vertex1="motherboard5_assembly_v29" vertex2="motherboard5_assembly_v26" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v30" vertex2="motherboard5_assembly_v28" vertex3="motherboard5_assembly_v31"/>
-       <triangular vertex1="motherboard5_assembly_v31" vertex2="motherboard5_assembly_v28" vertex3="motherboard5_assembly_v29"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v30" vertex3="motherboard5_assembly_v33"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v30" vertex3="motherboard5_assembly_v31"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v32" vertex3="motherboard5_assembly_v35"/>
-       <triangular vertex1="motherboard5_assembly_v35" vertex2="motherboard5_assembly_v32" vertex3="motherboard5_assembly_v33"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v34" vertex3="motherboard5_assembly_v3"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v34" vertex3="motherboard5_assembly_v35"/>
-       <triangular vertex1="motherboard5_assembly_v20" vertex2="motherboard5_assembly_v22" vertex3="motherboard5_assembly_v24"/>
-       <triangular vertex1="motherboard5_assembly_v16" vertex2="motherboard5_assembly_v18" vertex3="motherboard5_assembly_v20"/>
-       <triangular vertex1="motherboard5_assembly_v36" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v37"/>
-       <triangular vertex1="motherboard5_assembly_v37" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v38"/>
-       <triangular vertex1="motherboard5_assembly_v39" vertex2="motherboard5_assembly_v40" vertex3="motherboard5_assembly_v34"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v40" vertex3="motherboard5_assembly_v41"/>
-       <triangular vertex1="motherboard5_assembly_v42" vertex2="motherboard5_assembly_v43" vertex3="motherboard5_assembly_v8"/>
-       <triangular vertex1="motherboard5_assembly_v44" vertex2="motherboard5_assembly_v45" vertex3="motherboard5_assembly_v32"/>
-       <triangular vertex1="motherboard5_assembly_v14" vertex2="motherboard5_assembly_v30" vertex3="motherboard5_assembly_v12"/>
-       <triangular vertex1="motherboard5_assembly_v12" vertex2="motherboard5_assembly_v30" vertex3="motherboard5_assembly_v32"/>
-       <triangular vertex1="motherboard5_assembly_v12" vertex2="motherboard5_assembly_v32" vertex3="motherboard5_assembly_v10"/>
-       <triangular vertex1="motherboard5_assembly_v10" vertex2="motherboard5_assembly_v32" vertex3="motherboard5_assembly_v8"/>
-       <triangular vertex1="motherboard5_assembly_v20" vertex2="motherboard5_assembly_v24" vertex3="motherboard5_assembly_v16"/>
-       <triangular vertex1="motherboard5_assembly_v16" vertex2="motherboard5_assembly_v24" vertex3="motherboard5_assembly_v26"/>
-       <triangular vertex1="motherboard5_assembly_v16" vertex2="motherboard5_assembly_v26" vertex3="motherboard5_assembly_v14"/>
-       <triangular vertex1="motherboard5_assembly_v14" vertex2="motherboard5_assembly_v26" vertex3="motherboard5_assembly_v28"/>
-       <triangular vertex1="motherboard5_assembly_v14" vertex2="motherboard5_assembly_v28" vertex3="motherboard5_assembly_v30"/>
-       <triangular vertex1="motherboard5_assembly_v36" vertex2="motherboard5_assembly_v46" vertex3="motherboard5_assembly_v0"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v46" vertex3="motherboard5_assembly_v47"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v47" vertex3="motherboard5_assembly_v48"/>
-       <triangular vertex1="motherboard5_assembly_v48" vertex2="motherboard5_assembly_v49" vertex3="motherboard5_assembly_v0"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v49" vertex3="motherboard5_assembly_v50"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v50" vertex3="motherboard5_assembly_v51"/>
-       <triangular vertex1="motherboard5_assembly_v52" vertex2="motherboard5_assembly_v1" vertex3="motherboard5_assembly_v53"/>
-       <triangular vertex1="motherboard5_assembly_v53" vertex2="motherboard5_assembly_v1" vertex3="motherboard5_assembly_v0"/>
-       <triangular vertex1="motherboard5_assembly_v53" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v54"/>
-       <triangular vertex1="motherboard5_assembly_v54" vertex2="motherboard5_assembly_v0" vertex3="motherboard5_assembly_v51"/>
-       <triangular vertex1="motherboard5_assembly_v52" vertex2="motherboard5_assembly_v55" vertex3="motherboard5_assembly_v1"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v55" vertex3="motherboard5_assembly_v56"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v56" vertex3="motherboard5_assembly_v57"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v58" vertex3="motherboard5_assembly_v34"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v58" vertex3="motherboard5_assembly_v59"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v59" vertex3="motherboard5_assembly_v39"/>
-       <triangular vertex1="motherboard5_assembly_v57" vertex2="motherboard5_assembly_v60" vertex3="motherboard5_assembly_v1"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v60" vertex3="motherboard5_assembly_v61"/>
-       <triangular vertex1="motherboard5_assembly_v1" vertex2="motherboard5_assembly_v61" vertex3="motherboard5_assembly_v58"/>
-       <triangular vertex1="motherboard5_assembly_v44" vertex2="motherboard5_assembly_v32" vertex3="motherboard5_assembly_v62"/>
-       <triangular vertex1="motherboard5_assembly_v4" vertex2="motherboard5_assembly_v6" vertex3="motherboard5_assembly_v0"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v6" vertex3="motherboard5_assembly_v8"/>
-       <triangular vertex1="motherboard5_assembly_v0" vertex2="motherboard5_assembly_v8" vertex3="motherboard5_assembly_v38"/>
-       <triangular vertex1="motherboard5_assembly_v38" vertex2="motherboard5_assembly_v8" vertex3="motherboard5_assembly_v43"/>
-       <triangular vertex1="motherboard5_assembly_v41" vertex2="motherboard5_assembly_v63" vertex3="motherboard5_assembly_v34"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v63" vertex3="motherboard5_assembly_v64"/>
-       <triangular vertex1="motherboard5_assembly_v34" vertex2="motherboard5_assembly_v64" vertex3="motherboard5_assembly_v32"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v64" vertex3="motherboard5_assembly_v65"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v65" vertex3="motherboard5_assembly_v62"/>
-       <triangular vertex1="motherboard5_assembly_v45" vertex2="motherboard5_assembly_v66" vertex3="motherboard5_assembly_v32"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v66" vertex3="motherboard5_assembly_v67"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v67" vertex3="motherboard5_assembly_v68"/>
-       <triangular vertex1="motherboard5_assembly_v68" vertex2="motherboard5_assembly_v69" vertex3="motherboard5_assembly_v32"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v69" vertex3="motherboard5_assembly_v70"/>
-       <triangular vertex1="motherboard5_assembly_v32" vertex2="motherboard5_assembly_v70" vertex3="motherboard5_assembly_v8"/>
-       <triangular vertex1="motherboard5_assembly_v8" vertex2="motherboard5_assembly_v70" vertex3="motherboard5_assembly_v71"/>
-       <triangular vertex1="motherboard5_assembly_v8" vertex2="motherboard5_assembly_v71" vertex3="motherboard5_assembly_v42"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v31" vertex3="motherboard5_assembly_v29"/>
-       <triangular vertex1="motherboard5_assembly_v72" vertex2="motherboard5_assembly_v73" vertex3="motherboard5_assembly_v35"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v25" vertex3="motherboard5_assembly_v17"/>
-       <triangular vertex1="motherboard5_assembly_v25" vertex2="motherboard5_assembly_v23" vertex3="motherboard5_assembly_v17"/>
-       <triangular vertex1="motherboard5_assembly_v17" vertex2="motherboard5_assembly_v23" vertex3="motherboard5_assembly_v21"/>
-       <triangular vertex1="motherboard5_assembly_v17" vertex2="motherboard5_assembly_v21" vertex3="motherboard5_assembly_v19"/>
-       <triangular vertex1="motherboard5_assembly_v72" vertex2="motherboard5_assembly_v35" vertex3="motherboard5_assembly_v74"/>
-       <triangular vertex1="motherboard5_assembly_v11" vertex2="motherboard5_assembly_v9" vertex3="motherboard5_assembly_v7"/>
-       <triangular vertex1="motherboard5_assembly_v17" vertex2="motherboard5_assembly_v15" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v15" vertex3="motherboard5_assembly_v13"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v13" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v13" vertex3="motherboard5_assembly_v11"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v11" vertex3="motherboard5_assembly_v5"/>
-       <triangular vertex1="motherboard5_assembly_v5" vertex2="motherboard5_assembly_v11" vertex3="motherboard5_assembly_v7"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v75" vertex3="motherboard5_assembly_v76"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v77" vertex3="motherboard5_assembly_v78"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v78" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v78" vertex3="motherboard5_assembly_v79"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v79" vertex3="motherboard5_assembly_v80"/>
-       <triangular vertex1="motherboard5_assembly_v76" vertex2="motherboard5_assembly_v81" vertex3="motherboard5_assembly_v33"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v81" vertex3="motherboard5_assembly_v82"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v82" vertex3="motherboard5_assembly_v35"/>
-       <triangular vertex1="motherboard5_assembly_v35" vertex2="motherboard5_assembly_v82" vertex3="motherboard5_assembly_v83"/>
-       <triangular vertex1="motherboard5_assembly_v35" vertex2="motherboard5_assembly_v83" vertex3="motherboard5_assembly_v74"/>
-       <triangular vertex1="motherboard5_assembly_v73" vertex2="motherboard5_assembly_v84" vertex3="motherboard5_assembly_v35"/>
-       <triangular vertex1="motherboard5_assembly_v35" vertex2="motherboard5_assembly_v84" vertex3="motherboard5_assembly_v85"/>
-       <triangular vertex1="motherboard5_assembly_v35" vertex2="motherboard5_assembly_v85" vertex3="motherboard5_assembly_v3"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v85" vertex3="motherboard5_assembly_v86"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v86" vertex3="motherboard5_assembly_v87"/>
-       <triangular vertex1="motherboard5_assembly_v80" vertex2="motherboard5_assembly_v88" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v88" vertex3="motherboard5_assembly_v89"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v89" vertex3="motherboard5_assembly_v90"/>
-       <triangular vertex1="motherboard5_assembly_v90" vertex2="motherboard5_assembly_v91" vertex3="motherboard5_assembly_v27"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v91" vertex3="motherboard5_assembly_v92"/>
-       <triangular vertex1="motherboard5_assembly_v27" vertex2="motherboard5_assembly_v92" vertex3="motherboard5_assembly_v29"/>
-       <triangular vertex1="motherboard5_assembly_v29" vertex2="motherboard5_assembly_v92" vertex3="motherboard5_assembly_v93"/>
-       <triangular vertex1="motherboard5_assembly_v29" vertex2="motherboard5_assembly_v93" vertex3="motherboard5_assembly_v33"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v93" vertex3="motherboard5_assembly_v94"/>
-       <triangular vertex1="motherboard5_assembly_v33" vertex2="motherboard5_assembly_v94" vertex3="motherboard5_assembly_v75"/>
-       <triangular vertex1="motherboard5_assembly_v87" vertex2="motherboard5_assembly_v95" vertex3="motherboard5_assembly_v3"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v95" vertex3="motherboard5_assembly_v96"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v96" vertex3="motherboard5_assembly_v97"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v98" vertex3="motherboard5_assembly_v99"/>
-       <triangular vertex1="motherboard5_assembly_v100" vertex2="motherboard5_assembly_v101" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v101" vertex3="motherboard5_assembly_v102"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v102" vertex3="motherboard5_assembly_v77"/>
-       <triangular vertex1="motherboard5_assembly_v99" vertex2="motherboard5_assembly_v103" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v103" vertex3="motherboard5_assembly_v104"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v104" vertex3="motherboard5_assembly_v100"/>
-       <triangular vertex1="motherboard5_assembly_v97" vertex2="motherboard5_assembly_v105" vertex3="motherboard5_assembly_v3"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v105" vertex3="motherboard5_assembly_v106"/>
-       <triangular vertex1="motherboard5_assembly_v3" vertex2="motherboard5_assembly_v106" vertex3="motherboard5_assembly_v2"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v106" vertex3="motherboard5_assembly_v107"/>
-       <triangular vertex1="motherboard5_assembly_v2" vertex2="motherboard5_assembly_v107" vertex3="motherboard5_assembly_v98"/>
-       <triangular vertex1="motherboard5_assembly_v106" vertex2="motherboard5_assembly_v52" vertex3="motherboard5_assembly_v107"/>
-       <triangular vertex1="motherboard5_assembly_v107" vertex2="motherboard5_assembly_v52" vertex3="motherboard5_assembly_v53"/>
-       <triangular vertex1="motherboard5_assembly_v107" vertex2="motherboard5_assembly_v53" vertex3="motherboard5_assembly_v98"/>
-       <triangular vertex1="motherboard5_assembly_v98" vertex2="motherboard5_assembly_v53" vertex3="motherboard5_assembly_v54"/>
-       <triangular vertex1="motherboard5_assembly_v98" vertex2="motherboard5_assembly_v54" vertex3="motherboard5_assembly_v99"/>
-       <triangular vertex1="motherboard5_assembly_v99" vertex2="motherboard5_assembly_v54" vertex3="motherboard5_assembly_v51"/>
-       <triangular vertex1="motherboard5_assembly_v99" vertex2="motherboard5_assembly_v51" vertex3="motherboard5_assembly_v103"/>
-       <triangular vertex1="motherboard5_assembly_v103" vertex2="motherboard5_assembly_v51" vertex3="motherboard5_assembly_v50"/>
-       <triangular vertex1="motherboard5_assembly_v103" vertex2="motherboard5_assembly_v50" vertex3="motherboard5_assembly_v104"/>
-       <triangular vertex1="motherboard5_assembly_v104" vertex2="motherboard5_assembly_v50" vertex3="motherboard5_assembly_v49"/>
-       <triangular vertex1="motherboard5_assembly_v104" vertex2="motherboard5_assembly_v49" vertex3="motherboard5_assembly_v100"/>
-       <triangular vertex1="motherboard5_assembly_v100" vertex2="motherboard5_assembly_v49" vertex3="motherboard5_assembly_v48"/>
-       <triangular vertex1="motherboard5_assembly_v100" vertex2="motherboard5_assembly_v48" vertex3="motherboard5_assembly_v101"/>
-       <triangular vertex1="motherboard5_assembly_v101" vertex2="motherboard5_assembly_v48" vertex3="motherboard5_assembly_v47"/>
-       <triangular vertex1="motherboard5_assembly_v101" vertex2="motherboard5_assembly_v47" vertex3="motherboard5_assembly_v102"/>
-       <triangular vertex1="motherboard5_assembly_v102" vertex2="motherboard5_assembly_v47" vertex3="motherboard5_assembly_v46"/>
-       <triangular vertex1="motherboard5_assembly_v102" vertex2="motherboard5_assembly_v46" vertex3="motherboard5_assembly_v77"/>
-       <triangular vertex1="motherboard5_assembly_v77" vertex2="motherboard5_assembly_v46" vertex3="motherboard5_assembly_v36"/>
-       <triangular vertex1="motherboard5_assembly_v77" vertex2="motherboard5_assembly_v36" vertex3="motherboard5_assembly_v78"/>
-       <triangular vertex1="motherboard5_assembly_v78" vertex2="motherboard5_assembly_v36" vertex3="motherboard5_assembly_v37"/>
-       <triangular vertex1="motherboard5_assembly_v78" vertex2="motherboard5_assembly_v37" vertex3="motherboard5_assembly_v79"/>
-       <triangular vertex1="motherboard5_assembly_v79" vertex2="motherboard5_assembly_v37" vertex3="motherboard5_assembly_v38"/>
-       <triangular vertex1="motherboard5_assembly_v79" vertex2="motherboard5_assembly_v38" vertex3="motherboard5_assembly_v80"/>
-       <triangular vertex1="motherboard5_assembly_v80" vertex2="motherboard5_assembly_v38" vertex3="motherboard5_assembly_v43"/>
-       <triangular vertex1="motherboard5_assembly_v80" vertex2="motherboard5_assembly_v43" vertex3="motherboard5_assembly_v88"/>
-       <triangular vertex1="motherboard5_assembly_v88" vertex2="motherboard5_assembly_v43" vertex3="motherboard5_assembly_v42"/>
-       <triangular vertex1="motherboard5_assembly_v88" vertex2="motherboard5_assembly_v42" vertex3="motherboard5_assembly_v89"/>
-       <triangular vertex1="motherboard5_assembly_v89" vertex2="motherboard5_assembly_v42" vertex3="motherboard5_assembly_v71"/>
-       <triangular vertex1="motherboard5_assembly_v89" vertex2="motherboard5_assembly_v71" vertex3="motherboard5_assembly_v90"/>
-       <triangular vertex1="motherboard5_assembly_v90" vertex2="motherboard5_assembly_v71" vertex3="motherboard5_assembly_v70"/>
-       <triangular vertex1="motherboard5_assembly_v90" vertex2="motherboard5_assembly_v70" vertex3="motherboard5_assembly_v91"/>
-       <triangular vertex1="motherboard5_assembly_v91" vertex2="motherboard5_assembly_v70" vertex3="motherboard5_assembly_v69"/>
-       <triangular vertex1="motherboard5_assembly_v91" vertex2="motherboard5_assembly_v69" vertex3="motherboard5_assembly_v92"/>
-       <triangular vertex1="motherboard5_assembly_v92" vertex2="motherboard5_assembly_v69" vertex3="motherboard5_assembly_v68"/>
-       <triangular vertex1="motherboard5_assembly_v92" vertex2="motherboard5_assembly_v68" vertex3="motherboard5_assembly_v93"/>
-       <triangular vertex1="motherboard5_assembly_v93" vertex2="motherboard5_assembly_v68" vertex3="motherboard5_assembly_v67"/>
-       <triangular vertex1="motherboard5_assembly_v93" vertex2="motherboard5_assembly_v67" vertex3="motherboard5_assembly_v94"/>
-       <triangular vertex1="motherboard5_assembly_v94" vertex2="motherboard5_assembly_v67" vertex3="motherboard5_assembly_v66"/>
-       <triangular vertex1="motherboard5_assembly_v94" vertex2="motherboard5_assembly_v66" vertex3="motherboard5_assembly_v75"/>
-       <triangular vertex1="motherboard5_assembly_v75" vertex2="motherboard5_assembly_v66" vertex3="motherboard5_assembly_v45"/>
-       <triangular vertex1="motherboard5_assembly_v75" vertex2="motherboard5_assembly_v45" vertex3="motherboard5_assembly_v76"/>
-       <triangular vertex1="motherboard5_assembly_v76" vertex2="motherboard5_assembly_v45" vertex3="motherboard5_assembly_v44"/>
-       <triangular vertex1="motherboard5_assembly_v76" vertex2="motherboard5_assembly_v44" vertex3="motherboard5_assembly_v81"/>
-       <triangular vertex1="motherboard5_assembly_v81" vertex2="motherboard5_assembly_v44" vertex3="motherboard5_assembly_v62"/>
-       <triangular vertex1="motherboard5_assembly_v81" vertex2="motherboard5_assembly_v62" vertex3="motherboard5_assembly_v82"/>
-       <triangular vertex1="motherboard5_assembly_v82" vertex2="motherboard5_assembly_v62" vertex3="motherboard5_assembly_v65"/>
-       <triangular vertex1="motherboard5_assembly_v82" vertex2="motherboard5_assembly_v65" vertex3="motherboard5_assembly_v83"/>
-       <triangular vertex1="motherboard5_assembly_v83" vertex2="motherboard5_assembly_v65" vertex3="motherboard5_assembly_v64"/>
-       <triangular vertex1="motherboard5_assembly_v83" vertex2="motherboard5_assembly_v64" vertex3="motherboard5_assembly_v74"/>
-       <triangular vertex1="motherboard5_assembly_v74" vertex2="motherboard5_assembly_v64" vertex3="motherboard5_assembly_v63"/>
-       <triangular vertex1="motherboard5_assembly_v74" vertex2="motherboard5_assembly_v63" vertex3="motherboard5_assembly_v72"/>
-       <triangular vertex1="motherboard5_assembly_v72" vertex2="motherboard5_assembly_v63" vertex3="motherboard5_assembly_v41"/>
-       <triangular vertex1="motherboard5_assembly_v72" vertex2="motherboard5_assembly_v41" vertex3="motherboard5_assembly_v73"/>
-       <triangular vertex1="motherboard5_assembly_v73" vertex2="motherboard5_assembly_v41" vertex3="motherboard5_assembly_v40"/>
-       <triangular vertex1="motherboard5_assembly_v73" vertex2="motherboard5_assembly_v40" vertex3="motherboard5_assembly_v84"/>
-       <triangular vertex1="motherboard5_assembly_v84" vertex2="motherboard5_assembly_v40" vertex3="motherboard5_assembly_v39"/>
-       <triangular vertex1="motherboard5_assembly_v84" vertex2="motherboard5_assembly_v39" vertex3="motherboard5_assembly_v85"/>
-       <triangular vertex1="motherboard5_assembly_v85" vertex2="motherboard5_assembly_v39" vertex3="motherboard5_assembly_v59"/>
-       <triangular vertex1="motherboard5_assembly_v85" vertex2="motherboard5_assembly_v59" vertex3="motherboard5_assembly_v86"/>
-       <triangular vertex1="motherboard5_assembly_v86" vertex2="motherboard5_assembly_v59" vertex3="motherboard5_assembly_v58"/>
-       <triangular vertex1="motherboard5_assembly_v86" vertex2="motherboard5_assembly_v58" vertex3="motherboard5_assembly_v87"/>
-       <triangular vertex1="motherboard5_assembly_v87" vertex2="motherboard5_assembly_v58" vertex3="motherboard5_assembly_v61"/>
-       <triangular vertex1="motherboard5_assembly_v87" vertex2="motherboard5_assembly_v61" vertex3="motherboard5_assembly_v95"/>
-       <triangular vertex1="motherboard5_assembly_v95" vertex2="motherboard5_assembly_v61" vertex3="motherboard5_assembly_v60"/>
-       <triangular vertex1="motherboard5_assembly_v95" vertex2="motherboard5_assembly_v60" vertex3="motherboard5_assembly_v96"/>
-       <triangular vertex1="motherboard5_assembly_v96" vertex2="motherboard5_assembly_v60" vertex3="motherboard5_assembly_v57"/>
-       <triangular vertex1="motherboard5_assembly_v96" vertex2="motherboard5_assembly_v57" vertex3="motherboard5_assembly_v97"/>
-       <triangular vertex1="motherboard5_assembly_v97" vertex2="motherboard5_assembly_v57" vertex3="motherboard5_assembly_v56"/>
-       <triangular vertex1="motherboard5_assembly_v97" vertex2="motherboard5_assembly_v56" vertex3="motherboard5_assembly_v105"/>
-       <triangular vertex1="motherboard5_assembly_v105" vertex2="motherboard5_assembly_v56" vertex3="motherboard5_assembly_v55"/>
-       <triangular vertex1="motherboard5_assembly_v105" vertex2="motherboard5_assembly_v55" vertex3="motherboard5_assembly_v106"/>
-       <triangular vertex1="motherboard5_assembly_v106" vertex2="motherboard5_assembly_v55" vertex3="motherboard5_assembly_v52"/>
-       <triangular vertex1="motherboard5_assembly_v108" vertex2="motherboard5_assembly_v109" vertex3="motherboard5_assembly_v110"/>
-       <triangular vertex1="motherboard5_assembly_v110" vertex2="motherboard5_assembly_v109" vertex3="motherboard5_assembly_v111"/>
-       <triangular vertex1="motherboard5_assembly_v112" vertex2="motherboard5_assembly_v108" vertex3="motherboard5_assembly_v113"/>
-       <triangular vertex1="motherboard5_assembly_v113" vertex2="motherboard5_assembly_v108" vertex3="motherboard5_assembly_v110"/>
-       <triangular vertex1="motherboard5_assembly_v114" vertex2="motherboard5_assembly_v112" vertex3="motherboard5_assembly_v115"/>
-       <triangular vertex1="motherboard5_assembly_v115" vertex2="motherboard5_assembly_v112" vertex3="motherboard5_assembly_v113"/>
-       <triangular vertex1="motherboard5_assembly_v109" vertex2="motherboard5_assembly_v114" vertex3="motherboard5_assembly_v111"/>
-       <triangular vertex1="motherboard5_assembly_v111" vertex2="motherboard5_assembly_v114" vertex3="motherboard5_assembly_v115"/>
-       <triangular vertex1="motherboard5_assembly_v112" vertex2="motherboard5_assembly_v114" vertex3="motherboard5_assembly_v108"/>
-       <triangular vertex1="motherboard5_assembly_v108" vertex2="motherboard5_assembly_v114" vertex3="motherboard5_assembly_v109"/>
-       <triangular vertex1="motherboard5_assembly_v115" vertex2="motherboard5_assembly_v113" vertex3="motherboard5_assembly_v111"/>
-       <triangular vertex1="motherboard5_assembly_v111" vertex2="motherboard5_assembly_v113" vertex3="motherboard5_assembly_v110"/>
-       <triangular vertex1="motherboard5_assembly_v116" vertex2="motherboard5_assembly_v117" vertex3="motherboard5_assembly_v118"/>
-       <triangular vertex1="motherboard5_assembly_v118" vertex2="motherboard5_assembly_v117" vertex3="motherboard5_assembly_v119"/>
-       <triangular vertex1="motherboard5_assembly_v120" vertex2="motherboard5_assembly_v116" vertex3="motherboard5_assembly_v121"/>
-       <triangular vertex1="motherboard5_assembly_v121" vertex2="motherboard5_assembly_v116" vertex3="motherboard5_assembly_v118"/>
-       <triangular vertex1="motherboard5_assembly_v122" vertex2="motherboard5_assembly_v120" vertex3="motherboard5_assembly_v123"/>
-       <triangular vertex1="motherboard5_assembly_v123" vertex2="motherboard5_assembly_v120" vertex3="motherboard5_assembly_v121"/>
-       <triangular vertex1="motherboard5_assembly_v117" vertex2="motherboard5_assembly_v122" vertex3="motherboard5_assembly_v119"/>
-       <triangular vertex1="motherboard5_assembly_v119" vertex2="motherboard5_assembly_v122" vertex3="motherboard5_assembly_v123"/>
-       <triangular vertex1="motherboard5_assembly_v120" vertex2="motherboard5_assembly_v122" vertex3="motherboard5_assembly_v116"/>
-       <triangular vertex1="motherboard5_assembly_v116" vertex2="motherboard5_assembly_v122" vertex3="motherboard5_assembly_v117"/>
-       <triangular vertex1="motherboard5_assembly_v123" vertex2="motherboard5_assembly_v121" vertex3="motherboard5_assembly_v119"/>
-       <triangular vertex1="motherboard5_assembly_v119" vertex2="motherboard5_assembly_v121" vertex3="motherboard5_assembly_v118"/>
-       <triangular vertex1="motherboard5_assembly_v124" vertex2="motherboard5_assembly_v125" vertex3="motherboard5_assembly_v126"/>
-       <triangular vertex1="motherboard5_assembly_v126" vertex2="motherboard5_assembly_v125" vertex3="motherboard5_assembly_v127"/>
-       <triangular vertex1="motherboard5_assembly_v128" vertex2="motherboard5_assembly_v124" vertex3="motherboard5_assembly_v129"/>
-       <triangular vertex1="motherboard5_assembly_v129" vertex2="motherboard5_assembly_v124" vertex3="motherboard5_assembly_v126"/>
-       <triangular vertex1="motherboard5_assembly_v130" vertex2="motherboard5_assembly_v128" vertex3="motherboard5_assembly_v131"/>
-       <triangular vertex1="motherboard5_assembly_v131" vertex2="motherboard5_assembly_v128" vertex3="motherboard5_assembly_v129"/>
-       <triangular vertex1="motherboard5_assembly_v125" vertex2="motherboard5_assembly_v130" vertex3="motherboard5_assembly_v127"/>
-       <triangular vertex1="motherboard5_assembly_v127" vertex2="motherboard5_assembly_v130" vertex3="motherboard5_assembly_v131"/>
-       <triangular vertex1="motherboard5_assembly_v128" vertex2="motherboard5_assembly_v130" vertex3="motherboard5_assembly_v124"/>
-       <triangular vertex1="motherboard5_assembly_v124" vertex2="motherboard5_assembly_v130" vertex3="motherboard5_assembly_v125"/>
-       <triangular vertex1="motherboard5_assembly_v131" vertex2="motherboard5_assembly_v129" vertex3="motherboard5_assembly_v127"/>
-       <triangular vertex1="motherboard5_assembly_v127" vertex2="motherboard5_assembly_v129" vertex3="motherboard5_assembly_v126"/>
-       <triangular vertex1="motherboard5_assembly_v132" vertex2="motherboard5_assembly_v133" vertex3="motherboard5_assembly_v134"/>
-       <triangular vertex1="motherboard5_assembly_v134" vertex2="motherboard5_assembly_v133" vertex3="motherboard5_assembly_v135"/>
-       <triangular vertex1="motherboard5_assembly_v136" vertex2="motherboard5_assembly_v132" vertex3="motherboard5_assembly_v137"/>
-       <triangular vertex1="motherboard5_assembly_v137" vertex2="motherboard5_assembly_v132" vertex3="motherboard5_assembly_v134"/>
-       <triangular vertex1="motherboard5_assembly_v138" vertex2="motherboard5_assembly_v136" vertex3="motherboard5_assembly_v139"/>
-       <triangular vertex1="motherboard5_assembly_v139" vertex2="motherboard5_assembly_v136" vertex3="motherboard5_assembly_v137"/>
-       <triangular vertex1="motherboard5_assembly_v133" vertex2="motherboard5_assembly_v138" vertex3="motherboard5_assembly_v135"/>
-       <triangular vertex1="motherboard5_assembly_v135" vertex2="motherboard5_assembly_v138" vertex3="motherboard5_assembly_v139"/>
-       <triangular vertex1="motherboard5_assembly_v136" vertex2="motherboard5_assembly_v138" vertex3="motherboard5_assembly_v132"/>
-       <triangular vertex1="motherboard5_assembly_v132" vertex2="motherboard5_assembly_v138" vertex3="motherboard5_assembly_v133"/>
-       <triangular vertex1="motherboard5_assembly_v139" vertex2="motherboard5_assembly_v137" vertex3="motherboard5_assembly_v135"/>
-       <triangular vertex1="motherboard5_assembly_v135" vertex2="motherboard5_assembly_v137" vertex3="motherboard5_assembly_v134"/>
-       <triangular vertex1="motherboard5_assembly_v140" vertex2="motherboard5_assembly_v141" vertex3="motherboard5_assembly_v142"/>
-       <triangular vertex1="motherboard5_assembly_v142" vertex2="motherboard5_assembly_v141" vertex3="motherboard5_assembly_v143"/>
-       <triangular vertex1="motherboard5_assembly_v144" vertex2="motherboard5_assembly_v140" vertex3="motherboard5_assembly_v145"/>
-       <triangular vertex1="motherboard5_assembly_v145" vertex2="motherboard5_assembly_v140" vertex3="motherboard5_assembly_v142"/>
-       <triangular vertex1="motherboard5_assembly_v146" vertex2="motherboard5_assembly_v144" vertex3="motherboard5_assembly_v147"/>
-       <triangular vertex1="motherboard5_assembly_v147" vertex2="motherboard5_assembly_v144" vertex3="motherboard5_assembly_v145"/>
-       <triangular vertex1="motherboard5_assembly_v141" vertex2="motherboard5_assembly_v146" vertex3="motherboard5_assembly_v143"/>
-       <triangular vertex1="motherboard5_assembly_v143" vertex2="motherboard5_assembly_v146" vertex3="motherboard5_assembly_v147"/>
-       <triangular vertex1="motherboard5_assembly_v144" vertex2="motherboard5_assembly_v146" vertex3="motherboard5_assembly_v140"/>
-       <triangular vertex1="motherboard5_assembly_v140" vertex2="motherboard5_assembly_v146" vertex3="motherboard5_assembly_v141"/>
-       <triangular vertex1="motherboard5_assembly_v147" vertex2="motherboard5_assembly_v145" vertex3="motherboard5_assembly_v143"/>
-       <triangular vertex1="motherboard5_assembly_v143" vertex2="motherboard5_assembly_v145" vertex3="motherboard5_assembly_v142"/>
-       <triangular vertex1="motherboard5_assembly_v148" vertex2="motherboard5_assembly_v149" vertex3="motherboard5_assembly_v150"/>
-       <triangular vertex1="motherboard5_assembly_v150" vertex2="motherboard5_assembly_v149" vertex3="motherboard5_assembly_v151"/>
-       <triangular vertex1="motherboard5_assembly_v152" vertex2="motherboard5_assembly_v148" vertex3="motherboard5_assembly_v153"/>
-       <triangular vertex1="motherboard5_assembly_v153" vertex2="motherboard5_assembly_v148" vertex3="motherboard5_assembly_v150"/>
-       <triangular vertex1="motherboard5_assembly_v154" vertex2="motherboard5_assembly_v152" vertex3="motherboard5_assembly_v155"/>
-       <triangular vertex1="motherboard5_assembly_v155" vertex2="motherboard5_assembly_v152" vertex3="motherboard5_assembly_v153"/>
-       <triangular vertex1="motherboard5_assembly_v149" vertex2="motherboard5_assembly_v154" vertex3="motherboard5_assembly_v151"/>
-       <triangular vertex1="motherboard5_assembly_v151" vertex2="motherboard5_assembly_v154" vertex3="motherboard5_assembly_v155"/>
-       <triangular vertex1="motherboard5_assembly_v152" vertex2="motherboard5_assembly_v154" vertex3="motherboard5_assembly_v148"/>
-       <triangular vertex1="motherboard5_assembly_v148" vertex2="motherboard5_assembly_v154" vertex3="motherboard5_assembly_v149"/>
-       <triangular vertex1="motherboard5_assembly_v155" vertex2="motherboard5_assembly_v153" vertex3="motherboard5_assembly_v151"/>
-       <triangular vertex1="motherboard5_assembly_v151" vertex2="motherboard5_assembly_v153" vertex3="motherboard5_assembly_v150"/>
-       <triangular vertex1="motherboard5_assembly_v156" vertex2="motherboard5_assembly_v157" vertex3="motherboard5_assembly_v158"/>
-       <triangular vertex1="motherboard5_assembly_v158" vertex2="motherboard5_assembly_v157" vertex3="motherboard5_assembly_v159"/>
-       <triangular vertex1="motherboard5_assembly_v160" vertex2="motherboard5_assembly_v156" vertex3="motherboard5_assembly_v161"/>
-       <triangular vertex1="motherboard5_assembly_v161" vertex2="motherboard5_assembly_v156" vertex3="motherboard5_assembly_v158"/>
-       <triangular vertex1="motherboard5_assembly_v162" vertex2="motherboard5_assembly_v160" vertex3="motherboard5_assembly_v163"/>
-       <triangular vertex1="motherboard5_assembly_v163" vertex2="motherboard5_assembly_v160" vertex3="motherboard5_assembly_v161"/>
-       <triangular vertex1="motherboard5_assembly_v157" vertex2="motherboard5_assembly_v162" vertex3="motherboard5_assembly_v159"/>
-       <triangular vertex1="motherboard5_assembly_v159" vertex2="motherboard5_assembly_v162" vertex3="motherboard5_assembly_v163"/>
-       <triangular vertex1="motherboard5_assembly_v160" vertex2="motherboard5_assembly_v162" vertex3="motherboard5_assembly_v156"/>
-       <triangular vertex1="motherboard5_assembly_v156" vertex2="motherboard5_assembly_v162" vertex3="motherboard5_assembly_v157"/>
-       <triangular vertex1="motherboard5_assembly_v163" vertex2="motherboard5_assembly_v161" vertex3="motherboard5_assembly_v159"/>
-       <triangular vertex1="motherboard5_assembly_v159" vertex2="motherboard5_assembly_v161" vertex3="motherboard5_assembly_v158"/>
-       <triangular vertex1="motherboard5_assembly_v164" vertex2="motherboard5_assembly_v165" vertex3="motherboard5_assembly_v166"/>
-       <triangular vertex1="motherboard5_assembly_v166" vertex2="motherboard5_assembly_v165" vertex3="motherboard5_assembly_v167"/>
-       <triangular vertex1="motherboard5_assembly_v168" vertex2="motherboard5_assembly_v164" vertex3="motherboard5_assembly_v169"/>
-       <triangular vertex1="motherboard5_assembly_v169" vertex2="motherboard5_assembly_v164" vertex3="motherboard5_assembly_v166"/>
-       <triangular vertex1="motherboard5_assembly_v170" vertex2="motherboard5_assembly_v168" vertex3="motherboard5_assembly_v171"/>
-       <triangular vertex1="motherboard5_assembly_v171" vertex2="motherboard5_assembly_v168" vertex3="motherboard5_assembly_v169"/>
-       <triangular vertex1="motherboard5_assembly_v165" vertex2="motherboard5_assembly_v170" vertex3="motherboard5_assembly_v167"/>
-       <triangular vertex1="motherboard5_assembly_v167" vertex2="motherboard5_assembly_v170" vertex3="motherboard5_assembly_v171"/>
-       <triangular vertex1="motherboard5_assembly_v168" vertex2="motherboard5_assembly_v170" vertex3="motherboard5_assembly_v164"/>
-       <triangular vertex1="motherboard5_assembly_v164" vertex2="motherboard5_assembly_v170" vertex3="motherboard5_assembly_v165"/>
-       <triangular vertex1="motherboard5_assembly_v171" vertex2="motherboard5_assembly_v169" vertex3="motherboard5_assembly_v167"/>
-       <triangular vertex1="motherboard5_assembly_v167" vertex2="motherboard5_assembly_v169" vertex3="motherboard5_assembly_v166"/>
+    <tessellated aunit="deg" lunit="mm" name="nohole_motherboard5_assembly-SOL">
+       <triangular vertex1="nohole_motherboard5_assembly_v0" vertex2="nohole_motherboard5_assembly_v1" vertex3="nohole_motherboard5_assembly_v2"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v2" vertex2="nohole_motherboard5_assembly_v1" vertex3="nohole_motherboard5_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v4" vertex2="nohole_motherboard5_assembly_v0" vertex3="nohole_motherboard5_assembly_v5"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v5" vertex2="nohole_motherboard5_assembly_v0" vertex3="nohole_motherboard5_assembly_v2"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v6" vertex2="nohole_motherboard5_assembly_v4" vertex3="nohole_motherboard5_assembly_v7"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v7" vertex2="nohole_motherboard5_assembly_v4" vertex3="nohole_motherboard5_assembly_v5"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v8" vertex2="nohole_motherboard5_assembly_v6" vertex3="nohole_motherboard5_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v9" vertex2="nohole_motherboard5_assembly_v6" vertex3="nohole_motherboard5_assembly_v7"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v10" vertex2="nohole_motherboard5_assembly_v8" vertex3="nohole_motherboard5_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v11" vertex2="nohole_motherboard5_assembly_v8" vertex3="nohole_motherboard5_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v12" vertex2="nohole_motherboard5_assembly_v10" vertex3="nohole_motherboard5_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v13" vertex2="nohole_motherboard5_assembly_v10" vertex3="nohole_motherboard5_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v14" vertex2="nohole_motherboard5_assembly_v12" vertex3="nohole_motherboard5_assembly_v15"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v15" vertex2="nohole_motherboard5_assembly_v12" vertex3="nohole_motherboard5_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v16" vertex2="nohole_motherboard5_assembly_v14" vertex3="nohole_motherboard5_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v17" vertex2="nohole_motherboard5_assembly_v14" vertex3="nohole_motherboard5_assembly_v15"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v18" vertex2="nohole_motherboard5_assembly_v16" vertex3="nohole_motherboard5_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v19" vertex2="nohole_motherboard5_assembly_v16" vertex3="nohole_motherboard5_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v20" vertex2="nohole_motherboard5_assembly_v18" vertex3="nohole_motherboard5_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v21" vertex2="nohole_motherboard5_assembly_v18" vertex3="nohole_motherboard5_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v22" vertex2="nohole_motherboard5_assembly_v20" vertex3="nohole_motherboard5_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v23" vertex2="nohole_motherboard5_assembly_v20" vertex3="nohole_motherboard5_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v24" vertex2="nohole_motherboard5_assembly_v22" vertex3="nohole_motherboard5_assembly_v25"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v25" vertex2="nohole_motherboard5_assembly_v22" vertex3="nohole_motherboard5_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v26" vertex2="nohole_motherboard5_assembly_v24" vertex3="nohole_motherboard5_assembly_v27"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v27" vertex2="nohole_motherboard5_assembly_v24" vertex3="nohole_motherboard5_assembly_v25"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v28" vertex2="nohole_motherboard5_assembly_v26" vertex3="nohole_motherboard5_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v29" vertex2="nohole_motherboard5_assembly_v26" vertex3="nohole_motherboard5_assembly_v27"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v30" vertex2="nohole_motherboard5_assembly_v28" vertex3="nohole_motherboard5_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v31" vertex2="nohole_motherboard5_assembly_v28" vertex3="nohole_motherboard5_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v32" vertex2="nohole_motherboard5_assembly_v30" vertex3="nohole_motherboard5_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v33" vertex2="nohole_motherboard5_assembly_v30" vertex3="nohole_motherboard5_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v34" vertex2="nohole_motherboard5_assembly_v32" vertex3="nohole_motherboard5_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v35" vertex2="nohole_motherboard5_assembly_v32" vertex3="nohole_motherboard5_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v1" vertex2="nohole_motherboard5_assembly_v34" vertex3="nohole_motherboard5_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v3" vertex2="nohole_motherboard5_assembly_v34" vertex3="nohole_motherboard5_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v0" vertex2="nohole_motherboard5_assembly_v4" vertex3="nohole_motherboard5_assembly_v6"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v20" vertex2="nohole_motherboard5_assembly_v22" vertex3="nohole_motherboard5_assembly_v24"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v16" vertex2="nohole_motherboard5_assembly_v18" vertex3="nohole_motherboard5_assembly_v20"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v34" vertex2="nohole_motherboard5_assembly_v1" vertex3="nohole_motherboard5_assembly_v32"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v32" vertex2="nohole_motherboard5_assembly_v1" vertex3="nohole_motherboard5_assembly_v0"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v32" vertex2="nohole_motherboard5_assembly_v0" vertex3="nohole_motherboard5_assembly_v8"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v8" vertex2="nohole_motherboard5_assembly_v0" vertex3="nohole_motherboard5_assembly_v6"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v14" vertex2="nohole_motherboard5_assembly_v30" vertex3="nohole_motherboard5_assembly_v12"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v12" vertex2="nohole_motherboard5_assembly_v30" vertex3="nohole_motherboard5_assembly_v32"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v12" vertex2="nohole_motherboard5_assembly_v32" vertex3="nohole_motherboard5_assembly_v10"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v10" vertex2="nohole_motherboard5_assembly_v32" vertex3="nohole_motherboard5_assembly_v8"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v20" vertex2="nohole_motherboard5_assembly_v24" vertex3="nohole_motherboard5_assembly_v16"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v16" vertex2="nohole_motherboard5_assembly_v24" vertex3="nohole_motherboard5_assembly_v26"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v16" vertex2="nohole_motherboard5_assembly_v26" vertex3="nohole_motherboard5_assembly_v14"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v14" vertex2="nohole_motherboard5_assembly_v26" vertex3="nohole_motherboard5_assembly_v28"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v14" vertex2="nohole_motherboard5_assembly_v28" vertex3="nohole_motherboard5_assembly_v30"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v27" vertex2="nohole_motherboard5_assembly_v25" vertex3="nohole_motherboard5_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v2" vertex2="nohole_motherboard5_assembly_v3" vertex3="nohole_motherboard5_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v11" vertex2="nohole_motherboard5_assembly_v9" vertex3="nohole_motherboard5_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v7" vertex2="nohole_motherboard5_assembly_v5" vertex3="nohole_motherboard5_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v9" vertex2="nohole_motherboard5_assembly_v5" vertex3="nohole_motherboard5_assembly_v2"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v9" vertex2="nohole_motherboard5_assembly_v2" vertex3="nohole_motherboard5_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v33" vertex2="nohole_motherboard5_assembly_v2" vertex3="nohole_motherboard5_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v25" vertex2="nohole_motherboard5_assembly_v23" vertex3="nohole_motherboard5_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v17" vertex2="nohole_motherboard5_assembly_v23" vertex3="nohole_motherboard5_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v17" vertex2="nohole_motherboard5_assembly_v21" vertex3="nohole_motherboard5_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v27" vertex2="nohole_motherboard5_assembly_v17" vertex3="nohole_motherboard5_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v29" vertex2="nohole_motherboard5_assembly_v17" vertex3="nohole_motherboard5_assembly_v15"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v29" vertex2="nohole_motherboard5_assembly_v15" vertex3="nohole_motherboard5_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v31" vertex2="nohole_motherboard5_assembly_v15" vertex3="nohole_motherboard5_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v33" vertex2="nohole_motherboard5_assembly_v15" vertex3="nohole_motherboard5_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v33" vertex2="nohole_motherboard5_assembly_v13" vertex3="nohole_motherboard5_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v36" vertex2="nohole_motherboard5_assembly_v37" vertex3="nohole_motherboard5_assembly_v38"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v38" vertex2="nohole_motherboard5_assembly_v37" vertex3="nohole_motherboard5_assembly_v39"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v40" vertex2="nohole_motherboard5_assembly_v36" vertex3="nohole_motherboard5_assembly_v41"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v41" vertex2="nohole_motherboard5_assembly_v36" vertex3="nohole_motherboard5_assembly_v38"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v42" vertex2="nohole_motherboard5_assembly_v40" vertex3="nohole_motherboard5_assembly_v43"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v43" vertex2="nohole_motherboard5_assembly_v40" vertex3="nohole_motherboard5_assembly_v41"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v37" vertex2="nohole_motherboard5_assembly_v42" vertex3="nohole_motherboard5_assembly_v39"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v39" vertex2="nohole_motherboard5_assembly_v42" vertex3="nohole_motherboard5_assembly_v43"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v40" vertex2="nohole_motherboard5_assembly_v42" vertex3="nohole_motherboard5_assembly_v36"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v36" vertex2="nohole_motherboard5_assembly_v42" vertex3="nohole_motherboard5_assembly_v37"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v43" vertex2="nohole_motherboard5_assembly_v41" vertex3="nohole_motherboard5_assembly_v39"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v39" vertex2="nohole_motherboard5_assembly_v41" vertex3="nohole_motherboard5_assembly_v38"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v44" vertex2="nohole_motherboard5_assembly_v45" vertex3="nohole_motherboard5_assembly_v46"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v46" vertex2="nohole_motherboard5_assembly_v45" vertex3="nohole_motherboard5_assembly_v47"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v48" vertex2="nohole_motherboard5_assembly_v44" vertex3="nohole_motherboard5_assembly_v49"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v49" vertex2="nohole_motherboard5_assembly_v44" vertex3="nohole_motherboard5_assembly_v46"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v50" vertex2="nohole_motherboard5_assembly_v48" vertex3="nohole_motherboard5_assembly_v51"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v51" vertex2="nohole_motherboard5_assembly_v48" vertex3="nohole_motherboard5_assembly_v49"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v45" vertex2="nohole_motherboard5_assembly_v50" vertex3="nohole_motherboard5_assembly_v47"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v47" vertex2="nohole_motherboard5_assembly_v50" vertex3="nohole_motherboard5_assembly_v51"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v48" vertex2="nohole_motherboard5_assembly_v50" vertex3="nohole_motherboard5_assembly_v44"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v44" vertex2="nohole_motherboard5_assembly_v50" vertex3="nohole_motherboard5_assembly_v45"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v51" vertex2="nohole_motherboard5_assembly_v49" vertex3="nohole_motherboard5_assembly_v47"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v47" vertex2="nohole_motherboard5_assembly_v49" vertex3="nohole_motherboard5_assembly_v46"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v52" vertex2="nohole_motherboard5_assembly_v53" vertex3="nohole_motherboard5_assembly_v54"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v54" vertex2="nohole_motherboard5_assembly_v53" vertex3="nohole_motherboard5_assembly_v55"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v56" vertex2="nohole_motherboard5_assembly_v52" vertex3="nohole_motherboard5_assembly_v57"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v57" vertex2="nohole_motherboard5_assembly_v52" vertex3="nohole_motherboard5_assembly_v54"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v58" vertex2="nohole_motherboard5_assembly_v56" vertex3="nohole_motherboard5_assembly_v59"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v59" vertex2="nohole_motherboard5_assembly_v56" vertex3="nohole_motherboard5_assembly_v57"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v53" vertex2="nohole_motherboard5_assembly_v58" vertex3="nohole_motherboard5_assembly_v55"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v55" vertex2="nohole_motherboard5_assembly_v58" vertex3="nohole_motherboard5_assembly_v59"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v56" vertex2="nohole_motherboard5_assembly_v58" vertex3="nohole_motherboard5_assembly_v52"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v52" vertex2="nohole_motherboard5_assembly_v58" vertex3="nohole_motherboard5_assembly_v53"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v59" vertex2="nohole_motherboard5_assembly_v57" vertex3="nohole_motherboard5_assembly_v55"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v55" vertex2="nohole_motherboard5_assembly_v57" vertex3="nohole_motherboard5_assembly_v54"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v60" vertex2="nohole_motherboard5_assembly_v61" vertex3="nohole_motherboard5_assembly_v62"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v62" vertex2="nohole_motherboard5_assembly_v61" vertex3="nohole_motherboard5_assembly_v63"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v64" vertex2="nohole_motherboard5_assembly_v60" vertex3="nohole_motherboard5_assembly_v65"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v65" vertex2="nohole_motherboard5_assembly_v60" vertex3="nohole_motherboard5_assembly_v62"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v66" vertex2="nohole_motherboard5_assembly_v64" vertex3="nohole_motherboard5_assembly_v67"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v67" vertex2="nohole_motherboard5_assembly_v64" vertex3="nohole_motherboard5_assembly_v65"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v61" vertex2="nohole_motherboard5_assembly_v66" vertex3="nohole_motherboard5_assembly_v63"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v63" vertex2="nohole_motherboard5_assembly_v66" vertex3="nohole_motherboard5_assembly_v67"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v64" vertex2="nohole_motherboard5_assembly_v66" vertex3="nohole_motherboard5_assembly_v60"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v60" vertex2="nohole_motherboard5_assembly_v66" vertex3="nohole_motherboard5_assembly_v61"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v67" vertex2="nohole_motherboard5_assembly_v65" vertex3="nohole_motherboard5_assembly_v63"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v63" vertex2="nohole_motherboard5_assembly_v65" vertex3="nohole_motherboard5_assembly_v62"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v68" vertex2="nohole_motherboard5_assembly_v69" vertex3="nohole_motherboard5_assembly_v70"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v70" vertex2="nohole_motherboard5_assembly_v69" vertex3="nohole_motherboard5_assembly_v71"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v72" vertex2="nohole_motherboard5_assembly_v68" vertex3="nohole_motherboard5_assembly_v73"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v73" vertex2="nohole_motherboard5_assembly_v68" vertex3="nohole_motherboard5_assembly_v70"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v74" vertex2="nohole_motherboard5_assembly_v72" vertex3="nohole_motherboard5_assembly_v75"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v75" vertex2="nohole_motherboard5_assembly_v72" vertex3="nohole_motherboard5_assembly_v73"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v69" vertex2="nohole_motherboard5_assembly_v74" vertex3="nohole_motherboard5_assembly_v71"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v71" vertex2="nohole_motherboard5_assembly_v74" vertex3="nohole_motherboard5_assembly_v75"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v72" vertex2="nohole_motherboard5_assembly_v74" vertex3="nohole_motherboard5_assembly_v68"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v68" vertex2="nohole_motherboard5_assembly_v74" vertex3="nohole_motherboard5_assembly_v69"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v75" vertex2="nohole_motherboard5_assembly_v73" vertex3="nohole_motherboard5_assembly_v71"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v71" vertex2="nohole_motherboard5_assembly_v73" vertex3="nohole_motherboard5_assembly_v70"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v76" vertex2="nohole_motherboard5_assembly_v77" vertex3="nohole_motherboard5_assembly_v78"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v78" vertex2="nohole_motherboard5_assembly_v77" vertex3="nohole_motherboard5_assembly_v79"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v80" vertex2="nohole_motherboard5_assembly_v76" vertex3="nohole_motherboard5_assembly_v81"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v81" vertex2="nohole_motherboard5_assembly_v76" vertex3="nohole_motherboard5_assembly_v78"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v82" vertex2="nohole_motherboard5_assembly_v80" vertex3="nohole_motherboard5_assembly_v83"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v83" vertex2="nohole_motherboard5_assembly_v80" vertex3="nohole_motherboard5_assembly_v81"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v77" vertex2="nohole_motherboard5_assembly_v82" vertex3="nohole_motherboard5_assembly_v79"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v79" vertex2="nohole_motherboard5_assembly_v82" vertex3="nohole_motherboard5_assembly_v83"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v80" vertex2="nohole_motherboard5_assembly_v82" vertex3="nohole_motherboard5_assembly_v76"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v76" vertex2="nohole_motherboard5_assembly_v82" vertex3="nohole_motherboard5_assembly_v77"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v83" vertex2="nohole_motherboard5_assembly_v81" vertex3="nohole_motherboard5_assembly_v79"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v79" vertex2="nohole_motherboard5_assembly_v81" vertex3="nohole_motherboard5_assembly_v78"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v84" vertex2="nohole_motherboard5_assembly_v85" vertex3="nohole_motherboard5_assembly_v86"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v86" vertex2="nohole_motherboard5_assembly_v85" vertex3="nohole_motherboard5_assembly_v87"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v88" vertex2="nohole_motherboard5_assembly_v84" vertex3="nohole_motherboard5_assembly_v89"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v89" vertex2="nohole_motherboard5_assembly_v84" vertex3="nohole_motherboard5_assembly_v86"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v90" vertex2="nohole_motherboard5_assembly_v88" vertex3="nohole_motherboard5_assembly_v91"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v91" vertex2="nohole_motherboard5_assembly_v88" vertex3="nohole_motherboard5_assembly_v89"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v85" vertex2="nohole_motherboard5_assembly_v90" vertex3="nohole_motherboard5_assembly_v87"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v87" vertex2="nohole_motherboard5_assembly_v90" vertex3="nohole_motherboard5_assembly_v91"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v88" vertex2="nohole_motherboard5_assembly_v90" vertex3="nohole_motherboard5_assembly_v84"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v84" vertex2="nohole_motherboard5_assembly_v90" vertex3="nohole_motherboard5_assembly_v85"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v91" vertex2="nohole_motherboard5_assembly_v89" vertex3="nohole_motherboard5_assembly_v87"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v87" vertex2="nohole_motherboard5_assembly_v89" vertex3="nohole_motherboard5_assembly_v86"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v92" vertex2="nohole_motherboard5_assembly_v93" vertex3="nohole_motherboard5_assembly_v94"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v94" vertex2="nohole_motherboard5_assembly_v93" vertex3="nohole_motherboard5_assembly_v95"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v96" vertex2="nohole_motherboard5_assembly_v92" vertex3="nohole_motherboard5_assembly_v97"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v97" vertex2="nohole_motherboard5_assembly_v92" vertex3="nohole_motherboard5_assembly_v94"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v98" vertex2="nohole_motherboard5_assembly_v96" vertex3="nohole_motherboard5_assembly_v99"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v99" vertex2="nohole_motherboard5_assembly_v96" vertex3="nohole_motherboard5_assembly_v97"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v93" vertex2="nohole_motherboard5_assembly_v98" vertex3="nohole_motherboard5_assembly_v95"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v95" vertex2="nohole_motherboard5_assembly_v98" vertex3="nohole_motherboard5_assembly_v99"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v96" vertex2="nohole_motherboard5_assembly_v98" vertex3="nohole_motherboard5_assembly_v92"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v92" vertex2="nohole_motherboard5_assembly_v98" vertex3="nohole_motherboard5_assembly_v93"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v99" vertex2="nohole_motherboard5_assembly_v97" vertex3="nohole_motherboard5_assembly_v95"/>
+       <triangular vertex1="nohole_motherboard5_assembly_v95" vertex2="nohole_motherboard5_assembly_v97" vertex3="nohole_motherboard5_assembly_v94"/>
     </tessellated>
   </solids>
 
   <structure>
-    <volume name="motherboard5_assembly">
+    <volume name="nohole_motherboard5_assembly">
       <materialref ref="FR40x27264f0"/>
-      <solidref ref="motherboard5_assembly-SOL"/>
+      <solidref ref="nohole_motherboard5_assembly-SOL"/>
     </volume>
   </structure>
 
   <setup name="Default" version="1.0">
-    <world ref="motherboard5_assembly"/>
+    <world ref="nohole_motherboard5_assembly"/>
   </setup>
 </gdml>

--- a/Detectors/data/ldmx-det-v14/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-det-v14/ecal_motherboard6_assembly.gdml
@@ -2,591 +2,371 @@
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
   <define>
-    <position name="motherboard6_assembly_v0" unit="mm" x="106.2316" y="8.166" z="10.69263"/>
-    <position name="motherboard6_assembly_v1" unit="mm" x="204.4361" y="8.166" z="67.39101"/>
-    <position name="motherboard6_assembly_v2" unit="mm" x="106.2316" y="6.666" z="10.69263"/>
-    <position name="motherboard6_assembly_v3" unit="mm" x="204.4361" y="6.666" z="67.39101"/>
-    <position name="motherboard6_assembly_v4" unit="mm" x="15.35848" y="8.166" z="168.0895"/>
-    <position name="motherboard6_assembly_v5" unit="mm" x="15.35848" y="6.666" z="168.0895"/>
-    <position name="motherboard6_assembly_v6" unit="mm" x="15.35848" y="8.166" z="271.4943"/>
-    <position name="motherboard6_assembly_v7" unit="mm" x="15.35848" y="6.666" z="271.4943"/>
-    <position name="motherboard6_assembly_v8" unit="mm" x="120.4637" y="8.166" z="271.4943"/>
-    <position name="motherboard6_assembly_v9" unit="mm" x="120.4637" y="6.666" z="271.4943"/>
-    <position name="motherboard6_assembly_v10" unit="mm" x="171.2637" y="8.166" z="300.8237"/>
-    <position name="motherboard6_assembly_v11" unit="mm" x="171.2637" y="6.666" z="300.8237"/>
-    <position name="motherboard6_assembly_v12" unit="mm" x="204.4361" y="8.166" z="358.2799"/>
-    <position name="motherboard6_assembly_v13" unit="mm" x="204.4361" y="6.666" z="358.2799"/>
-    <position name="motherboard6_assembly_v14" unit="mm" x="204.4361" y="8.166" z="416.9387"/>
-    <position name="motherboard6_assembly_v15" unit="mm" x="204.4361" y="6.666" z="416.9387"/>
-    <position name="motherboard6_assembly_v16" unit="mm" x="255.2361" y="8.166" z="446.2681"/>
-    <position name="motherboard6_assembly_v17" unit="mm" x="255.2361" y="6.666" z="446.2681"/>
-    <position name="motherboard6_assembly_v18" unit="mm" x="306.0361" y="8.166" z="416.9387"/>
-    <position name="motherboard6_assembly_v19" unit="mm" x="306.0361" y="6.666" z="416.9387"/>
-    <position name="motherboard6_assembly_v20" unit="mm" x="306.0361" y="8.166" z="358.2799"/>
-    <position name="motherboard6_assembly_v21" unit="mm" x="306.0361" y="6.666" z="358.2799"/>
-    <position name="motherboard6_assembly_v22" unit="mm" x="309.8791" y="8.166" z="292.9649"/>
-    <position name="motherboard6_assembly_v23" unit="mm" x="309.8791" y="6.666" z="292.9649"/>
-    <position name="motherboard6_assembly_v24" unit="mm" x="368.5379" y="8.166" z="292.9649"/>
-    <position name="motherboard6_assembly_v25" unit="mm" x="368.5379" y="6.666" z="292.9649"/>
-    <position name="motherboard6_assembly_v26" unit="mm" x="397.8673" y="8.166" z="242.1649"/>
-    <position name="motherboard6_assembly_v27" unit="mm" x="397.8673" y="6.666" z="242.1649"/>
-    <position name="motherboard6_assembly_v28" unit="mm" x="368.5379" y="8.166" z="191.3649"/>
-    <position name="motherboard6_assembly_v29" unit="mm" x="368.5379" y="6.666" z="191.3649"/>
-    <position name="motherboard6_assembly_v30" unit="mm" x="309.8791" y="8.166" z="191.3649"/>
-    <position name="motherboard6_assembly_v31" unit="mm" x="309.8791" y="6.666" z="191.3649"/>
-    <position name="motherboard6_assembly_v32" unit="mm" x="306.0361" y="8.166" z="126.0498"/>
-    <position name="motherboard6_assembly_v33" unit="mm" x="306.0361" y="6.666" z="126.0498"/>
-    <position name="motherboard6_assembly_v34" unit="mm" x="306.0361" y="8.166" z="67.39101"/>
-    <position name="motherboard6_assembly_v35" unit="mm" x="306.0361" y="6.666" z="67.39101"/>
-    <position name="motherboard6_assembly_v36" unit="mm" x="255.2361" y="8.166" z="38.06162"/>
-    <position name="motherboard6_assembly_v37" unit="mm" x="255.2361" y="6.666" z="38.06162"/>
-    <position name="motherboard6_assembly_v38" unit="mm" x="155.72" y="8.166" z="130.7285"/>
-    <position name="motherboard6_assembly_v39" unit="mm" x="157.2247" y="8.166" z="130.0268"/>
-    <position name="motherboard6_assembly_v40" unit="mm" x="158.8285" y="8.166" z="129.5971"/>
-    <position name="motherboard6_assembly_v41" unit="mm" x="169.8628" y="8.166" z="137.3234"/>
-    <position name="motherboard6_assembly_v42" unit="mm" x="170.0075" y="8.166" z="138.9774"/>
-    <position name="motherboard6_assembly_v43" unit="mm" x="168.7314" y="8.166" z="143.7399"/>
-    <position name="motherboard6_assembly_v44" unit="mm" x="169.4331" y="8.166" z="142.2351"/>
-    <position name="motherboard6_assembly_v45" unit="mm" x="169.8628" y="8.166" z="140.6314"/>
-    <position name="motherboard6_assembly_v46" unit="mm" x="160.4825" y="8.166" z="129.4524"/>
-    <position name="motherboard6_assembly_v47" unit="mm" x="162.1365" y="8.166" z="129.5971"/>
-    <position name="motherboard6_assembly_v48" unit="mm" x="163.7402" y="8.166" z="130.0268"/>
-    <position name="motherboard6_assembly_v49" unit="mm" x="151.5319" y="8.166" z="135.7196"/>
-    <position name="motherboard6_assembly_v50" unit="mm" x="167.7791" y="8.166" z="145.0999"/>
-    <position name="motherboard6_assembly_v51" unit="mm" x="166.605" y="8.166" z="146.2739"/>
-    <position name="motherboard6_assembly_v52" unit="mm" x="165.245" y="8.166" z="147.2263"/>
-    <position name="motherboard6_assembly_v53" unit="mm" x="163.7402" y="8.166" z="147.9279"/>
-    <position name="motherboard6_assembly_v54" unit="mm" x="162.1365" y="8.166" z="148.3577"/>
-    <position name="motherboard6_assembly_v55" unit="mm" x="160.4825" y="8.166" z="148.5024"/>
-    <position name="motherboard6_assembly_v56" unit="mm" x="158.8285" y="8.166" z="148.3577"/>
-    <position name="motherboard6_assembly_v57" unit="mm" x="157.2247" y="8.166" z="147.9279"/>
-    <position name="motherboard6_assembly_v58" unit="mm" x="166.605" y="8.166" z="131.6808"/>
-    <position name="motherboard6_assembly_v59" unit="mm" x="167.7791" y="8.166" z="132.8548"/>
-    <position name="motherboard6_assembly_v60" unit="mm" x="152.2336" y="8.166" z="143.7399"/>
-    <position name="motherboard6_assembly_v61" unit="mm" x="151.5319" y="8.166" z="142.2351"/>
-    <position name="motherboard6_assembly_v62" unit="mm" x="151.1022" y="8.166" z="140.6314"/>
-    <position name="motherboard6_assembly_v63" unit="mm" x="150.9575" y="8.166" z="138.9774"/>
-    <position name="motherboard6_assembly_v64" unit="mm" x="151.1022" y="8.166" z="137.3234"/>
-    <position name="motherboard6_assembly_v65" unit="mm" x="152.2336" y="8.166" z="134.2149"/>
-    <position name="motherboard6_assembly_v66" unit="mm" x="153.1859" y="8.166" z="132.8548"/>
-    <position name="motherboard6_assembly_v67" unit="mm" x="154.3599" y="8.166" z="131.6808"/>
-    <position name="motherboard6_assembly_v68" unit="mm" x="168.7314" y="8.166" z="134.2149"/>
-    <position name="motherboard6_assembly_v69" unit="mm" x="169.4331" y="8.166" z="135.7196"/>
-    <position name="motherboard6_assembly_v70" unit="mm" x="155.72" y="8.166" z="147.2263"/>
-    <position name="motherboard6_assembly_v71" unit="mm" x="154.3599" y="8.166" z="146.2739"/>
-    <position name="motherboard6_assembly_v72" unit="mm" x="153.1859" y="8.166" z="145.0999"/>
-    <position name="motherboard6_assembly_v73" unit="mm" x="165.245" y="8.166" z="130.7285"/>
-    <position name="motherboard6_assembly_v74" unit="mm" x="150.9575" y="6.666" z="138.9774"/>
-    <position name="motherboard6_assembly_v75" unit="mm" x="151.1022" y="6.666" z="140.6314"/>
-    <position name="motherboard6_assembly_v76" unit="mm" x="151.5319" y="6.666" z="142.2351"/>
-    <position name="motherboard6_assembly_v77" unit="mm" x="152.2336" y="6.666" z="143.7399"/>
-    <position name="motherboard6_assembly_v78" unit="mm" x="158.8285" y="6.666" z="129.5971"/>
-    <position name="motherboard6_assembly_v79" unit="mm" x="157.2247" y="6.666" z="130.0268"/>
-    <position name="motherboard6_assembly_v80" unit="mm" x="155.72" y="6.666" z="130.7285"/>
-    <position name="motherboard6_assembly_v81" unit="mm" x="154.3599" y="6.666" z="131.6808"/>
-    <position name="motherboard6_assembly_v82" unit="mm" x="151.1022" y="6.666" z="137.3234"/>
-    <position name="motherboard6_assembly_v83" unit="mm" x="153.1859" y="6.666" z="145.0999"/>
-    <position name="motherboard6_assembly_v84" unit="mm" x="154.3599" y="6.666" z="146.2739"/>
-    <position name="motherboard6_assembly_v85" unit="mm" x="155.72" y="6.666" z="147.2263"/>
-    <position name="motherboard6_assembly_v86" unit="mm" x="162.1365" y="6.666" z="148.3577"/>
-    <position name="motherboard6_assembly_v87" unit="mm" x="163.7402" y="6.666" z="147.9279"/>
-    <position name="motherboard6_assembly_v88" unit="mm" x="165.245" y="6.666" z="147.2263"/>
-    <position name="motherboard6_assembly_v89" unit="mm" x="166.605" y="6.666" z="146.2739"/>
-    <position name="motherboard6_assembly_v90" unit="mm" x="169.8628" y="6.666" z="140.6314"/>
-    <position name="motherboard6_assembly_v91" unit="mm" x="169.4331" y="6.666" z="142.2351"/>
-    <position name="motherboard6_assembly_v92" unit="mm" x="167.7791" y="6.666" z="145.0999"/>
-    <position name="motherboard6_assembly_v93" unit="mm" x="168.7314" y="6.666" z="143.7399"/>
-    <position name="motherboard6_assembly_v94" unit="mm" x="153.1859" y="6.666" z="132.8548"/>
-    <position name="motherboard6_assembly_v95" unit="mm" x="152.2336" y="6.666" z="134.2149"/>
-    <position name="motherboard6_assembly_v96" unit="mm" x="151.5319" y="6.666" z="135.7196"/>
-    <position name="motherboard6_assembly_v97" unit="mm" x="157.2247" y="6.666" z="147.9279"/>
-    <position name="motherboard6_assembly_v98" unit="mm" x="158.8285" y="6.666" z="148.3577"/>
-    <position name="motherboard6_assembly_v99" unit="mm" x="160.4825" y="6.666" z="148.5024"/>
-    <position name="motherboard6_assembly_v100" unit="mm" x="170.0075" y="6.666" z="138.9774"/>
-    <position name="motherboard6_assembly_v101" unit="mm" x="169.8628" y="6.666" z="137.3234"/>
-    <position name="motherboard6_assembly_v102" unit="mm" x="169.4331" y="6.666" z="135.7196"/>
-    <position name="motherboard6_assembly_v103" unit="mm" x="166.605" y="6.666" z="131.6808"/>
-    <position name="motherboard6_assembly_v104" unit="mm" x="165.245" y="6.666" z="130.7285"/>
-    <position name="motherboard6_assembly_v105" unit="mm" x="163.7402" y="6.666" z="130.0268"/>
-    <position name="motherboard6_assembly_v106" unit="mm" x="162.1365" y="6.666" z="129.5971"/>
-    <position name="motherboard6_assembly_v107" unit="mm" x="160.4825" y="6.666" z="129.4524"/>
-    <position name="motherboard6_assembly_v108" unit="mm" x="168.7314" y="6.666" z="134.2149"/>
-    <position name="motherboard6_assembly_v109" unit="mm" x="167.7791" y="6.666" z="132.8548"/>
-    <position name="motherboard6_assembly_v110" unit="mm" x="58.60662" y="6.666" z="93.18155"/>
-    <position name="motherboard6_assembly_v111" unit="mm" x="65.53482" y="6.666" z="97.18155"/>
-    <position name="motherboard6_assembly_v112" unit="mm" x="58.60662" y="1.666" z="93.18155"/>
-    <position name="motherboard6_assembly_v113" unit="mm" x="65.53482" y="1.666" z="97.18155"/>
-    <position name="motherboard6_assembly_v114" unit="mm" x="27.60662" y="6.666" z="146.8751"/>
-    <position name="motherboard6_assembly_v115" unit="mm" x="27.60662" y="1.666" z="146.8751"/>
-    <position name="motherboard6_assembly_v116" unit="mm" x="34.53482" y="6.666" z="150.8751"/>
-    <position name="motherboard6_assembly_v117" unit="mm" x="34.53482" y="1.666" z="150.8751"/>
-    <position name="motherboard6_assembly_v118" unit="mm" x="52.71431" y="1.666" z="79.38732"/>
-    <position name="motherboard6_assembly_v119" unit="mm" x="121.9963" y="1.666" z="119.3873"/>
-    <position name="motherboard6_assembly_v120" unit="mm" x="52.71431" y="0.066" z="79.38732"/>
-    <position name="motherboard6_assembly_v121" unit="mm" x="121.9963" y="0.066" z="119.3873"/>
-    <position name="motherboard6_assembly_v122" unit="mm" x="12.71431" y="1.666" z="148.6694"/>
-    <position name="motherboard6_assembly_v123" unit="mm" x="12.71431" y="0.066" z="148.6694"/>
-    <position name="motherboard6_assembly_v124" unit="mm" x="81.99634" y="1.666" z="188.6694"/>
-    <position name="motherboard6_assembly_v125" unit="mm" x="81.99634" y="0.066" z="188.6694"/>
-    <position name="motherboard6_assembly_v126" unit="mm" x="63.14604" y="4.666" z="118.319"/>
-    <position name="motherboard6_assembly_v127" unit="mm" x="83.06462" y="4.666" z="129.819"/>
-    <position name="motherboard6_assembly_v128" unit="mm" x="63.14604" y="1.666" z="118.319"/>
-    <position name="motherboard6_assembly_v129" unit="mm" x="83.06462" y="1.666" z="129.819"/>
-    <position name="motherboard6_assembly_v130" unit="mm" x="51.64604" y="4.666" z="138.2376"/>
-    <position name="motherboard6_assembly_v131" unit="mm" x="51.64604" y="1.666" z="138.2376"/>
-    <position name="motherboard6_assembly_v132" unit="mm" x="71.56462" y="4.666" z="149.7376"/>
-    <position name="motherboard6_assembly_v133" unit="mm" x="71.56462" y="1.666" z="149.7376"/>
-    <position name="motherboard6_assembly_v134" unit="mm" x="100.1758" y="6.666" z="117.1816"/>
-    <position name="motherboard6_assembly_v135" unit="mm" x="107.104" y="6.666" z="121.1816"/>
-    <position name="motherboard6_assembly_v136" unit="mm" x="100.1758" y="1.666" z="117.1816"/>
-    <position name="motherboard6_assembly_v137" unit="mm" x="107.104" y="1.666" z="121.1816"/>
-    <position name="motherboard6_assembly_v138" unit="mm" x="69.17584" y="6.666" z="170.8751"/>
-    <position name="motherboard6_assembly_v139" unit="mm" x="69.17584" y="1.666" z="170.8751"/>
-    <position name="motherboard6_assembly_v140" unit="mm" x="76.10404" y="6.666" z="174.8751"/>
-    <position name="motherboard6_assembly_v141" unit="mm" x="76.10404" y="1.666" z="174.8751"/>
-    <position name="motherboard6_assembly_v142" unit="mm" x="15.35848" y="6.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v143" unit="mm" x="23.35848" y="6.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v144" unit="mm" x="15.35848" y="1.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v145" unit="mm" x="23.35848" y="1.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v146" unit="mm" x="15.35848" y="6.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v147" unit="mm" x="15.35848" y="1.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v148" unit="mm" x="23.35848" y="6.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v149" unit="mm" x="23.35848" y="1.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v150" unit="mm" x="3.358484" y="1.666" z="198.8941"/>
-    <position name="motherboard6_assembly_v151" unit="mm" x="83.35848" y="1.666" z="198.8941"/>
-    <position name="motherboard6_assembly_v152" unit="mm" x="3.358484" y="0.066" z="198.8941"/>
-    <position name="motherboard6_assembly_v153" unit="mm" x="83.35848" y="0.066" z="198.8941"/>
-    <position name="motherboard6_assembly_v154" unit="mm" x="3.358484" y="1.666" z="278.8941"/>
-    <position name="motherboard6_assembly_v155" unit="mm" x="3.358484" y="0.066" z="278.8941"/>
-    <position name="motherboard6_assembly_v156" unit="mm" x="83.35848" y="1.666" z="278.8941"/>
-    <position name="motherboard6_assembly_v157" unit="mm" x="83.35848" y="0.066" z="278.8941"/>
-    <position name="motherboard6_assembly_v158" unit="mm" x="31.85848" y="4.666" z="227.3941"/>
-    <position name="motherboard6_assembly_v159" unit="mm" x="54.85848" y="4.666" z="227.3941"/>
-    <position name="motherboard6_assembly_v160" unit="mm" x="31.85848" y="1.666" z="227.3941"/>
-    <position name="motherboard6_assembly_v161" unit="mm" x="54.85848" y="1.666" z="227.3941"/>
-    <position name="motherboard6_assembly_v162" unit="mm" x="31.85848" y="4.666" z="250.3941"/>
-    <position name="motherboard6_assembly_v163" unit="mm" x="31.85848" y="1.666" z="250.3941"/>
-    <position name="motherboard6_assembly_v164" unit="mm" x="54.85848" y="4.666" z="250.3941"/>
-    <position name="motherboard6_assembly_v165" unit="mm" x="54.85848" y="1.666" z="250.3941"/>
-    <position name="motherboard6_assembly_v166" unit="mm" x="63.35848" y="6.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v167" unit="mm" x="71.35848" y="6.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v168" unit="mm" x="63.35848" y="1.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v169" unit="mm" x="71.35848" y="1.666" z="207.8941"/>
-    <position name="motherboard6_assembly_v170" unit="mm" x="63.35848" y="6.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v171" unit="mm" x="63.35848" y="1.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v172" unit="mm" x="71.35848" y="6.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v173" unit="mm" x="71.35848" y="1.666" z="269.8941"/>
-    <position name="motherboard6_assembly_v174" unit="mm" x="103.0566" y="6.666" z="16.19189"/>
-    <position name="motherboard6_assembly_v175" unit="mm" x="109.9848" y="6.666" z="20.1919"/>
-    <position name="motherboard6_assembly_v176" unit="mm" x="103.0566" y="1.666" z="16.19189"/>
-    <position name="motherboard6_assembly_v177" unit="mm" x="109.9848" y="1.666" z="20.1919"/>
-    <position name="motherboard6_assembly_v178" unit="mm" x="72.05662" y="6.666" z="69.88547"/>
-    <position name="motherboard6_assembly_v179" unit="mm" x="72.05662" y="1.666" z="69.88547"/>
-    <position name="motherboard6_assembly_v180" unit="mm" x="78.98482" y="6.666" z="73.88547"/>
-    <position name="motherboard6_assembly_v181" unit="mm" x="78.98482" y="1.666" z="73.88547"/>
-    <position name="motherboard6_assembly_v182" unit="mm" x="97.16431" y="1.666" z="2.397666"/>
-    <position name="motherboard6_assembly_v183" unit="mm" x="166.4463" y="1.666" z="42.39767"/>
-    <position name="motherboard6_assembly_v184" unit="mm" x="97.16431" y="0.066" z="2.397666"/>
-    <position name="motherboard6_assembly_v185" unit="mm" x="166.4463" y="0.066" z="42.39767"/>
-    <position name="motherboard6_assembly_v186" unit="mm" x="57.16431" y="1.666" z="71.6797"/>
-    <position name="motherboard6_assembly_v187" unit="mm" x="57.16431" y="0.066" z="71.6797"/>
-    <position name="motherboard6_assembly_v188" unit="mm" x="126.4463" y="1.666" z="111.6797"/>
-    <position name="motherboard6_assembly_v189" unit="mm" x="126.4463" y="0.066" z="111.6797"/>
-    <position name="motherboard6_assembly_v190" unit="mm" x="107.596" y="4.666" z="41.32939"/>
-    <position name="motherboard6_assembly_v191" unit="mm" x="127.5146" y="4.666" z="52.82939"/>
-    <position name="motherboard6_assembly_v192" unit="mm" x="107.596" y="1.666" z="41.32939"/>
-    <position name="motherboard6_assembly_v193" unit="mm" x="127.5146" y="1.666" z="52.82939"/>
-    <position name="motherboard6_assembly_v194" unit="mm" x="96.09604" y="4.666" z="61.24797"/>
-    <position name="motherboard6_assembly_v195" unit="mm" x="96.09604" y="1.666" z="61.24797"/>
-    <position name="motherboard6_assembly_v196" unit="mm" x="116.0146" y="4.666" z="72.74797"/>
-    <position name="motherboard6_assembly_v197" unit="mm" x="116.0146" y="1.666" z="72.74797"/>
-    <position name="motherboard6_assembly_v198" unit="mm" x="144.6258" y="6.666" z="40.19189"/>
-    <position name="motherboard6_assembly_v199" unit="mm" x="151.554" y="6.666" z="44.1919"/>
-    <position name="motherboard6_assembly_v200" unit="mm" x="144.6258" y="1.666" z="40.19189"/>
-    <position name="motherboard6_assembly_v201" unit="mm" x="151.554" y="1.666" z="44.1919"/>
-    <position name="motherboard6_assembly_v202" unit="mm" x="113.6258" y="6.666" z="93.88547"/>
-    <position name="motherboard6_assembly_v203" unit="mm" x="113.6258" y="1.666" z="93.88547"/>
-    <position name="motherboard6_assembly_v204" unit="mm" x="120.554" y="6.666" z="97.88547"/>
-    <position name="motherboard6_assembly_v205" unit="mm" x="120.554" y="1.666" z="97.88547"/>
+    <position name="nohole_motherboard6_assembly_v0" unit="mm" x="106.2316" y="8.166" z="10.69263"/>
+    <position name="nohole_motherboard6_assembly_v1" unit="mm" x="204.4361" y="8.166" z="67.39101"/>
+    <position name="nohole_motherboard6_assembly_v2" unit="mm" x="106.2316" y="6.666" z="10.69263"/>
+    <position name="nohole_motherboard6_assembly_v3" unit="mm" x="204.4361" y="6.666" z="67.39101"/>
+    <position name="nohole_motherboard6_assembly_v4" unit="mm" x="15.35848" y="8.166" z="168.0895"/>
+    <position name="nohole_motherboard6_assembly_v5" unit="mm" x="15.35848" y="6.666" z="168.0895"/>
+    <position name="nohole_motherboard6_assembly_v6" unit="mm" x="15.35848" y="8.166" z="271.4943"/>
+    <position name="nohole_motherboard6_assembly_v7" unit="mm" x="15.35848" y="6.666" z="271.4943"/>
+    <position name="nohole_motherboard6_assembly_v8" unit="mm" x="120.4637" y="8.166" z="271.4943"/>
+    <position name="nohole_motherboard6_assembly_v9" unit="mm" x="120.4637" y="6.666" z="271.4943"/>
+    <position name="nohole_motherboard6_assembly_v10" unit="mm" x="171.2637" y="8.166" z="300.8237"/>
+    <position name="nohole_motherboard6_assembly_v11" unit="mm" x="171.2637" y="6.666" z="300.8237"/>
+    <position name="nohole_motherboard6_assembly_v12" unit="mm" x="204.4361" y="8.166" z="358.2799"/>
+    <position name="nohole_motherboard6_assembly_v13" unit="mm" x="204.4361" y="6.666" z="358.2799"/>
+    <position name="nohole_motherboard6_assembly_v14" unit="mm" x="204.4361" y="8.166" z="416.9387"/>
+    <position name="nohole_motherboard6_assembly_v15" unit="mm" x="204.4361" y="6.666" z="416.9387"/>
+    <position name="nohole_motherboard6_assembly_v16" unit="mm" x="255.2361" y="8.166" z="446.2681"/>
+    <position name="nohole_motherboard6_assembly_v17" unit="mm" x="255.2361" y="6.666" z="446.2681"/>
+    <position name="nohole_motherboard6_assembly_v18" unit="mm" x="306.0361" y="8.166" z="416.9387"/>
+    <position name="nohole_motherboard6_assembly_v19" unit="mm" x="306.0361" y="6.666" z="416.9387"/>
+    <position name="nohole_motherboard6_assembly_v20" unit="mm" x="306.0361" y="8.166" z="358.2799"/>
+    <position name="nohole_motherboard6_assembly_v21" unit="mm" x="306.0361" y="6.666" z="358.2799"/>
+    <position name="nohole_motherboard6_assembly_v22" unit="mm" x="309.8791" y="8.166" z="292.9649"/>
+    <position name="nohole_motherboard6_assembly_v23" unit="mm" x="309.8791" y="6.666" z="292.9649"/>
+    <position name="nohole_motherboard6_assembly_v24" unit="mm" x="368.5379" y="8.166" z="292.9649"/>
+    <position name="nohole_motherboard6_assembly_v25" unit="mm" x="368.5379" y="6.666" z="292.9649"/>
+    <position name="nohole_motherboard6_assembly_v26" unit="mm" x="397.8673" y="8.166" z="242.1649"/>
+    <position name="nohole_motherboard6_assembly_v27" unit="mm" x="397.8673" y="6.666" z="242.1649"/>
+    <position name="nohole_motherboard6_assembly_v28" unit="mm" x="368.5379" y="8.166" z="191.3649"/>
+    <position name="nohole_motherboard6_assembly_v29" unit="mm" x="368.5379" y="6.666" z="191.3649"/>
+    <position name="nohole_motherboard6_assembly_v30" unit="mm" x="309.8791" y="8.166" z="191.3649"/>
+    <position name="nohole_motherboard6_assembly_v31" unit="mm" x="309.8791" y="6.666" z="191.3649"/>
+    <position name="nohole_motherboard6_assembly_v32" unit="mm" x="306.0361" y="8.166" z="126.0498"/>
+    <position name="nohole_motherboard6_assembly_v33" unit="mm" x="306.0361" y="6.666" z="126.0498"/>
+    <position name="nohole_motherboard6_assembly_v34" unit="mm" x="306.0361" y="8.166" z="67.39101"/>
+    <position name="nohole_motherboard6_assembly_v35" unit="mm" x="306.0361" y="6.666" z="67.39101"/>
+    <position name="nohole_motherboard6_assembly_v36" unit="mm" x="255.2361" y="8.166" z="38.06162"/>
+    <position name="nohole_motherboard6_assembly_v37" unit="mm" x="255.2361" y="6.666" z="38.06162"/>
+    <position name="nohole_motherboard6_assembly_v38" unit="mm" x="103.0566" y="6.666" z="16.19189"/>
+    <position name="nohole_motherboard6_assembly_v39" unit="mm" x="109.9848" y="6.666" z="20.1919"/>
+    <position name="nohole_motherboard6_assembly_v40" unit="mm" x="103.0566" y="1.666" z="16.19189"/>
+    <position name="nohole_motherboard6_assembly_v41" unit="mm" x="109.9848" y="1.666" z="20.1919"/>
+    <position name="nohole_motherboard6_assembly_v42" unit="mm" x="72.05662" y="6.666" z="69.88547"/>
+    <position name="nohole_motherboard6_assembly_v43" unit="mm" x="72.05662" y="1.666" z="69.88547"/>
+    <position name="nohole_motherboard6_assembly_v44" unit="mm" x="78.98482" y="6.666" z="73.88547"/>
+    <position name="nohole_motherboard6_assembly_v45" unit="mm" x="78.98482" y="1.666" z="73.88547"/>
+    <position name="nohole_motherboard6_assembly_v46" unit="mm" x="107.596" y="4.666" z="41.32939"/>
+    <position name="nohole_motherboard6_assembly_v47" unit="mm" x="127.5146" y="4.666" z="52.82939"/>
+    <position name="nohole_motherboard6_assembly_v48" unit="mm" x="107.596" y="1.666" z="41.32939"/>
+    <position name="nohole_motherboard6_assembly_v49" unit="mm" x="127.5146" y="1.666" z="52.82939"/>
+    <position name="nohole_motherboard6_assembly_v50" unit="mm" x="96.09604" y="4.666" z="61.24797"/>
+    <position name="nohole_motherboard6_assembly_v51" unit="mm" x="96.09604" y="1.666" z="61.24797"/>
+    <position name="nohole_motherboard6_assembly_v52" unit="mm" x="116.0146" y="4.666" z="72.74797"/>
+    <position name="nohole_motherboard6_assembly_v53" unit="mm" x="116.0146" y="1.666" z="72.74797"/>
+    <position name="nohole_motherboard6_assembly_v54" unit="mm" x="144.6258" y="6.666" z="40.19189"/>
+    <position name="nohole_motherboard6_assembly_v55" unit="mm" x="151.554" y="6.666" z="44.1919"/>
+    <position name="nohole_motherboard6_assembly_v56" unit="mm" x="144.6258" y="1.666" z="40.19189"/>
+    <position name="nohole_motherboard6_assembly_v57" unit="mm" x="151.554" y="1.666" z="44.1919"/>
+    <position name="nohole_motherboard6_assembly_v58" unit="mm" x="113.6258" y="6.666" z="93.88547"/>
+    <position name="nohole_motherboard6_assembly_v59" unit="mm" x="113.6258" y="1.666" z="93.88547"/>
+    <position name="nohole_motherboard6_assembly_v60" unit="mm" x="120.554" y="6.666" z="97.88547"/>
+    <position name="nohole_motherboard6_assembly_v61" unit="mm" x="120.554" y="1.666" z="97.88547"/>
+    <position name="nohole_motherboard6_assembly_v62" unit="mm" x="97.16431" y="1.666" z="2.397666"/>
+    <position name="nohole_motherboard6_assembly_v63" unit="mm" x="166.4463" y="1.666" z="42.39767"/>
+    <position name="nohole_motherboard6_assembly_v64" unit="mm" x="97.16431" y="0.066" z="2.397666"/>
+    <position name="nohole_motherboard6_assembly_v65" unit="mm" x="166.4463" y="0.066" z="42.39767"/>
+    <position name="nohole_motherboard6_assembly_v66" unit="mm" x="57.16431" y="1.666" z="71.6797"/>
+    <position name="nohole_motherboard6_assembly_v67" unit="mm" x="57.16431" y="0.066" z="71.6797"/>
+    <position name="nohole_motherboard6_assembly_v68" unit="mm" x="126.4463" y="1.666" z="111.6797"/>
+    <position name="nohole_motherboard6_assembly_v69" unit="mm" x="126.4463" y="0.066" z="111.6797"/>
+    <position name="nohole_motherboard6_assembly_v70" unit="mm" x="15.35848" y="6.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v71" unit="mm" x="23.35848" y="6.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v72" unit="mm" x="15.35848" y="1.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v73" unit="mm" x="23.35848" y="1.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v74" unit="mm" x="15.35848" y="6.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v75" unit="mm" x="15.35848" y="1.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v76" unit="mm" x="23.35848" y="6.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v77" unit="mm" x="23.35848" y="1.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v78" unit="mm" x="31.85848" y="4.666" z="227.3941"/>
+    <position name="nohole_motherboard6_assembly_v79" unit="mm" x="54.85848" y="4.666" z="227.3941"/>
+    <position name="nohole_motherboard6_assembly_v80" unit="mm" x="31.85848" y="1.666" z="227.3941"/>
+    <position name="nohole_motherboard6_assembly_v81" unit="mm" x="54.85848" y="1.666" z="227.3941"/>
+    <position name="nohole_motherboard6_assembly_v82" unit="mm" x="31.85848" y="4.666" z="250.3941"/>
+    <position name="nohole_motherboard6_assembly_v83" unit="mm" x="31.85848" y="1.666" z="250.3941"/>
+    <position name="nohole_motherboard6_assembly_v84" unit="mm" x="54.85848" y="4.666" z="250.3941"/>
+    <position name="nohole_motherboard6_assembly_v85" unit="mm" x="54.85848" y="1.666" z="250.3941"/>
+    <position name="nohole_motherboard6_assembly_v86" unit="mm" x="63.35848" y="6.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v87" unit="mm" x="71.35848" y="6.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v88" unit="mm" x="63.35848" y="1.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v89" unit="mm" x="71.35848" y="1.666" z="207.8941"/>
+    <position name="nohole_motherboard6_assembly_v90" unit="mm" x="63.35848" y="6.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v91" unit="mm" x="63.35848" y="1.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v92" unit="mm" x="71.35848" y="6.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v93" unit="mm" x="71.35848" y="1.666" z="269.8941"/>
+    <position name="nohole_motherboard6_assembly_v94" unit="mm" x="3.358484" y="1.666" z="198.8941"/>
+    <position name="nohole_motherboard6_assembly_v95" unit="mm" x="83.35848" y="1.666" z="198.8941"/>
+    <position name="nohole_motherboard6_assembly_v96" unit="mm" x="3.358484" y="0.066" z="198.8941"/>
+    <position name="nohole_motherboard6_assembly_v97" unit="mm" x="83.35848" y="0.066" z="198.8941"/>
+    <position name="nohole_motherboard6_assembly_v98" unit="mm" x="3.358484" y="1.666" z="278.8941"/>
+    <position name="nohole_motherboard6_assembly_v99" unit="mm" x="3.358484" y="0.066" z="278.8941"/>
+    <position name="nohole_motherboard6_assembly_v100" unit="mm" x="83.35848" y="1.666" z="278.8941"/>
+    <position name="nohole_motherboard6_assembly_v101" unit="mm" x="83.35848" y="0.066" z="278.8941"/>
+    <position name="nohole_motherboard6_assembly_v102" unit="mm" x="58.60662" y="6.666" z="93.18155"/>
+    <position name="nohole_motherboard6_assembly_v103" unit="mm" x="65.53482" y="6.666" z="97.18155"/>
+    <position name="nohole_motherboard6_assembly_v104" unit="mm" x="58.60662" y="1.666" z="93.18155"/>
+    <position name="nohole_motherboard6_assembly_v105" unit="mm" x="65.53482" y="1.666" z="97.18155"/>
+    <position name="nohole_motherboard6_assembly_v106" unit="mm" x="27.60662" y="6.666" z="146.8751"/>
+    <position name="nohole_motherboard6_assembly_v107" unit="mm" x="27.60662" y="1.666" z="146.8751"/>
+    <position name="nohole_motherboard6_assembly_v108" unit="mm" x="34.53482" y="6.666" z="150.8751"/>
+    <position name="nohole_motherboard6_assembly_v109" unit="mm" x="34.53482" y="1.666" z="150.8751"/>
+    <position name="nohole_motherboard6_assembly_v110" unit="mm" x="63.14604" y="4.666" z="118.319"/>
+    <position name="nohole_motherboard6_assembly_v111" unit="mm" x="83.06462" y="4.666" z="129.819"/>
+    <position name="nohole_motherboard6_assembly_v112" unit="mm" x="63.14604" y="1.666" z="118.319"/>
+    <position name="nohole_motherboard6_assembly_v113" unit="mm" x="83.06462" y="1.666" z="129.819"/>
+    <position name="nohole_motherboard6_assembly_v114" unit="mm" x="51.64604" y="4.666" z="138.2376"/>
+    <position name="nohole_motherboard6_assembly_v115" unit="mm" x="51.64604" y="1.666" z="138.2376"/>
+    <position name="nohole_motherboard6_assembly_v116" unit="mm" x="71.56462" y="4.666" z="149.7376"/>
+    <position name="nohole_motherboard6_assembly_v117" unit="mm" x="71.56462" y="1.666" z="149.7376"/>
+    <position name="nohole_motherboard6_assembly_v118" unit="mm" x="100.1758" y="6.666" z="117.1816"/>
+    <position name="nohole_motherboard6_assembly_v119" unit="mm" x="107.104" y="6.666" z="121.1816"/>
+    <position name="nohole_motherboard6_assembly_v120" unit="mm" x="100.1758" y="1.666" z="117.1816"/>
+    <position name="nohole_motherboard6_assembly_v121" unit="mm" x="107.104" y="1.666" z="121.1816"/>
+    <position name="nohole_motherboard6_assembly_v122" unit="mm" x="69.17584" y="6.666" z="170.8751"/>
+    <position name="nohole_motherboard6_assembly_v123" unit="mm" x="69.17584" y="1.666" z="170.8751"/>
+    <position name="nohole_motherboard6_assembly_v124" unit="mm" x="76.10404" y="6.666" z="174.8751"/>
+    <position name="nohole_motherboard6_assembly_v125" unit="mm" x="76.10404" y="1.666" z="174.8751"/>
+    <position name="nohole_motherboard6_assembly_v126" unit="mm" x="52.71431" y="1.666" z="79.38732"/>
+    <position name="nohole_motherboard6_assembly_v127" unit="mm" x="121.9963" y="1.666" z="119.3873"/>
+    <position name="nohole_motherboard6_assembly_v128" unit="mm" x="52.71431" y="0.066" z="79.38732"/>
+    <position name="nohole_motherboard6_assembly_v129" unit="mm" x="121.9963" y="0.066" z="119.3873"/>
+    <position name="nohole_motherboard6_assembly_v130" unit="mm" x="12.71431" y="1.666" z="148.6694"/>
+    <position name="nohole_motherboard6_assembly_v131" unit="mm" x="12.71431" y="0.066" z="148.6694"/>
+    <position name="nohole_motherboard6_assembly_v132" unit="mm" x="81.99634" y="1.666" z="188.6694"/>
+    <position name="nohole_motherboard6_assembly_v133" unit="mm" x="81.99634" y="0.066" z="188.6694"/>
   </define>
 
   <solids>
-    <tessellated aunit="deg" lunit="mm" name="motherboard6_assembly-SOL">
-       <triangular vertex1="motherboard6_assembly_v0" vertex2="motherboard6_assembly_v1" vertex3="motherboard6_assembly_v2"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v1" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v4" vertex2="motherboard6_assembly_v0" vertex3="motherboard6_assembly_v5"/>
-       <triangular vertex1="motherboard6_assembly_v5" vertex2="motherboard6_assembly_v0" vertex3="motherboard6_assembly_v2"/>
-       <triangular vertex1="motherboard6_assembly_v6" vertex2="motherboard6_assembly_v4" vertex3="motherboard6_assembly_v7"/>
-       <triangular vertex1="motherboard6_assembly_v7" vertex2="motherboard6_assembly_v4" vertex3="motherboard6_assembly_v5"/>
-       <triangular vertex1="motherboard6_assembly_v8" vertex2="motherboard6_assembly_v6" vertex3="motherboard6_assembly_v9"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v6" vertex3="motherboard6_assembly_v7"/>
-       <triangular vertex1="motherboard6_assembly_v10" vertex2="motherboard6_assembly_v8" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v8" vertex3="motherboard6_assembly_v9"/>
-       <triangular vertex1="motherboard6_assembly_v12" vertex2="motherboard6_assembly_v10" vertex3="motherboard6_assembly_v13"/>
-       <triangular vertex1="motherboard6_assembly_v13" vertex2="motherboard6_assembly_v10" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v14" vertex2="motherboard6_assembly_v12" vertex3="motherboard6_assembly_v15"/>
-       <triangular vertex1="motherboard6_assembly_v15" vertex2="motherboard6_assembly_v12" vertex3="motherboard6_assembly_v13"/>
-       <triangular vertex1="motherboard6_assembly_v16" vertex2="motherboard6_assembly_v14" vertex3="motherboard6_assembly_v17"/>
-       <triangular vertex1="motherboard6_assembly_v17" vertex2="motherboard6_assembly_v14" vertex3="motherboard6_assembly_v15"/>
-       <triangular vertex1="motherboard6_assembly_v18" vertex2="motherboard6_assembly_v16" vertex3="motherboard6_assembly_v19"/>
-       <triangular vertex1="motherboard6_assembly_v19" vertex2="motherboard6_assembly_v16" vertex3="motherboard6_assembly_v17"/>
-       <triangular vertex1="motherboard6_assembly_v20" vertex2="motherboard6_assembly_v18" vertex3="motherboard6_assembly_v21"/>
-       <triangular vertex1="motherboard6_assembly_v21" vertex2="motherboard6_assembly_v18" vertex3="motherboard6_assembly_v19"/>
-       <triangular vertex1="motherboard6_assembly_v22" vertex2="motherboard6_assembly_v20" vertex3="motherboard6_assembly_v23"/>
-       <triangular vertex1="motherboard6_assembly_v23" vertex2="motherboard6_assembly_v20" vertex3="motherboard6_assembly_v21"/>
-       <triangular vertex1="motherboard6_assembly_v24" vertex2="motherboard6_assembly_v22" vertex3="motherboard6_assembly_v25"/>
-       <triangular vertex1="motherboard6_assembly_v25" vertex2="motherboard6_assembly_v22" vertex3="motherboard6_assembly_v23"/>
-       <triangular vertex1="motherboard6_assembly_v26" vertex2="motherboard6_assembly_v24" vertex3="motherboard6_assembly_v27"/>
-       <triangular vertex1="motherboard6_assembly_v27" vertex2="motherboard6_assembly_v24" vertex3="motherboard6_assembly_v25"/>
-       <triangular vertex1="motherboard6_assembly_v28" vertex2="motherboard6_assembly_v26" vertex3="motherboard6_assembly_v29"/>
-       <triangular vertex1="motherboard6_assembly_v29" vertex2="motherboard6_assembly_v26" vertex3="motherboard6_assembly_v27"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v28" vertex3="motherboard6_assembly_v31"/>
-       <triangular vertex1="motherboard6_assembly_v31" vertex2="motherboard6_assembly_v28" vertex3="motherboard6_assembly_v29"/>
-       <triangular vertex1="motherboard6_assembly_v32" vertex2="motherboard6_assembly_v30" vertex3="motherboard6_assembly_v33"/>
-       <triangular vertex1="motherboard6_assembly_v33" vertex2="motherboard6_assembly_v30" vertex3="motherboard6_assembly_v31"/>
-       <triangular vertex1="motherboard6_assembly_v34" vertex2="motherboard6_assembly_v32" vertex3="motherboard6_assembly_v35"/>
-       <triangular vertex1="motherboard6_assembly_v35" vertex2="motherboard6_assembly_v32" vertex3="motherboard6_assembly_v33"/>
-       <triangular vertex1="motherboard6_assembly_v36" vertex2="motherboard6_assembly_v34" vertex3="motherboard6_assembly_v37"/>
-       <triangular vertex1="motherboard6_assembly_v37" vertex2="motherboard6_assembly_v34" vertex3="motherboard6_assembly_v35"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v36" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v36" vertex3="motherboard6_assembly_v37"/>
-       <triangular vertex1="motherboard6_assembly_v18" vertex2="motherboard6_assembly_v20" vertex3="motherboard6_assembly_v16"/>
-       <triangular vertex1="motherboard6_assembly_v16" vertex2="motherboard6_assembly_v20" vertex3="motherboard6_assembly_v12"/>
-       <triangular vertex1="motherboard6_assembly_v16" vertex2="motherboard6_assembly_v12" vertex3="motherboard6_assembly_v14"/>
-       <triangular vertex1="motherboard6_assembly_v24" vertex2="motherboard6_assembly_v26" vertex3="motherboard6_assembly_v22"/>
-       <triangular vertex1="motherboard6_assembly_v22" vertex2="motherboard6_assembly_v26" vertex3="motherboard6_assembly_v28"/>
-       <triangular vertex1="motherboard6_assembly_v22" vertex2="motherboard6_assembly_v28" vertex3="motherboard6_assembly_v30"/>
-       <triangular vertex1="motherboard6_assembly_v38" vertex2="motherboard6_assembly_v39" vertex3="motherboard6_assembly_v1"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v39" vertex3="motherboard6_assembly_v40"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v41" vertex3="motherboard6_assembly_v42"/>
-       <triangular vertex1="motherboard6_assembly_v43" vertex2="motherboard6_assembly_v22" vertex3="motherboard6_assembly_v44"/>
-       <triangular vertex1="motherboard6_assembly_v44" vertex2="motherboard6_assembly_v22" vertex3="motherboard6_assembly_v30"/>
-       <triangular vertex1="motherboard6_assembly_v44" vertex2="motherboard6_assembly_v30" vertex3="motherboard6_assembly_v45"/>
-       <triangular vertex1="motherboard6_assembly_v45" vertex2="motherboard6_assembly_v30" vertex3="motherboard6_assembly_v42"/>
-       <triangular vertex1="motherboard6_assembly_v40" vertex2="motherboard6_assembly_v46" vertex3="motherboard6_assembly_v1"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v46" vertex3="motherboard6_assembly_v47"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v47" vertex3="motherboard6_assembly_v48"/>
-       <triangular vertex1="motherboard6_assembly_v0" vertex2="motherboard6_assembly_v4" vertex3="motherboard6_assembly_v49"/>
-       <triangular vertex1="motherboard6_assembly_v43" vertex2="motherboard6_assembly_v50" vertex3="motherboard6_assembly_v22"/>
-       <triangular vertex1="motherboard6_assembly_v22" vertex2="motherboard6_assembly_v50" vertex3="motherboard6_assembly_v51"/>
-       <triangular vertex1="motherboard6_assembly_v22" vertex2="motherboard6_assembly_v51" vertex3="motherboard6_assembly_v20"/>
-       <triangular vertex1="motherboard6_assembly_v20" vertex2="motherboard6_assembly_v51" vertex3="motherboard6_assembly_v52"/>
-       <triangular vertex1="motherboard6_assembly_v20" vertex2="motherboard6_assembly_v52" vertex3="motherboard6_assembly_v12"/>
-       <triangular vertex1="motherboard6_assembly_v52" vertex2="motherboard6_assembly_v53" vertex3="motherboard6_assembly_v12"/>
-       <triangular vertex1="motherboard6_assembly_v12" vertex2="motherboard6_assembly_v53" vertex3="motherboard6_assembly_v54"/>
-       <triangular vertex1="motherboard6_assembly_v12" vertex2="motherboard6_assembly_v54" vertex3="motherboard6_assembly_v10"/>
-       <triangular vertex1="motherboard6_assembly_v10" vertex2="motherboard6_assembly_v54" vertex3="motherboard6_assembly_v55"/>
-       <triangular vertex1="motherboard6_assembly_v10" vertex2="motherboard6_assembly_v55" vertex3="motherboard6_assembly_v8"/>
-       <triangular vertex1="motherboard6_assembly_v8" vertex2="motherboard6_assembly_v55" vertex3="motherboard6_assembly_v56"/>
-       <triangular vertex1="motherboard6_assembly_v8" vertex2="motherboard6_assembly_v56" vertex3="motherboard6_assembly_v57"/>
-       <triangular vertex1="motherboard6_assembly_v58" vertex2="motherboard6_assembly_v59" vertex3="motherboard6_assembly_v30"/>
-       <triangular vertex1="motherboard6_assembly_v6" vertex2="motherboard6_assembly_v60" vertex3="motherboard6_assembly_v4"/>
-       <triangular vertex1="motherboard6_assembly_v4" vertex2="motherboard6_assembly_v60" vertex3="motherboard6_assembly_v61"/>
-       <triangular vertex1="motherboard6_assembly_v4" vertex2="motherboard6_assembly_v61" vertex3="motherboard6_assembly_v62"/>
-       <triangular vertex1="motherboard6_assembly_v62" vertex2="motherboard6_assembly_v63" vertex3="motherboard6_assembly_v4"/>
-       <triangular vertex1="motherboard6_assembly_v4" vertex2="motherboard6_assembly_v63" vertex3="motherboard6_assembly_v64"/>
-       <triangular vertex1="motherboard6_assembly_v4" vertex2="motherboard6_assembly_v64" vertex3="motherboard6_assembly_v49"/>
-       <triangular vertex1="motherboard6_assembly_v49" vertex2="motherboard6_assembly_v65" vertex3="motherboard6_assembly_v0"/>
-       <triangular vertex1="motherboard6_assembly_v0" vertex2="motherboard6_assembly_v65" vertex3="motherboard6_assembly_v66"/>
-       <triangular vertex1="motherboard6_assembly_v0" vertex2="motherboard6_assembly_v66" vertex3="motherboard6_assembly_v1"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v66" vertex3="motherboard6_assembly_v67"/>
-       <triangular vertex1="motherboard6_assembly_v1" vertex2="motherboard6_assembly_v67" vertex3="motherboard6_assembly_v38"/>
-       <triangular vertex1="motherboard6_assembly_v59" vertex2="motherboard6_assembly_v68" vertex3="motherboard6_assembly_v30"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v68" vertex3="motherboard6_assembly_v69"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v69" vertex3="motherboard6_assembly_v41"/>
-       <triangular vertex1="motherboard6_assembly_v32" vertex2="motherboard6_assembly_v34" vertex3="motherboard6_assembly_v36"/>
-       <triangular vertex1="motherboard6_assembly_v57" vertex2="motherboard6_assembly_v70" vertex3="motherboard6_assembly_v8"/>
-       <triangular vertex1="motherboard6_assembly_v8" vertex2="motherboard6_assembly_v70" vertex3="motherboard6_assembly_v71"/>
-       <triangular vertex1="motherboard6_assembly_v8" vertex2="motherboard6_assembly_v71" vertex3="motherboard6_assembly_v6"/>
-       <triangular vertex1="motherboard6_assembly_v6" vertex2="motherboard6_assembly_v71" vertex3="motherboard6_assembly_v72"/>
-       <triangular vertex1="motherboard6_assembly_v6" vertex2="motherboard6_assembly_v72" vertex3="motherboard6_assembly_v60"/>
-       <triangular vertex1="motherboard6_assembly_v36" vertex2="motherboard6_assembly_v1" vertex3="motherboard6_assembly_v32"/>
-       <triangular vertex1="motherboard6_assembly_v32" vertex2="motherboard6_assembly_v1" vertex3="motherboard6_assembly_v48"/>
-       <triangular vertex1="motherboard6_assembly_v32" vertex2="motherboard6_assembly_v48" vertex3="motherboard6_assembly_v30"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v48" vertex3="motherboard6_assembly_v73"/>
-       <triangular vertex1="motherboard6_assembly_v30" vertex2="motherboard6_assembly_v73" vertex3="motherboard6_assembly_v58"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v37" vertex3="motherboard6_assembly_v35"/>
-       <triangular vertex1="motherboard6_assembly_v17" vertex2="motherboard6_assembly_v15" vertex3="motherboard6_assembly_v13"/>
-       <triangular vertex1="motherboard6_assembly_v27" vertex2="motherboard6_assembly_v25" vertex3="motherboard6_assembly_v29"/>
-       <triangular vertex1="motherboard6_assembly_v29" vertex2="motherboard6_assembly_v25" vertex3="motherboard6_assembly_v23"/>
-       <triangular vertex1="motherboard6_assembly_v29" vertex2="motherboard6_assembly_v23" vertex3="motherboard6_assembly_v31"/>
-       <triangular vertex1="motherboard6_assembly_v17" vertex2="motherboard6_assembly_v13" vertex3="motherboard6_assembly_v19"/>
-       <triangular vertex1="motherboard6_assembly_v33" vertex2="motherboard6_assembly_v31" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v31" vertex3="motherboard6_assembly_v23"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v23" vertex3="motherboard6_assembly_v13"/>
-       <triangular vertex1="motherboard6_assembly_v13" vertex2="motherboard6_assembly_v23" vertex3="motherboard6_assembly_v21"/>
-       <triangular vertex1="motherboard6_assembly_v13" vertex2="motherboard6_assembly_v21" vertex3="motherboard6_assembly_v19"/>
-       <triangular vertex1="motherboard6_assembly_v74" vertex2="motherboard6_assembly_v75" vertex3="motherboard6_assembly_v9"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v75" vertex3="motherboard6_assembly_v76"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v76" vertex3="motherboard6_assembly_v77"/>
-       <triangular vertex1="motherboard6_assembly_v78" vertex2="motherboard6_assembly_v79" vertex3="motherboard6_assembly_v2"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v79" vertex3="motherboard6_assembly_v80"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v80" vertex3="motherboard6_assembly_v81"/>
-       <triangular vertex1="motherboard6_assembly_v74" vertex2="motherboard6_assembly_v9" vertex3="motherboard6_assembly_v82"/>
-       <triangular vertex1="motherboard6_assembly_v82" vertex2="motherboard6_assembly_v9" vertex3="motherboard6_assembly_v7"/>
-       <triangular vertex1="motherboard6_assembly_v82" vertex2="motherboard6_assembly_v7" vertex3="motherboard6_assembly_v5"/>
-       <triangular vertex1="motherboard6_assembly_v77" vertex2="motherboard6_assembly_v83" vertex3="motherboard6_assembly_v9"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v83" vertex3="motherboard6_assembly_v84"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v84" vertex3="motherboard6_assembly_v85"/>
-       <triangular vertex1="motherboard6_assembly_v86" vertex2="motherboard6_assembly_v87" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v87" vertex3="motherboard6_assembly_v88"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v88" vertex3="motherboard6_assembly_v89"/>
-       <triangular vertex1="motherboard6_assembly_v35" vertex2="motherboard6_assembly_v33" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v33" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v11" vertex3="motherboard6_assembly_v90"/>
-       <triangular vertex1="motherboard6_assembly_v90" vertex2="motherboard6_assembly_v11" vertex3="motherboard6_assembly_v91"/>
-       <triangular vertex1="motherboard6_assembly_v89" vertex2="motherboard6_assembly_v92" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v92" vertex3="motherboard6_assembly_v93"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v93" vertex3="motherboard6_assembly_v91"/>
-       <triangular vertex1="motherboard6_assembly_v81" vertex2="motherboard6_assembly_v94" vertex3="motherboard6_assembly_v2"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v94" vertex3="motherboard6_assembly_v95"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v95" vertex3="motherboard6_assembly_v5"/>
-       <triangular vertex1="motherboard6_assembly_v5" vertex2="motherboard6_assembly_v95" vertex3="motherboard6_assembly_v96"/>
-       <triangular vertex1="motherboard6_assembly_v5" vertex2="motherboard6_assembly_v96" vertex3="motherboard6_assembly_v82"/>
-       <triangular vertex1="motherboard6_assembly_v85" vertex2="motherboard6_assembly_v97" vertex3="motherboard6_assembly_v9"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v97" vertex3="motherboard6_assembly_v98"/>
-       <triangular vertex1="motherboard6_assembly_v9" vertex2="motherboard6_assembly_v98" vertex3="motherboard6_assembly_v11"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v98" vertex3="motherboard6_assembly_v99"/>
-       <triangular vertex1="motherboard6_assembly_v11" vertex2="motherboard6_assembly_v99" vertex3="motherboard6_assembly_v86"/>
-       <triangular vertex1="motherboard6_assembly_v90" vertex2="motherboard6_assembly_v100" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v100" vertex3="motherboard6_assembly_v101"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v101" vertex3="motherboard6_assembly_v102"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v103" vertex3="motherboard6_assembly_v104"/>
-       <triangular vertex1="motherboard6_assembly_v104" vertex2="motherboard6_assembly_v105" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v105" vertex3="motherboard6_assembly_v106"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v106" vertex3="motherboard6_assembly_v2"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v106" vertex3="motherboard6_assembly_v107"/>
-       <triangular vertex1="motherboard6_assembly_v2" vertex2="motherboard6_assembly_v107" vertex3="motherboard6_assembly_v78"/>
-       <triangular vertex1="motherboard6_assembly_v102" vertex2="motherboard6_assembly_v108" vertex3="motherboard6_assembly_v3"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v108" vertex3="motherboard6_assembly_v109"/>
-       <triangular vertex1="motherboard6_assembly_v3" vertex2="motherboard6_assembly_v109" vertex3="motherboard6_assembly_v103"/>
-       <triangular vertex1="motherboard6_assembly_v99" vertex2="motherboard6_assembly_v55" vertex3="motherboard6_assembly_v86"/>
-       <triangular vertex1="motherboard6_assembly_v86" vertex2="motherboard6_assembly_v55" vertex3="motherboard6_assembly_v54"/>
-       <triangular vertex1="motherboard6_assembly_v86" vertex2="motherboard6_assembly_v54" vertex3="motherboard6_assembly_v87"/>
-       <triangular vertex1="motherboard6_assembly_v87" vertex2="motherboard6_assembly_v54" vertex3="motherboard6_assembly_v53"/>
-       <triangular vertex1="motherboard6_assembly_v87" vertex2="motherboard6_assembly_v53" vertex3="motherboard6_assembly_v88"/>
-       <triangular vertex1="motherboard6_assembly_v88" vertex2="motherboard6_assembly_v53" vertex3="motherboard6_assembly_v52"/>
-       <triangular vertex1="motherboard6_assembly_v88" vertex2="motherboard6_assembly_v52" vertex3="motherboard6_assembly_v89"/>
-       <triangular vertex1="motherboard6_assembly_v89" vertex2="motherboard6_assembly_v52" vertex3="motherboard6_assembly_v51"/>
-       <triangular vertex1="motherboard6_assembly_v89" vertex2="motherboard6_assembly_v51" vertex3="motherboard6_assembly_v92"/>
-       <triangular vertex1="motherboard6_assembly_v92" vertex2="motherboard6_assembly_v51" vertex3="motherboard6_assembly_v50"/>
-       <triangular vertex1="motherboard6_assembly_v92" vertex2="motherboard6_assembly_v50" vertex3="motherboard6_assembly_v93"/>
-       <triangular vertex1="motherboard6_assembly_v93" vertex2="motherboard6_assembly_v50" vertex3="motherboard6_assembly_v43"/>
-       <triangular vertex1="motherboard6_assembly_v93" vertex2="motherboard6_assembly_v43" vertex3="motherboard6_assembly_v91"/>
-       <triangular vertex1="motherboard6_assembly_v91" vertex2="motherboard6_assembly_v43" vertex3="motherboard6_assembly_v44"/>
-       <triangular vertex1="motherboard6_assembly_v91" vertex2="motherboard6_assembly_v44" vertex3="motherboard6_assembly_v90"/>
-       <triangular vertex1="motherboard6_assembly_v90" vertex2="motherboard6_assembly_v44" vertex3="motherboard6_assembly_v45"/>
-       <triangular vertex1="motherboard6_assembly_v90" vertex2="motherboard6_assembly_v45" vertex3="motherboard6_assembly_v100"/>
-       <triangular vertex1="motherboard6_assembly_v100" vertex2="motherboard6_assembly_v45" vertex3="motherboard6_assembly_v42"/>
-       <triangular vertex1="motherboard6_assembly_v100" vertex2="motherboard6_assembly_v42" vertex3="motherboard6_assembly_v101"/>
-       <triangular vertex1="motherboard6_assembly_v101" vertex2="motherboard6_assembly_v42" vertex3="motherboard6_assembly_v41"/>
-       <triangular vertex1="motherboard6_assembly_v101" vertex2="motherboard6_assembly_v41" vertex3="motherboard6_assembly_v102"/>
-       <triangular vertex1="motherboard6_assembly_v102" vertex2="motherboard6_assembly_v41" vertex3="motherboard6_assembly_v69"/>
-       <triangular vertex1="motherboard6_assembly_v102" vertex2="motherboard6_assembly_v69" vertex3="motherboard6_assembly_v108"/>
-       <triangular vertex1="motherboard6_assembly_v108" vertex2="motherboard6_assembly_v69" vertex3="motherboard6_assembly_v68"/>
-       <triangular vertex1="motherboard6_assembly_v108" vertex2="motherboard6_assembly_v68" vertex3="motherboard6_assembly_v109"/>
-       <triangular vertex1="motherboard6_assembly_v109" vertex2="motherboard6_assembly_v68" vertex3="motherboard6_assembly_v59"/>
-       <triangular vertex1="motherboard6_assembly_v109" vertex2="motherboard6_assembly_v59" vertex3="motherboard6_assembly_v103"/>
-       <triangular vertex1="motherboard6_assembly_v103" vertex2="motherboard6_assembly_v59" vertex3="motherboard6_assembly_v58"/>
-       <triangular vertex1="motherboard6_assembly_v103" vertex2="motherboard6_assembly_v58" vertex3="motherboard6_assembly_v104"/>
-       <triangular vertex1="motherboard6_assembly_v104" vertex2="motherboard6_assembly_v58" vertex3="motherboard6_assembly_v73"/>
-       <triangular vertex1="motherboard6_assembly_v104" vertex2="motherboard6_assembly_v73" vertex3="motherboard6_assembly_v105"/>
-       <triangular vertex1="motherboard6_assembly_v105" vertex2="motherboard6_assembly_v73" vertex3="motherboard6_assembly_v48"/>
-       <triangular vertex1="motherboard6_assembly_v105" vertex2="motherboard6_assembly_v48" vertex3="motherboard6_assembly_v106"/>
-       <triangular vertex1="motherboard6_assembly_v106" vertex2="motherboard6_assembly_v48" vertex3="motherboard6_assembly_v47"/>
-       <triangular vertex1="motherboard6_assembly_v106" vertex2="motherboard6_assembly_v47" vertex3="motherboard6_assembly_v107"/>
-       <triangular vertex1="motherboard6_assembly_v107" vertex2="motherboard6_assembly_v47" vertex3="motherboard6_assembly_v46"/>
-       <triangular vertex1="motherboard6_assembly_v107" vertex2="motherboard6_assembly_v46" vertex3="motherboard6_assembly_v78"/>
-       <triangular vertex1="motherboard6_assembly_v78" vertex2="motherboard6_assembly_v46" vertex3="motherboard6_assembly_v40"/>
-       <triangular vertex1="motherboard6_assembly_v78" vertex2="motherboard6_assembly_v40" vertex3="motherboard6_assembly_v79"/>
-       <triangular vertex1="motherboard6_assembly_v79" vertex2="motherboard6_assembly_v40" vertex3="motherboard6_assembly_v39"/>
-       <triangular vertex1="motherboard6_assembly_v79" vertex2="motherboard6_assembly_v39" vertex3="motherboard6_assembly_v80"/>
-       <triangular vertex1="motherboard6_assembly_v80" vertex2="motherboard6_assembly_v39" vertex3="motherboard6_assembly_v38"/>
-       <triangular vertex1="motherboard6_assembly_v80" vertex2="motherboard6_assembly_v38" vertex3="motherboard6_assembly_v81"/>
-       <triangular vertex1="motherboard6_assembly_v81" vertex2="motherboard6_assembly_v38" vertex3="motherboard6_assembly_v67"/>
-       <triangular vertex1="motherboard6_assembly_v81" vertex2="motherboard6_assembly_v67" vertex3="motherboard6_assembly_v94"/>
-       <triangular vertex1="motherboard6_assembly_v94" vertex2="motherboard6_assembly_v67" vertex3="motherboard6_assembly_v66"/>
-       <triangular vertex1="motherboard6_assembly_v94" vertex2="motherboard6_assembly_v66" vertex3="motherboard6_assembly_v95"/>
-       <triangular vertex1="motherboard6_assembly_v95" vertex2="motherboard6_assembly_v66" vertex3="motherboard6_assembly_v65"/>
-       <triangular vertex1="motherboard6_assembly_v95" vertex2="motherboard6_assembly_v65" vertex3="motherboard6_assembly_v96"/>
-       <triangular vertex1="motherboard6_assembly_v96" vertex2="motherboard6_assembly_v65" vertex3="motherboard6_assembly_v49"/>
-       <triangular vertex1="motherboard6_assembly_v96" vertex2="motherboard6_assembly_v49" vertex3="motherboard6_assembly_v82"/>
-       <triangular vertex1="motherboard6_assembly_v82" vertex2="motherboard6_assembly_v49" vertex3="motherboard6_assembly_v64"/>
-       <triangular vertex1="motherboard6_assembly_v82" vertex2="motherboard6_assembly_v64" vertex3="motherboard6_assembly_v74"/>
-       <triangular vertex1="motherboard6_assembly_v74" vertex2="motherboard6_assembly_v64" vertex3="motherboard6_assembly_v63"/>
-       <triangular vertex1="motherboard6_assembly_v74" vertex2="motherboard6_assembly_v63" vertex3="motherboard6_assembly_v75"/>
-       <triangular vertex1="motherboard6_assembly_v75" vertex2="motherboard6_assembly_v63" vertex3="motherboard6_assembly_v62"/>
-       <triangular vertex1="motherboard6_assembly_v75" vertex2="motherboard6_assembly_v62" vertex3="motherboard6_assembly_v76"/>
-       <triangular vertex1="motherboard6_assembly_v76" vertex2="motherboard6_assembly_v62" vertex3="motherboard6_assembly_v61"/>
-       <triangular vertex1="motherboard6_assembly_v76" vertex2="motherboard6_assembly_v61" vertex3="motherboard6_assembly_v77"/>
-       <triangular vertex1="motherboard6_assembly_v77" vertex2="motherboard6_assembly_v61" vertex3="motherboard6_assembly_v60"/>
-       <triangular vertex1="motherboard6_assembly_v77" vertex2="motherboard6_assembly_v60" vertex3="motherboard6_assembly_v83"/>
-       <triangular vertex1="motherboard6_assembly_v83" vertex2="motherboard6_assembly_v60" vertex3="motherboard6_assembly_v72"/>
-       <triangular vertex1="motherboard6_assembly_v83" vertex2="motherboard6_assembly_v72" vertex3="motherboard6_assembly_v84"/>
-       <triangular vertex1="motherboard6_assembly_v84" vertex2="motherboard6_assembly_v72" vertex3="motherboard6_assembly_v71"/>
-       <triangular vertex1="motherboard6_assembly_v84" vertex2="motherboard6_assembly_v71" vertex3="motherboard6_assembly_v85"/>
-       <triangular vertex1="motherboard6_assembly_v85" vertex2="motherboard6_assembly_v71" vertex3="motherboard6_assembly_v70"/>
-       <triangular vertex1="motherboard6_assembly_v85" vertex2="motherboard6_assembly_v70" vertex3="motherboard6_assembly_v97"/>
-       <triangular vertex1="motherboard6_assembly_v97" vertex2="motherboard6_assembly_v70" vertex3="motherboard6_assembly_v57"/>
-       <triangular vertex1="motherboard6_assembly_v97" vertex2="motherboard6_assembly_v57" vertex3="motherboard6_assembly_v98"/>
-       <triangular vertex1="motherboard6_assembly_v98" vertex2="motherboard6_assembly_v57" vertex3="motherboard6_assembly_v56"/>
-       <triangular vertex1="motherboard6_assembly_v98" vertex2="motherboard6_assembly_v56" vertex3="motherboard6_assembly_v99"/>
-       <triangular vertex1="motherboard6_assembly_v99" vertex2="motherboard6_assembly_v56" vertex3="motherboard6_assembly_v55"/>
-       <triangular vertex1="motherboard6_assembly_v110" vertex2="motherboard6_assembly_v111" vertex3="motherboard6_assembly_v112"/>
-       <triangular vertex1="motherboard6_assembly_v112" vertex2="motherboard6_assembly_v111" vertex3="motherboard6_assembly_v113"/>
-       <triangular vertex1="motherboard6_assembly_v114" vertex2="motherboard6_assembly_v110" vertex3="motherboard6_assembly_v115"/>
-       <triangular vertex1="motherboard6_assembly_v115" vertex2="motherboard6_assembly_v110" vertex3="motherboard6_assembly_v112"/>
-       <triangular vertex1="motherboard6_assembly_v116" vertex2="motherboard6_assembly_v114" vertex3="motherboard6_assembly_v117"/>
-       <triangular vertex1="motherboard6_assembly_v117" vertex2="motherboard6_assembly_v114" vertex3="motherboard6_assembly_v115"/>
-       <triangular vertex1="motherboard6_assembly_v111" vertex2="motherboard6_assembly_v116" vertex3="motherboard6_assembly_v113"/>
-       <triangular vertex1="motherboard6_assembly_v113" vertex2="motherboard6_assembly_v116" vertex3="motherboard6_assembly_v117"/>
-       <triangular vertex1="motherboard6_assembly_v114" vertex2="motherboard6_assembly_v116" vertex3="motherboard6_assembly_v110"/>
-       <triangular vertex1="motherboard6_assembly_v110" vertex2="motherboard6_assembly_v116" vertex3="motherboard6_assembly_v111"/>
-       <triangular vertex1="motherboard6_assembly_v117" vertex2="motherboard6_assembly_v115" vertex3="motherboard6_assembly_v113"/>
-       <triangular vertex1="motherboard6_assembly_v113" vertex2="motherboard6_assembly_v115" vertex3="motherboard6_assembly_v112"/>
-       <triangular vertex1="motherboard6_assembly_v118" vertex2="motherboard6_assembly_v119" vertex3="motherboard6_assembly_v120"/>
-       <triangular vertex1="motherboard6_assembly_v120" vertex2="motherboard6_assembly_v119" vertex3="motherboard6_assembly_v121"/>
-       <triangular vertex1="motherboard6_assembly_v122" vertex2="motherboard6_assembly_v118" vertex3="motherboard6_assembly_v123"/>
-       <triangular vertex1="motherboard6_assembly_v123" vertex2="motherboard6_assembly_v118" vertex3="motherboard6_assembly_v120"/>
-       <triangular vertex1="motherboard6_assembly_v124" vertex2="motherboard6_assembly_v122" vertex3="motherboard6_assembly_v125"/>
-       <triangular vertex1="motherboard6_assembly_v125" vertex2="motherboard6_assembly_v122" vertex3="motherboard6_assembly_v123"/>
-       <triangular vertex1="motherboard6_assembly_v119" vertex2="motherboard6_assembly_v124" vertex3="motherboard6_assembly_v121"/>
-       <triangular vertex1="motherboard6_assembly_v121" vertex2="motherboard6_assembly_v124" vertex3="motherboard6_assembly_v125"/>
-       <triangular vertex1="motherboard6_assembly_v122" vertex2="motherboard6_assembly_v124" vertex3="motherboard6_assembly_v118"/>
-       <triangular vertex1="motherboard6_assembly_v118" vertex2="motherboard6_assembly_v124" vertex3="motherboard6_assembly_v119"/>
-       <triangular vertex1="motherboard6_assembly_v125" vertex2="motherboard6_assembly_v123" vertex3="motherboard6_assembly_v121"/>
-       <triangular vertex1="motherboard6_assembly_v121" vertex2="motherboard6_assembly_v123" vertex3="motherboard6_assembly_v120"/>
-       <triangular vertex1="motherboard6_assembly_v126" vertex2="motherboard6_assembly_v127" vertex3="motherboard6_assembly_v128"/>
-       <triangular vertex1="motherboard6_assembly_v128" vertex2="motherboard6_assembly_v127" vertex3="motherboard6_assembly_v129"/>
-       <triangular vertex1="motherboard6_assembly_v130" vertex2="motherboard6_assembly_v126" vertex3="motherboard6_assembly_v131"/>
-       <triangular vertex1="motherboard6_assembly_v131" vertex2="motherboard6_assembly_v126" vertex3="motherboard6_assembly_v128"/>
-       <triangular vertex1="motherboard6_assembly_v132" vertex2="motherboard6_assembly_v130" vertex3="motherboard6_assembly_v133"/>
-       <triangular vertex1="motherboard6_assembly_v133" vertex2="motherboard6_assembly_v130" vertex3="motherboard6_assembly_v131"/>
-       <triangular vertex1="motherboard6_assembly_v127" vertex2="motherboard6_assembly_v132" vertex3="motherboard6_assembly_v129"/>
-       <triangular vertex1="motherboard6_assembly_v129" vertex2="motherboard6_assembly_v132" vertex3="motherboard6_assembly_v133"/>
-       <triangular vertex1="motherboard6_assembly_v130" vertex2="motherboard6_assembly_v132" vertex3="motherboard6_assembly_v126"/>
-       <triangular vertex1="motherboard6_assembly_v126" vertex2="motherboard6_assembly_v132" vertex3="motherboard6_assembly_v127"/>
-       <triangular vertex1="motherboard6_assembly_v133" vertex2="motherboard6_assembly_v131" vertex3="motherboard6_assembly_v129"/>
-       <triangular vertex1="motherboard6_assembly_v129" vertex2="motherboard6_assembly_v131" vertex3="motherboard6_assembly_v128"/>
-       <triangular vertex1="motherboard6_assembly_v134" vertex2="motherboard6_assembly_v135" vertex3="motherboard6_assembly_v136"/>
-       <triangular vertex1="motherboard6_assembly_v136" vertex2="motherboard6_assembly_v135" vertex3="motherboard6_assembly_v137"/>
-       <triangular vertex1="motherboard6_assembly_v138" vertex2="motherboard6_assembly_v134" vertex3="motherboard6_assembly_v139"/>
-       <triangular vertex1="motherboard6_assembly_v139" vertex2="motherboard6_assembly_v134" vertex3="motherboard6_assembly_v136"/>
-       <triangular vertex1="motherboard6_assembly_v140" vertex2="motherboard6_assembly_v138" vertex3="motherboard6_assembly_v141"/>
-       <triangular vertex1="motherboard6_assembly_v141" vertex2="motherboard6_assembly_v138" vertex3="motherboard6_assembly_v139"/>
-       <triangular vertex1="motherboard6_assembly_v135" vertex2="motherboard6_assembly_v140" vertex3="motherboard6_assembly_v137"/>
-       <triangular vertex1="motherboard6_assembly_v137" vertex2="motherboard6_assembly_v140" vertex3="motherboard6_assembly_v141"/>
-       <triangular vertex1="motherboard6_assembly_v138" vertex2="motherboard6_assembly_v140" vertex3="motherboard6_assembly_v134"/>
-       <triangular vertex1="motherboard6_assembly_v134" vertex2="motherboard6_assembly_v140" vertex3="motherboard6_assembly_v135"/>
-       <triangular vertex1="motherboard6_assembly_v141" vertex2="motherboard6_assembly_v139" vertex3="motherboard6_assembly_v137"/>
-       <triangular vertex1="motherboard6_assembly_v137" vertex2="motherboard6_assembly_v139" vertex3="motherboard6_assembly_v136"/>
-       <triangular vertex1="motherboard6_assembly_v142" vertex2="motherboard6_assembly_v143" vertex3="motherboard6_assembly_v144"/>
-       <triangular vertex1="motherboard6_assembly_v144" vertex2="motherboard6_assembly_v143" vertex3="motherboard6_assembly_v145"/>
-       <triangular vertex1="motherboard6_assembly_v146" vertex2="motherboard6_assembly_v142" vertex3="motherboard6_assembly_v147"/>
-       <triangular vertex1="motherboard6_assembly_v147" vertex2="motherboard6_assembly_v142" vertex3="motherboard6_assembly_v144"/>
-       <triangular vertex1="motherboard6_assembly_v148" vertex2="motherboard6_assembly_v146" vertex3="motherboard6_assembly_v149"/>
-       <triangular vertex1="motherboard6_assembly_v149" vertex2="motherboard6_assembly_v146" vertex3="motherboard6_assembly_v147"/>
-       <triangular vertex1="motherboard6_assembly_v143" vertex2="motherboard6_assembly_v148" vertex3="motherboard6_assembly_v145"/>
-       <triangular vertex1="motherboard6_assembly_v145" vertex2="motherboard6_assembly_v148" vertex3="motherboard6_assembly_v149"/>
-       <triangular vertex1="motherboard6_assembly_v146" vertex2="motherboard6_assembly_v148" vertex3="motherboard6_assembly_v142"/>
-       <triangular vertex1="motherboard6_assembly_v142" vertex2="motherboard6_assembly_v148" vertex3="motherboard6_assembly_v143"/>
-       <triangular vertex1="motherboard6_assembly_v149" vertex2="motherboard6_assembly_v147" vertex3="motherboard6_assembly_v145"/>
-       <triangular vertex1="motherboard6_assembly_v145" vertex2="motherboard6_assembly_v147" vertex3="motherboard6_assembly_v144"/>
-       <triangular vertex1="motherboard6_assembly_v150" vertex2="motherboard6_assembly_v151" vertex3="motherboard6_assembly_v152"/>
-       <triangular vertex1="motherboard6_assembly_v152" vertex2="motherboard6_assembly_v151" vertex3="motherboard6_assembly_v153"/>
-       <triangular vertex1="motherboard6_assembly_v154" vertex2="motherboard6_assembly_v150" vertex3="motherboard6_assembly_v155"/>
-       <triangular vertex1="motherboard6_assembly_v155" vertex2="motherboard6_assembly_v150" vertex3="motherboard6_assembly_v152"/>
-       <triangular vertex1="motherboard6_assembly_v156" vertex2="motherboard6_assembly_v154" vertex3="motherboard6_assembly_v157"/>
-       <triangular vertex1="motherboard6_assembly_v157" vertex2="motherboard6_assembly_v154" vertex3="motherboard6_assembly_v155"/>
-       <triangular vertex1="motherboard6_assembly_v151" vertex2="motherboard6_assembly_v156" vertex3="motherboard6_assembly_v153"/>
-       <triangular vertex1="motherboard6_assembly_v153" vertex2="motherboard6_assembly_v156" vertex3="motherboard6_assembly_v157"/>
-       <triangular vertex1="motherboard6_assembly_v154" vertex2="motherboard6_assembly_v156" vertex3="motherboard6_assembly_v150"/>
-       <triangular vertex1="motherboard6_assembly_v150" vertex2="motherboard6_assembly_v156" vertex3="motherboard6_assembly_v151"/>
-       <triangular vertex1="motherboard6_assembly_v157" vertex2="motherboard6_assembly_v155" vertex3="motherboard6_assembly_v153"/>
-       <triangular vertex1="motherboard6_assembly_v153" vertex2="motherboard6_assembly_v155" vertex3="motherboard6_assembly_v152"/>
-       <triangular vertex1="motherboard6_assembly_v158" vertex2="motherboard6_assembly_v159" vertex3="motherboard6_assembly_v160"/>
-       <triangular vertex1="motherboard6_assembly_v160" vertex2="motherboard6_assembly_v159" vertex3="motherboard6_assembly_v161"/>
-       <triangular vertex1="motherboard6_assembly_v162" vertex2="motherboard6_assembly_v158" vertex3="motherboard6_assembly_v163"/>
-       <triangular vertex1="motherboard6_assembly_v163" vertex2="motherboard6_assembly_v158" vertex3="motherboard6_assembly_v160"/>
-       <triangular vertex1="motherboard6_assembly_v164" vertex2="motherboard6_assembly_v162" vertex3="motherboard6_assembly_v165"/>
-       <triangular vertex1="motherboard6_assembly_v165" vertex2="motherboard6_assembly_v162" vertex3="motherboard6_assembly_v163"/>
-       <triangular vertex1="motherboard6_assembly_v159" vertex2="motherboard6_assembly_v164" vertex3="motherboard6_assembly_v161"/>
-       <triangular vertex1="motherboard6_assembly_v161" vertex2="motherboard6_assembly_v164" vertex3="motherboard6_assembly_v165"/>
-       <triangular vertex1="motherboard6_assembly_v162" vertex2="motherboard6_assembly_v164" vertex3="motherboard6_assembly_v158"/>
-       <triangular vertex1="motherboard6_assembly_v158" vertex2="motherboard6_assembly_v164" vertex3="motherboard6_assembly_v159"/>
-       <triangular vertex1="motherboard6_assembly_v165" vertex2="motherboard6_assembly_v163" vertex3="motherboard6_assembly_v161"/>
-       <triangular vertex1="motherboard6_assembly_v161" vertex2="motherboard6_assembly_v163" vertex3="motherboard6_assembly_v160"/>
-       <triangular vertex1="motherboard6_assembly_v166" vertex2="motherboard6_assembly_v167" vertex3="motherboard6_assembly_v168"/>
-       <triangular vertex1="motherboard6_assembly_v168" vertex2="motherboard6_assembly_v167" vertex3="motherboard6_assembly_v169"/>
-       <triangular vertex1="motherboard6_assembly_v170" vertex2="motherboard6_assembly_v166" vertex3="motherboard6_assembly_v171"/>
-       <triangular vertex1="motherboard6_assembly_v171" vertex2="motherboard6_assembly_v166" vertex3="motherboard6_assembly_v168"/>
-       <triangular vertex1="motherboard6_assembly_v172" vertex2="motherboard6_assembly_v170" vertex3="motherboard6_assembly_v173"/>
-       <triangular vertex1="motherboard6_assembly_v173" vertex2="motherboard6_assembly_v170" vertex3="motherboard6_assembly_v171"/>
-       <triangular vertex1="motherboard6_assembly_v167" vertex2="motherboard6_assembly_v172" vertex3="motherboard6_assembly_v169"/>
-       <triangular vertex1="motherboard6_assembly_v169" vertex2="motherboard6_assembly_v172" vertex3="motherboard6_assembly_v173"/>
-       <triangular vertex1="motherboard6_assembly_v170" vertex2="motherboard6_assembly_v172" vertex3="motherboard6_assembly_v166"/>
-       <triangular vertex1="motherboard6_assembly_v166" vertex2="motherboard6_assembly_v172" vertex3="motherboard6_assembly_v167"/>
-       <triangular vertex1="motherboard6_assembly_v173" vertex2="motherboard6_assembly_v171" vertex3="motherboard6_assembly_v169"/>
-       <triangular vertex1="motherboard6_assembly_v169" vertex2="motherboard6_assembly_v171" vertex3="motherboard6_assembly_v168"/>
-       <triangular vertex1="motherboard6_assembly_v174" vertex2="motherboard6_assembly_v175" vertex3="motherboard6_assembly_v176"/>
-       <triangular vertex1="motherboard6_assembly_v176" vertex2="motherboard6_assembly_v175" vertex3="motherboard6_assembly_v177"/>
-       <triangular vertex1="motherboard6_assembly_v178" vertex2="motherboard6_assembly_v174" vertex3="motherboard6_assembly_v179"/>
-       <triangular vertex1="motherboard6_assembly_v179" vertex2="motherboard6_assembly_v174" vertex3="motherboard6_assembly_v176"/>
-       <triangular vertex1="motherboard6_assembly_v180" vertex2="motherboard6_assembly_v178" vertex3="motherboard6_assembly_v181"/>
-       <triangular vertex1="motherboard6_assembly_v181" vertex2="motherboard6_assembly_v178" vertex3="motherboard6_assembly_v179"/>
-       <triangular vertex1="motherboard6_assembly_v175" vertex2="motherboard6_assembly_v180" vertex3="motherboard6_assembly_v177"/>
-       <triangular vertex1="motherboard6_assembly_v177" vertex2="motherboard6_assembly_v180" vertex3="motherboard6_assembly_v181"/>
-       <triangular vertex1="motherboard6_assembly_v178" vertex2="motherboard6_assembly_v180" vertex3="motherboard6_assembly_v174"/>
-       <triangular vertex1="motherboard6_assembly_v174" vertex2="motherboard6_assembly_v180" vertex3="motherboard6_assembly_v175"/>
-       <triangular vertex1="motherboard6_assembly_v181" vertex2="motherboard6_assembly_v179" vertex3="motherboard6_assembly_v177"/>
-       <triangular vertex1="motherboard6_assembly_v177" vertex2="motherboard6_assembly_v179" vertex3="motherboard6_assembly_v176"/>
-       <triangular vertex1="motherboard6_assembly_v182" vertex2="motherboard6_assembly_v183" vertex3="motherboard6_assembly_v184"/>
-       <triangular vertex1="motherboard6_assembly_v184" vertex2="motherboard6_assembly_v183" vertex3="motherboard6_assembly_v185"/>
-       <triangular vertex1="motherboard6_assembly_v186" vertex2="motherboard6_assembly_v182" vertex3="motherboard6_assembly_v187"/>
-       <triangular vertex1="motherboard6_assembly_v187" vertex2="motherboard6_assembly_v182" vertex3="motherboard6_assembly_v184"/>
-       <triangular vertex1="motherboard6_assembly_v188" vertex2="motherboard6_assembly_v186" vertex3="motherboard6_assembly_v189"/>
-       <triangular vertex1="motherboard6_assembly_v189" vertex2="motherboard6_assembly_v186" vertex3="motherboard6_assembly_v187"/>
-       <triangular vertex1="motherboard6_assembly_v183" vertex2="motherboard6_assembly_v188" vertex3="motherboard6_assembly_v185"/>
-       <triangular vertex1="motherboard6_assembly_v185" vertex2="motherboard6_assembly_v188" vertex3="motherboard6_assembly_v189"/>
-       <triangular vertex1="motherboard6_assembly_v186" vertex2="motherboard6_assembly_v188" vertex3="motherboard6_assembly_v182"/>
-       <triangular vertex1="motherboard6_assembly_v182" vertex2="motherboard6_assembly_v188" vertex3="motherboard6_assembly_v183"/>
-       <triangular vertex1="motherboard6_assembly_v189" vertex2="motherboard6_assembly_v187" vertex3="motherboard6_assembly_v185"/>
-       <triangular vertex1="motherboard6_assembly_v185" vertex2="motherboard6_assembly_v187" vertex3="motherboard6_assembly_v184"/>
-       <triangular vertex1="motherboard6_assembly_v190" vertex2="motherboard6_assembly_v191" vertex3="motherboard6_assembly_v192"/>
-       <triangular vertex1="motherboard6_assembly_v192" vertex2="motherboard6_assembly_v191" vertex3="motherboard6_assembly_v193"/>
-       <triangular vertex1="motherboard6_assembly_v194" vertex2="motherboard6_assembly_v190" vertex3="motherboard6_assembly_v195"/>
-       <triangular vertex1="motherboard6_assembly_v195" vertex2="motherboard6_assembly_v190" vertex3="motherboard6_assembly_v192"/>
-       <triangular vertex1="motherboard6_assembly_v196" vertex2="motherboard6_assembly_v194" vertex3="motherboard6_assembly_v197"/>
-       <triangular vertex1="motherboard6_assembly_v197" vertex2="motherboard6_assembly_v194" vertex3="motherboard6_assembly_v195"/>
-       <triangular vertex1="motherboard6_assembly_v191" vertex2="motherboard6_assembly_v196" vertex3="motherboard6_assembly_v193"/>
-       <triangular vertex1="motherboard6_assembly_v193" vertex2="motherboard6_assembly_v196" vertex3="motherboard6_assembly_v197"/>
-       <triangular vertex1="motherboard6_assembly_v194" vertex2="motherboard6_assembly_v196" vertex3="motherboard6_assembly_v190"/>
-       <triangular vertex1="motherboard6_assembly_v190" vertex2="motherboard6_assembly_v196" vertex3="motherboard6_assembly_v191"/>
-       <triangular vertex1="motherboard6_assembly_v197" vertex2="motherboard6_assembly_v195" vertex3="motherboard6_assembly_v193"/>
-       <triangular vertex1="motherboard6_assembly_v193" vertex2="motherboard6_assembly_v195" vertex3="motherboard6_assembly_v192"/>
-       <triangular vertex1="motherboard6_assembly_v198" vertex2="motherboard6_assembly_v199" vertex3="motherboard6_assembly_v200"/>
-       <triangular vertex1="motherboard6_assembly_v200" vertex2="motherboard6_assembly_v199" vertex3="motherboard6_assembly_v201"/>
-       <triangular vertex1="motherboard6_assembly_v202" vertex2="motherboard6_assembly_v198" vertex3="motherboard6_assembly_v203"/>
-       <triangular vertex1="motherboard6_assembly_v203" vertex2="motherboard6_assembly_v198" vertex3="motherboard6_assembly_v200"/>
-       <triangular vertex1="motherboard6_assembly_v204" vertex2="motherboard6_assembly_v202" vertex3="motherboard6_assembly_v205"/>
-       <triangular vertex1="motherboard6_assembly_v205" vertex2="motherboard6_assembly_v202" vertex3="motherboard6_assembly_v203"/>
-       <triangular vertex1="motherboard6_assembly_v199" vertex2="motherboard6_assembly_v204" vertex3="motherboard6_assembly_v201"/>
-       <triangular vertex1="motherboard6_assembly_v201" vertex2="motherboard6_assembly_v204" vertex3="motherboard6_assembly_v205"/>
-       <triangular vertex1="motherboard6_assembly_v202" vertex2="motherboard6_assembly_v204" vertex3="motherboard6_assembly_v198"/>
-       <triangular vertex1="motherboard6_assembly_v198" vertex2="motherboard6_assembly_v204" vertex3="motherboard6_assembly_v199"/>
-       <triangular vertex1="motherboard6_assembly_v205" vertex2="motherboard6_assembly_v203" vertex3="motherboard6_assembly_v201"/>
-       <triangular vertex1="motherboard6_assembly_v201" vertex2="motherboard6_assembly_v203" vertex3="motherboard6_assembly_v200"/>
+    <tessellated aunit="deg" lunit="mm" name="nohole_motherboard6_assembly-SOL">
+       <triangular vertex1="nohole_motherboard6_assembly_v0" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v2"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v2" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v4" vertex2="nohole_motherboard6_assembly_v0" vertex3="nohole_motherboard6_assembly_v5"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v5" vertex2="nohole_motherboard6_assembly_v0" vertex3="nohole_motherboard6_assembly_v2"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v6" vertex2="nohole_motherboard6_assembly_v4" vertex3="nohole_motherboard6_assembly_v7"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v7" vertex2="nohole_motherboard6_assembly_v4" vertex3="nohole_motherboard6_assembly_v5"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v8" vertex2="nohole_motherboard6_assembly_v6" vertex3="nohole_motherboard6_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v9" vertex2="nohole_motherboard6_assembly_v6" vertex3="nohole_motherboard6_assembly_v7"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v10" vertex2="nohole_motherboard6_assembly_v8" vertex3="nohole_motherboard6_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v11" vertex2="nohole_motherboard6_assembly_v8" vertex3="nohole_motherboard6_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v12" vertex2="nohole_motherboard6_assembly_v10" vertex3="nohole_motherboard6_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v13" vertex2="nohole_motherboard6_assembly_v10" vertex3="nohole_motherboard6_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v14" vertex2="nohole_motherboard6_assembly_v12" vertex3="nohole_motherboard6_assembly_v15"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v15" vertex2="nohole_motherboard6_assembly_v12" vertex3="nohole_motherboard6_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v16" vertex2="nohole_motherboard6_assembly_v14" vertex3="nohole_motherboard6_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v17" vertex2="nohole_motherboard6_assembly_v14" vertex3="nohole_motherboard6_assembly_v15"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v18" vertex2="nohole_motherboard6_assembly_v16" vertex3="nohole_motherboard6_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v19" vertex2="nohole_motherboard6_assembly_v16" vertex3="nohole_motherboard6_assembly_v17"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v20" vertex2="nohole_motherboard6_assembly_v18" vertex3="nohole_motherboard6_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v21" vertex2="nohole_motherboard6_assembly_v18" vertex3="nohole_motherboard6_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v22" vertex2="nohole_motherboard6_assembly_v20" vertex3="nohole_motherboard6_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v23" vertex2="nohole_motherboard6_assembly_v20" vertex3="nohole_motherboard6_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v24" vertex2="nohole_motherboard6_assembly_v22" vertex3="nohole_motherboard6_assembly_v25"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v25" vertex2="nohole_motherboard6_assembly_v22" vertex3="nohole_motherboard6_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v26" vertex2="nohole_motherboard6_assembly_v24" vertex3="nohole_motherboard6_assembly_v27"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v27" vertex2="nohole_motherboard6_assembly_v24" vertex3="nohole_motherboard6_assembly_v25"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v28" vertex2="nohole_motherboard6_assembly_v26" vertex3="nohole_motherboard6_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v29" vertex2="nohole_motherboard6_assembly_v26" vertex3="nohole_motherboard6_assembly_v27"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v30" vertex2="nohole_motherboard6_assembly_v28" vertex3="nohole_motherboard6_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v31" vertex2="nohole_motherboard6_assembly_v28" vertex3="nohole_motherboard6_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v32" vertex2="nohole_motherboard6_assembly_v30" vertex3="nohole_motherboard6_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v33" vertex2="nohole_motherboard6_assembly_v30" vertex3="nohole_motherboard6_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v34" vertex2="nohole_motherboard6_assembly_v32" vertex3="nohole_motherboard6_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v35" vertex2="nohole_motherboard6_assembly_v32" vertex3="nohole_motherboard6_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v36" vertex2="nohole_motherboard6_assembly_v34" vertex3="nohole_motherboard6_assembly_v37"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v37" vertex2="nohole_motherboard6_assembly_v34" vertex3="nohole_motherboard6_assembly_v35"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v1" vertex2="nohole_motherboard6_assembly_v36" vertex3="nohole_motherboard6_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v3" vertex2="nohole_motherboard6_assembly_v36" vertex3="nohole_motherboard6_assembly_v37"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v16" vertex2="nohole_motherboard6_assembly_v18" vertex3="nohole_motherboard6_assembly_v20"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v24" vertex2="nohole_motherboard6_assembly_v26" vertex3="nohole_motherboard6_assembly_v22"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v22" vertex2="nohole_motherboard6_assembly_v26" vertex3="nohole_motherboard6_assembly_v28"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v34" vertex2="nohole_motherboard6_assembly_v36" vertex3="nohole_motherboard6_assembly_v32"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v32" vertex2="nohole_motherboard6_assembly_v36" vertex3="nohole_motherboard6_assembly_v1"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v32" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v30"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v30" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v10"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v1" vertex2="nohole_motherboard6_assembly_v0" vertex3="nohole_motherboard6_assembly_v4"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v10" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v8"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v8" vertex2="nohole_motherboard6_assembly_v1" vertex3="nohole_motherboard6_assembly_v4"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v8" vertex2="nohole_motherboard6_assembly_v4" vertex3="nohole_motherboard6_assembly_v6"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v14" vertex2="nohole_motherboard6_assembly_v16" vertex3="nohole_motherboard6_assembly_v12"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v12" vertex2="nohole_motherboard6_assembly_v16" vertex3="nohole_motherboard6_assembly_v20"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v12" vertex2="nohole_motherboard6_assembly_v20" vertex3="nohole_motherboard6_assembly_v10"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v10" vertex2="nohole_motherboard6_assembly_v20" vertex3="nohole_motherboard6_assembly_v22"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v10" vertex2="nohole_motherboard6_assembly_v22" vertex3="nohole_motherboard6_assembly_v30"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v30" vertex2="nohole_motherboard6_assembly_v22" vertex3="nohole_motherboard6_assembly_v28"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v5" vertex2="nohole_motherboard6_assembly_v2" vertex3="nohole_motherboard6_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v17" vertex2="nohole_motherboard6_assembly_v15" vertex3="nohole_motherboard6_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v37" vertex2="nohole_motherboard6_assembly_v35" vertex3="nohole_motherboard6_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v3" vertex2="nohole_motherboard6_assembly_v35" vertex3="nohole_motherboard6_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v27" vertex2="nohole_motherboard6_assembly_v25" vertex3="nohole_motherboard6_assembly_v29"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v29" vertex2="nohole_motherboard6_assembly_v25" vertex3="nohole_motherboard6_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v29" vertex2="nohole_motherboard6_assembly_v23" vertex3="nohole_motherboard6_assembly_v31"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v7" vertex2="nohole_motherboard6_assembly_v5" vertex3="nohole_motherboard6_assembly_v9"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v9" vertex2="nohole_motherboard6_assembly_v5" vertex3="nohole_motherboard6_assembly_v3"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v9" vertex2="nohole_motherboard6_assembly_v3" vertex3="nohole_motherboard6_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v11" vertex2="nohole_motherboard6_assembly_v3" vertex3="nohole_motherboard6_assembly_v33"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v17" vertex2="nohole_motherboard6_assembly_v13" vertex3="nohole_motherboard6_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v33" vertex2="nohole_motherboard6_assembly_v31" vertex3="nohole_motherboard6_assembly_v11"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v11" vertex2="nohole_motherboard6_assembly_v31" vertex3="nohole_motherboard6_assembly_v23"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v11" vertex2="nohole_motherboard6_assembly_v23" vertex3="nohole_motherboard6_assembly_v13"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v13" vertex2="nohole_motherboard6_assembly_v23" vertex3="nohole_motherboard6_assembly_v21"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v13" vertex2="nohole_motherboard6_assembly_v21" vertex3="nohole_motherboard6_assembly_v19"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v38" vertex2="nohole_motherboard6_assembly_v39" vertex3="nohole_motherboard6_assembly_v40"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v40" vertex2="nohole_motherboard6_assembly_v39" vertex3="nohole_motherboard6_assembly_v41"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v42" vertex2="nohole_motherboard6_assembly_v38" vertex3="nohole_motherboard6_assembly_v43"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v43" vertex2="nohole_motherboard6_assembly_v38" vertex3="nohole_motherboard6_assembly_v40"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v44" vertex2="nohole_motherboard6_assembly_v42" vertex3="nohole_motherboard6_assembly_v45"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v45" vertex2="nohole_motherboard6_assembly_v42" vertex3="nohole_motherboard6_assembly_v43"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v39" vertex2="nohole_motherboard6_assembly_v44" vertex3="nohole_motherboard6_assembly_v41"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v41" vertex2="nohole_motherboard6_assembly_v44" vertex3="nohole_motherboard6_assembly_v45"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v42" vertex2="nohole_motherboard6_assembly_v44" vertex3="nohole_motherboard6_assembly_v38"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v38" vertex2="nohole_motherboard6_assembly_v44" vertex3="nohole_motherboard6_assembly_v39"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v45" vertex2="nohole_motherboard6_assembly_v43" vertex3="nohole_motherboard6_assembly_v41"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v41" vertex2="nohole_motherboard6_assembly_v43" vertex3="nohole_motherboard6_assembly_v40"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v46" vertex2="nohole_motherboard6_assembly_v47" vertex3="nohole_motherboard6_assembly_v48"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v48" vertex2="nohole_motherboard6_assembly_v47" vertex3="nohole_motherboard6_assembly_v49"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v50" vertex2="nohole_motherboard6_assembly_v46" vertex3="nohole_motherboard6_assembly_v51"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v51" vertex2="nohole_motherboard6_assembly_v46" vertex3="nohole_motherboard6_assembly_v48"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v52" vertex2="nohole_motherboard6_assembly_v50" vertex3="nohole_motherboard6_assembly_v53"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v53" vertex2="nohole_motherboard6_assembly_v50" vertex3="nohole_motherboard6_assembly_v51"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v47" vertex2="nohole_motherboard6_assembly_v52" vertex3="nohole_motherboard6_assembly_v49"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v49" vertex2="nohole_motherboard6_assembly_v52" vertex3="nohole_motherboard6_assembly_v53"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v50" vertex2="nohole_motherboard6_assembly_v52" vertex3="nohole_motherboard6_assembly_v46"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v46" vertex2="nohole_motherboard6_assembly_v52" vertex3="nohole_motherboard6_assembly_v47"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v53" vertex2="nohole_motherboard6_assembly_v51" vertex3="nohole_motherboard6_assembly_v49"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v49" vertex2="nohole_motherboard6_assembly_v51" vertex3="nohole_motherboard6_assembly_v48"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v54" vertex2="nohole_motherboard6_assembly_v55" vertex3="nohole_motherboard6_assembly_v56"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v56" vertex2="nohole_motherboard6_assembly_v55" vertex3="nohole_motherboard6_assembly_v57"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v58" vertex2="nohole_motherboard6_assembly_v54" vertex3="nohole_motherboard6_assembly_v59"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v59" vertex2="nohole_motherboard6_assembly_v54" vertex3="nohole_motherboard6_assembly_v56"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v60" vertex2="nohole_motherboard6_assembly_v58" vertex3="nohole_motherboard6_assembly_v61"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v61" vertex2="nohole_motherboard6_assembly_v58" vertex3="nohole_motherboard6_assembly_v59"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v55" vertex2="nohole_motherboard6_assembly_v60" vertex3="nohole_motherboard6_assembly_v57"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v57" vertex2="nohole_motherboard6_assembly_v60" vertex3="nohole_motherboard6_assembly_v61"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v58" vertex2="nohole_motherboard6_assembly_v60" vertex3="nohole_motherboard6_assembly_v54"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v54" vertex2="nohole_motherboard6_assembly_v60" vertex3="nohole_motherboard6_assembly_v55"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v61" vertex2="nohole_motherboard6_assembly_v59" vertex3="nohole_motherboard6_assembly_v57"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v57" vertex2="nohole_motherboard6_assembly_v59" vertex3="nohole_motherboard6_assembly_v56"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v62" vertex2="nohole_motherboard6_assembly_v63" vertex3="nohole_motherboard6_assembly_v64"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v64" vertex2="nohole_motherboard6_assembly_v63" vertex3="nohole_motherboard6_assembly_v65"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v66" vertex2="nohole_motherboard6_assembly_v62" vertex3="nohole_motherboard6_assembly_v67"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v67" vertex2="nohole_motherboard6_assembly_v62" vertex3="nohole_motherboard6_assembly_v64"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v68" vertex2="nohole_motherboard6_assembly_v66" vertex3="nohole_motherboard6_assembly_v69"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v69" vertex2="nohole_motherboard6_assembly_v66" vertex3="nohole_motherboard6_assembly_v67"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v63" vertex2="nohole_motherboard6_assembly_v68" vertex3="nohole_motherboard6_assembly_v65"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v65" vertex2="nohole_motherboard6_assembly_v68" vertex3="nohole_motherboard6_assembly_v69"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v66" vertex2="nohole_motherboard6_assembly_v68" vertex3="nohole_motherboard6_assembly_v62"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v62" vertex2="nohole_motherboard6_assembly_v68" vertex3="nohole_motherboard6_assembly_v63"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v69" vertex2="nohole_motherboard6_assembly_v67" vertex3="nohole_motherboard6_assembly_v65"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v65" vertex2="nohole_motherboard6_assembly_v67" vertex3="nohole_motherboard6_assembly_v64"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v70" vertex2="nohole_motherboard6_assembly_v71" vertex3="nohole_motherboard6_assembly_v72"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v72" vertex2="nohole_motherboard6_assembly_v71" vertex3="nohole_motherboard6_assembly_v73"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v74" vertex2="nohole_motherboard6_assembly_v70" vertex3="nohole_motherboard6_assembly_v75"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v75" vertex2="nohole_motherboard6_assembly_v70" vertex3="nohole_motherboard6_assembly_v72"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v76" vertex2="nohole_motherboard6_assembly_v74" vertex3="nohole_motherboard6_assembly_v77"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v77" vertex2="nohole_motherboard6_assembly_v74" vertex3="nohole_motherboard6_assembly_v75"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v71" vertex2="nohole_motherboard6_assembly_v76" vertex3="nohole_motherboard6_assembly_v73"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v73" vertex2="nohole_motherboard6_assembly_v76" vertex3="nohole_motherboard6_assembly_v77"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v74" vertex2="nohole_motherboard6_assembly_v76" vertex3="nohole_motherboard6_assembly_v70"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v70" vertex2="nohole_motherboard6_assembly_v76" vertex3="nohole_motherboard6_assembly_v71"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v77" vertex2="nohole_motherboard6_assembly_v75" vertex3="nohole_motherboard6_assembly_v73"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v73" vertex2="nohole_motherboard6_assembly_v75" vertex3="nohole_motherboard6_assembly_v72"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v78" vertex2="nohole_motherboard6_assembly_v79" vertex3="nohole_motherboard6_assembly_v80"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v80" vertex2="nohole_motherboard6_assembly_v79" vertex3="nohole_motherboard6_assembly_v81"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v82" vertex2="nohole_motherboard6_assembly_v78" vertex3="nohole_motherboard6_assembly_v83"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v83" vertex2="nohole_motherboard6_assembly_v78" vertex3="nohole_motherboard6_assembly_v80"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v84" vertex2="nohole_motherboard6_assembly_v82" vertex3="nohole_motherboard6_assembly_v85"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v85" vertex2="nohole_motherboard6_assembly_v82" vertex3="nohole_motherboard6_assembly_v83"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v79" vertex2="nohole_motherboard6_assembly_v84" vertex3="nohole_motherboard6_assembly_v81"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v81" vertex2="nohole_motherboard6_assembly_v84" vertex3="nohole_motherboard6_assembly_v85"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v82" vertex2="nohole_motherboard6_assembly_v84" vertex3="nohole_motherboard6_assembly_v78"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v78" vertex2="nohole_motherboard6_assembly_v84" vertex3="nohole_motherboard6_assembly_v79"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v85" vertex2="nohole_motherboard6_assembly_v83" vertex3="nohole_motherboard6_assembly_v81"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v81" vertex2="nohole_motherboard6_assembly_v83" vertex3="nohole_motherboard6_assembly_v80"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v86" vertex2="nohole_motherboard6_assembly_v87" vertex3="nohole_motherboard6_assembly_v88"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v88" vertex2="nohole_motherboard6_assembly_v87" vertex3="nohole_motherboard6_assembly_v89"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v90" vertex2="nohole_motherboard6_assembly_v86" vertex3="nohole_motherboard6_assembly_v91"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v91" vertex2="nohole_motherboard6_assembly_v86" vertex3="nohole_motherboard6_assembly_v88"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v92" vertex2="nohole_motherboard6_assembly_v90" vertex3="nohole_motherboard6_assembly_v93"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v93" vertex2="nohole_motherboard6_assembly_v90" vertex3="nohole_motherboard6_assembly_v91"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v87" vertex2="nohole_motherboard6_assembly_v92" vertex3="nohole_motherboard6_assembly_v89"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v89" vertex2="nohole_motherboard6_assembly_v92" vertex3="nohole_motherboard6_assembly_v93"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v90" vertex2="nohole_motherboard6_assembly_v92" vertex3="nohole_motherboard6_assembly_v86"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v86" vertex2="nohole_motherboard6_assembly_v92" vertex3="nohole_motherboard6_assembly_v87"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v93" vertex2="nohole_motherboard6_assembly_v91" vertex3="nohole_motherboard6_assembly_v89"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v89" vertex2="nohole_motherboard6_assembly_v91" vertex3="nohole_motherboard6_assembly_v88"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v94" vertex2="nohole_motherboard6_assembly_v95" vertex3="nohole_motherboard6_assembly_v96"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v96" vertex2="nohole_motherboard6_assembly_v95" vertex3="nohole_motherboard6_assembly_v97"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v98" vertex2="nohole_motherboard6_assembly_v94" vertex3="nohole_motherboard6_assembly_v99"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v99" vertex2="nohole_motherboard6_assembly_v94" vertex3="nohole_motherboard6_assembly_v96"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v100" vertex2="nohole_motherboard6_assembly_v98" vertex3="nohole_motherboard6_assembly_v101"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v101" vertex2="nohole_motherboard6_assembly_v98" vertex3="nohole_motherboard6_assembly_v99"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v95" vertex2="nohole_motherboard6_assembly_v100" vertex3="nohole_motherboard6_assembly_v97"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v97" vertex2="nohole_motherboard6_assembly_v100" vertex3="nohole_motherboard6_assembly_v101"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v98" vertex2="nohole_motherboard6_assembly_v100" vertex3="nohole_motherboard6_assembly_v94"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v94" vertex2="nohole_motherboard6_assembly_v100" vertex3="nohole_motherboard6_assembly_v95"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v101" vertex2="nohole_motherboard6_assembly_v99" vertex3="nohole_motherboard6_assembly_v97"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v97" vertex2="nohole_motherboard6_assembly_v99" vertex3="nohole_motherboard6_assembly_v96"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v102" vertex2="nohole_motherboard6_assembly_v103" vertex3="nohole_motherboard6_assembly_v104"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v104" vertex2="nohole_motherboard6_assembly_v103" vertex3="nohole_motherboard6_assembly_v105"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v106" vertex2="nohole_motherboard6_assembly_v102" vertex3="nohole_motherboard6_assembly_v107"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v107" vertex2="nohole_motherboard6_assembly_v102" vertex3="nohole_motherboard6_assembly_v104"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v108" vertex2="nohole_motherboard6_assembly_v106" vertex3="nohole_motherboard6_assembly_v109"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v109" vertex2="nohole_motherboard6_assembly_v106" vertex3="nohole_motherboard6_assembly_v107"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v103" vertex2="nohole_motherboard6_assembly_v108" vertex3="nohole_motherboard6_assembly_v105"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v105" vertex2="nohole_motherboard6_assembly_v108" vertex3="nohole_motherboard6_assembly_v109"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v106" vertex2="nohole_motherboard6_assembly_v108" vertex3="nohole_motherboard6_assembly_v102"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v102" vertex2="nohole_motherboard6_assembly_v108" vertex3="nohole_motherboard6_assembly_v103"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v109" vertex2="nohole_motherboard6_assembly_v107" vertex3="nohole_motherboard6_assembly_v105"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v105" vertex2="nohole_motherboard6_assembly_v107" vertex3="nohole_motherboard6_assembly_v104"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v110" vertex2="nohole_motherboard6_assembly_v111" vertex3="nohole_motherboard6_assembly_v112"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v112" vertex2="nohole_motherboard6_assembly_v111" vertex3="nohole_motherboard6_assembly_v113"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v114" vertex2="nohole_motherboard6_assembly_v110" vertex3="nohole_motherboard6_assembly_v115"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v115" vertex2="nohole_motherboard6_assembly_v110" vertex3="nohole_motherboard6_assembly_v112"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v116" vertex2="nohole_motherboard6_assembly_v114" vertex3="nohole_motherboard6_assembly_v117"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v117" vertex2="nohole_motherboard6_assembly_v114" vertex3="nohole_motherboard6_assembly_v115"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v111" vertex2="nohole_motherboard6_assembly_v116" vertex3="nohole_motherboard6_assembly_v113"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v113" vertex2="nohole_motherboard6_assembly_v116" vertex3="nohole_motherboard6_assembly_v117"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v114" vertex2="nohole_motherboard6_assembly_v116" vertex3="nohole_motherboard6_assembly_v110"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v110" vertex2="nohole_motherboard6_assembly_v116" vertex3="nohole_motherboard6_assembly_v111"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v117" vertex2="nohole_motherboard6_assembly_v115" vertex3="nohole_motherboard6_assembly_v113"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v113" vertex2="nohole_motherboard6_assembly_v115" vertex3="nohole_motherboard6_assembly_v112"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v118" vertex2="nohole_motherboard6_assembly_v119" vertex3="nohole_motherboard6_assembly_v120"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v120" vertex2="nohole_motherboard6_assembly_v119" vertex3="nohole_motherboard6_assembly_v121"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v122" vertex2="nohole_motherboard6_assembly_v118" vertex3="nohole_motherboard6_assembly_v123"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v123" vertex2="nohole_motherboard6_assembly_v118" vertex3="nohole_motherboard6_assembly_v120"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v124" vertex2="nohole_motherboard6_assembly_v122" vertex3="nohole_motherboard6_assembly_v125"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v125" vertex2="nohole_motherboard6_assembly_v122" vertex3="nohole_motherboard6_assembly_v123"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v119" vertex2="nohole_motherboard6_assembly_v124" vertex3="nohole_motherboard6_assembly_v121"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v121" vertex2="nohole_motherboard6_assembly_v124" vertex3="nohole_motherboard6_assembly_v125"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v122" vertex2="nohole_motherboard6_assembly_v124" vertex3="nohole_motherboard6_assembly_v118"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v118" vertex2="nohole_motherboard6_assembly_v124" vertex3="nohole_motherboard6_assembly_v119"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v125" vertex2="nohole_motherboard6_assembly_v123" vertex3="nohole_motherboard6_assembly_v121"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v121" vertex2="nohole_motherboard6_assembly_v123" vertex3="nohole_motherboard6_assembly_v120"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v126" vertex2="nohole_motherboard6_assembly_v127" vertex3="nohole_motherboard6_assembly_v128"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v128" vertex2="nohole_motherboard6_assembly_v127" vertex3="nohole_motherboard6_assembly_v129"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v130" vertex2="nohole_motherboard6_assembly_v126" vertex3="nohole_motherboard6_assembly_v131"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v131" vertex2="nohole_motherboard6_assembly_v126" vertex3="nohole_motherboard6_assembly_v128"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v132" vertex2="nohole_motherboard6_assembly_v130" vertex3="nohole_motherboard6_assembly_v133"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v133" vertex2="nohole_motherboard6_assembly_v130" vertex3="nohole_motherboard6_assembly_v131"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v127" vertex2="nohole_motherboard6_assembly_v132" vertex3="nohole_motherboard6_assembly_v129"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v129" vertex2="nohole_motherboard6_assembly_v132" vertex3="nohole_motherboard6_assembly_v133"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v130" vertex2="nohole_motherboard6_assembly_v132" vertex3="nohole_motherboard6_assembly_v126"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v126" vertex2="nohole_motherboard6_assembly_v132" vertex3="nohole_motherboard6_assembly_v127"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v133" vertex2="nohole_motherboard6_assembly_v131" vertex3="nohole_motherboard6_assembly_v129"/>
+       <triangular vertex1="nohole_motherboard6_assembly_v129" vertex2="nohole_motherboard6_assembly_v131" vertex3="nohole_motherboard6_assembly_v128"/>
     </tessellated>
   </solids>
 
   <structure>
-    <volume name="motherboard6_assembly">
+    <volume name="nohole_motherboard6_assembly">
       <materialref ref="FR40x27264f0"/>
-      <solidref ref="motherboard6_assembly-SOL"/>
+      <solidref ref="nohole_motherboard6_assembly-SOL"/>
     </volume>
   </structure>
 
   <setup name="Default" version="1.0">
-    <world ref="motherboard6_assembly"/>
+    <world ref="nohole_motherboard6_assembly"/>
   </setup>
 </gdml>

--- a/Detectors/util/ecal_layer_stack.py
+++ b/Detectors/util/ecal_layer_stack.py
@@ -86,8 +86,8 @@ class Layer :
     def silicon() :
         return Layer('Si',Layer.SensDetThickness,sensitive=True)
 
-    def carbon() :
-        return Layer('Carbon',5.7)
+    def carbon(t) :
+        return Layer('Carbon',t)
 
     def enumerate_full_stack(sections) :
         layers = []
@@ -105,11 +105,13 @@ class Layer :
                 layers.append(Layer.glue(0.1))
                 layers.append(Layer.silicon())
                 layers.append(Layer.glue(0.2))
+                layers.append(Layer.carbon(0.79))
                 if cooling > 0 :
                     layers.append(Layer.tungsten(cooling))
-                layers.append(Layer.carbon())
+                layers.append(Layer.carbon(5.7))
                 if cooling > 0 :
                     layers.append(Layer.tungsten(cooling))
+                layers.append(Layer.carbon(0.79))
                 layers.append(Layer.glue(0.2))
                 layers.append(Layer.silicon())
                 layers.append(Layer.glue(0.1))

--- a/Detectors/util/ecal_layer_stack.py
+++ b/Detectors/util/ecal_layer_stack.py
@@ -153,10 +153,8 @@ def calc_weights(layers_partitioned_by_sensdet) :
     # Does include sensitive detector layers
     Zpos_layer = [ ]
     for section in layers_partitioned_by_sensdet :
-        print('section')
         dE_section, X0_section, L_section, Zdepth_section = 0., 0., 0., 0.
         for l in section :
-            print(' ',l)
             dE_section += l.thickness * l.dEdx
             X0_section += l.thickness / l.x0
             L_section  += l.thickness / l.nuclen
@@ -208,6 +206,9 @@ def main() :
     mbs = materials_between_sensdet(layers)
     weights = calc_weights(mbs)
     print_weights(*weights)
+
+    for l in layers :
+        print(l)
 
 if __name__ == '__main__' :
     main()


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1112 .

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] NA ~I attached any sub-module related changes to this PR.~
- [x] I ran my developments and the following shows that they are successful.

No hole in the motherboards...

![Screenshot from 2022-11-08 14-21-25](https://user-images.githubusercontent.com/31970302/200673612-1193b0af-756e-4419-9076-1fc53c8a0997.png)

The extra carbon base plate is hard to see, but I confirmed they were there by browsing the volumes in the G4 visualization.

The overlap check within the ecal also passed. The full parsing log is [gdml_parse.out.gz](https://github.com/LDMX-Software/ldmx-sw/files/9965194/gdml_parse.out.gz) and the only overlap is the known one where the support box overlaps with the envelope volume due to the "fins" poking out the front.

With the introduced material, this will lead to changing the layer weights in the Ecal reco pipeline, but that is a job for future tom :sunglasses: .