### PR TITLE
Ecal PN bias patch

### DIFF
--- a/Biasing/python/ecal.py
+++ b/Biasing/python/ecal.py
@@ -57,10 +57,7 @@ def photo_nuclear( detector, generator ) :
     sim.generators.append( generator )
     
     # Enable and configure the biasing
-    #   In order to conform to older samples,
-    #   we can only attach to some of the volumes in the ecal
-    #   so we ask for this operator to be attached to the 'old_ecal'
-    sim.biasing_operators = [ bias_operators.PhotoNuclear('old_ecal',450.,2500.,only_children_of_primary = True) ]
+    sim.biasing_operators = [ bias_operators.PhotoNuclear('ecal',450.,2500.,only_children_of_primary = True) ]
 
     # the following filters are in a library that needs to be included
     includeBiasing.library()

--- a/Biasing/src/Biasing/TargetBremFilter.cxx
+++ b/Biasing/src/Biasing/TargetBremFilter.cxx
@@ -65,6 +65,12 @@ void TargetBremFilter::stepping(const G4Step* step) {
       region.compareTo("target") != 0)
     return;
 
+  /*
+  std::cout << "[TargetBremFilter] : Stepping primary electron in 'target' region into " 
+    << track->GetNextVolume()->GetName()
+    << std::endl;
+   */
+
   /**
    * Check if the electron will be exiting the target
    *
@@ -73,9 +79,13 @@ void TargetBremFilter::stepping(const G4Step* step) {
    * visualization. This Physical Volume (PV) is associated with the
    * recoil parent volume and so it will break if the recoil parent volume
    * changes its name.
+   *
+   * We also check if the next volume is World_PV because in some geometries
+   * (e.g. v14), there is a air-gap between the target region and the recoil.
    */
   if (auto volume{track->GetNextVolume()->GetName()};
-      volume.compareTo("recoil_PV") == 0) {
+      volume.compareTo("recoil_PV") == 0
+      or volume.compareTo("World_PV") == 0) {
     // If the recoil electron
     if (track->GetMomentum().mag() >= recoilMaxPThreshold_) {
       track->SetTrackStatus(fKillTrackAndSecondaries);
@@ -111,6 +121,10 @@ void TargetBremFilter::stepping(const G4Step* step) {
       G4RunManager::GetRunManager()->AbortEvent();
       return;
     }
+
+    /*
+    std::cout << "[TargetBremFilter] : Found brem candidate" << std::endl;
+     */
 
     // Check if the recoil electron should be killed.  If not, postpone
     // its processing until the brem gamma has been processed.

--- a/Biasing/src/Biasing/TargetProcessFilter.cxx
+++ b/Biasing/src/Biasing/TargetProcessFilter.cxx
@@ -76,9 +76,13 @@ void TargetProcessFilter::stepping(const G4Step* step) {
      * visualization. This Physical Volume (PV) is associated with the
      * recoil parent volume and so it will break if the recoil parent volume
      * changes its name.
+     *
+     * We also check for 'World_PV' because in later geometries, there is
+     * an air gap between the target region and the recoil tracker.
      */
     if (auto volume{track->GetNextVolume()->GetName()};
-        volume.compareTo("recoil_PV") == 0) {
+        volume.compareTo("recoil_PV") == 0 or 
+        volume.compareTo("World_PV") == 0) {
       if (secondaries->size() != 0) {
         if (getEventInfo()->bremCandidateCount() == 1) {
           track->SetTrackStatus(fKillTrackAndSecondaries);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
I found this bug while trying to generate a small, local Ecal PN sample for validation. The increased air gap between the TS and the recoil tracker means that the `World_PV` volume is now the "next" volume after the target region in the v14 geometry.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
- [x] NA ~I attached any sub-module related changes to this PR.~

I know this works because I see the following printout when running ECal PN asking for 10 events:
```
<omitted for brevity>                                    
[ EcalProcessFilter ]: 1 Brem photon produced 55 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 2 Brem photon produced 48 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 3 Brem photon produced 27 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 4 Brem photon produced 13 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 5 Brem photon produced 27 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 6 Brem photon produced 48 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 7 Brem photon produced 8 particle via biasWrapper(photonNuclear) process.     
[ EcalProcessFilter ]: 8 Brem photon produced 35 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 9 Brem photon produced 42 particle via biasWrapper(photonNuclear) process.    
[ EcalProcessFilter ]: 10 Brem photon produced 7 particle via biasWrapper(photonNuclear) process.    
<omitted for brevity>
[ Simulator ] : Started 585 events to produce 10 events.
---- LDMXSW: Event processing complete  --------
```
whereas on `trunk` no such `EcalProcessFilter` printouts are seen.