### PR TITLE
make sure the Tracking Event library is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ add_subdirectory(SimCore ${CMAKE_BINARY_DIR}/SimCoreEvent)
 add_subdirectory(Ecal ${CMAKE_BINARY_DIR}/EcalEvent)
 add_subdirectory(Hcal ${CMAKE_BINARY_DIR}/HcalEvent)
 add_subdirectory(TrigScint ${CMAKE_BINARY_DIR}/TrigScintEvent)
+add_subdirectory(Tracking ${CMAKE_BINARY_DIR}/TrackingEvent)
 
 # Once the event libraries have been built, turn off the global option. 
 set(BUILD_EVENT_ONLY OFF CACHE BOOL "Build the SimCore library." FORCE)


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1142 .

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

A snippet of the compilation log shows that the Tracking Event classes are now being compiled into the event dictionary.
```
<snip>
[  0%] Built target Framework_Exception
[  7%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/CaloTrigPrim.cxx.o
[  7%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/CalorimeterHit.cxx.o
[  7%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/EventConstants.cxx.o
[  7%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/HgcrocDigiCollection.cxx.o
[ 14%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/HgcrocTrigDigi.cxx.o
[ 14%] Building CXX object ReconEvent/CMakeFiles/Recon_Event.dir/src/Recon/Event/TriggerResult.cxx.o
[ 14%] Linking CXX shared library libRecon_Event.so
[ 14%] Built target Recon_Event
[ 21%] Building CXX object SimCoreEvent/CMakeFiles/SimCore_Event.dir/src/SimCore/Event/SimCalorimeterHit.cxx.o
[ 21%] Building CXX object SimCoreEvent/CMakeFiles/SimCore_Event.dir/src/SimCore/Event/SimParticle.cxx.o
[ 21%] Building CXX object SimCoreEvent/CMakeFiles/SimCore_Event.dir/src/SimCore/Event/SimTrackerHit.cxx.o
[ 21%] Linking CXX shared library libSimCore_Event.so
[ 21%] Built target SimCore_Event
[ 21%] Building CXX object EcalEvent/CMakeFiles/Ecal_Event.dir/src/Ecal/Event/ClusterAlgoResult.cxx.o
[ 21%] Building CXX object EcalEvent/CMakeFiles/Ecal_Event.dir/src/Ecal/Event/EcalCluster.cxx.o
[ 21%] Building CXX object EcalEvent/CMakeFiles/Ecal_Event.dir/src/Ecal/Event/EcalDigiCollection.cxx.o
[ 28%] Building CXX object EcalEvent/CMakeFiles/Ecal_Event.dir/src/Ecal/Event/EcalHit.cxx.o
[ 28%] Building CXX object EcalEvent/CMakeFiles/Ecal_Event.dir/src/Ecal/Event/EcalVetoResult.cxx.o
[ 28%] Linking CXX shared library libEcal_Event.so
[ 28%] Built target Ecal_Event
[ 28%] Building CXX object HcalEvent/CMakeFiles/Hcal_Event.dir/src/Hcal/Event/HcalCluster.cxx.o
[ 28%] Building CXX object HcalEvent/CMakeFiles/Hcal_Event.dir/src/Hcal/Event/HcalHit.cxx.o
[ 35%] Building CXX object HcalEvent/CMakeFiles/Hcal_Event.dir/src/Hcal/Event/HcalVetoResult.cxx.o
[ 35%] Linking CXX shared library libHcal_Event.so
[ 35%] Built target Hcal_Event
[ 35%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/EventReadout.cxx.o
[ 35%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/TestBeamHit.cxx.o
[ 42%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/TrigScintCluster.cxx.o
[ 42%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/TrigScintHit.cxx.o
[ 42%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/TrigScintQIEDigis.cxx.o
[ 42%] Building CXX object TrigScintEvent/CMakeFiles/TrigScint_Event.dir/src/TrigScint/Event/TrigScintTrack.cxx.o
[ 50%] Linking CXX shared library libTrigScint_Event.so
[ 50%] Built target TrigScint_Event
[ 57%] Building CXX object TrackingEvent/CMakeFiles/Tracking_Event.dir/src/Tracking/Event/Measurement.cxx.o
[ 57%] Building CXX object TrackingEvent/CMakeFiles/Tracking_Event.dir/src/Tracking/Event/RawSiStripHit.cxx.o
[ 57%] Building CXX object TrackingEvent/CMakeFiles/Tracking_Event.dir/src/Tracking/Event/Track.cxx.o
[ 57%] Linking CXX shared library libTracking_Event.so
[ 57%] Built target Tracking_Event
[ 64%] Generating EventDic.cxx, libEventDic_rdict.pcm, libEventDic.rootmap
<snip>
```

- [x] NA ~I attached any sub-module related changes to this PR.~