### PR TITLE
Change from 25 to 24 bars per TS array layer, and increase height

### DIFF
--- a/Detectors/data/ldmx-det-v14/constants.gdml
+++ b/Detectors/data/ldmx-det-v14/constants.gdml
@@ -43,8 +43,8 @@
 <constant name="trigger_pad_dim_x"          value="target_dim_x" />
 <constant name="trigger_pad_dim_y"          value="target_dim_y" />
 <constant name="trigger_bar_dx"             value="30"/>
-<constant name="trigger_bar_dy"             value="3"/>   
-<constant name="number_of_bars"             value="25"/>
+<constant name="trigger_bar_dy"             value="3.05"/>   
+<constant name="number_of_bars"             value="24"/>
 
 <constant name="trigger_pad_offset"    
           value="(target_dim_y - (number_of_bars*trigger_bar_dy + (number_of_bars - 1)*trigger_pad_bar_gap))/2" />


### PR DESCRIPTION
Increasing the height by 0.05 mm to still cover beam spot in y

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

This resolves #1126.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

![simhitY_red1blu2orange3_48barsShaded](https://user-images.githubusercontent.com/42861632/202823845-f8109dc7-bc66-4d3a-af5c-29c510f6e946.png)

This plot shows the _y_ coordinate in TS simhits for Pad1 (red), Pad2 (blue) and Pad3 (orange), with 48 bars (shaded) and 50 bars (lines). The new geometry fully covers the beam spot (+/- 40 mm)

The output file used for the plot was obtained using this config, with files created before and after the change to the geometry:
``` python
from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('sim') #                                                                                                                       

import sys                                            
from LDMX.SimCore import generators as gen
from LDMX.SimCore import simulator
from LDMX.Biasing import filters
from LDMX.SimCore import simcfg

from LDMX.TrigScint.trigScint import TrigScintDigiProducer

from  LDMX.Ecal import EcalGeometry
import LDMX.Ecal.ecal_hardcoded_conditions                                                                            
import LDMX.Hcal.HcalGeometry
import LDMX.Hcal.hcal_hardcoded_conditions

p.run=1
mySim = simulator.simulator("mySim")
nySim.description = "Upstream 4 GeV 1-electron beam"
mySim.beamSpotSmear = [20., 80., 0] #mm                                                                                                            

# get the path to the installed detector description                                                                                               
from LDMX.Detectors.makePath import *
mySim.setDetector( 'ldmx-det-v14', True  ) #the true should tell it to include scoring planes                 

mpgGen = gen.multi( "mgpGen" ) # this is the line that actually creates the generator                                                              
mpgGen.vertex = [ -44., 0., -880 ] # mm                                                                                                            
mpgGen.nParticles = 1
mpgGen.pdgID = 11
mpgGen.enablePoisson = False

import math
theta = math.radians(5.65)
mpgGen.momentum = [ 4000.*math.sin(theta) , 0, 4000.*math.cos(theta) ] # MeV                                                                      

#set this as the simulator's generator                                                                                                             
mySim.generators = [ mpgGen ]

p.sequence = [
    mySim
    ]
                                                                                                           
p.outputFiles = [sys.argv[1]]
p.maxEvents = 20
```