### PR TITLE
Change method for looking up recoil electron

### DIFF
--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -29,17 +29,16 @@ namespace Analysis {
 std::tuple<int, const ldmx::SimParticle*> getRecoil(
     const std::map<int, ldmx::SimParticle>& particleMap) {
   // The recoil electron is "produced" in the dark brem geneartion 
-  for (auto const& [trackID, particle] : particleMap) {
-	if (particle.getPdgID() == 11 and
-		particle.getProcessType() ==
-		ldmx::SimParticle::ProcessType::eDarkBrem) {
-	  return {trackID, &particle};
-	}
-	else if (particle.getPdgID() == 11 and trackID == 1) {
-	  // primary electron
-	  return {trackID, &particle};
-	}
+  for (const auto& [trackID, particle] : particleMap) {
+    if (particle.getPdgID() == 11 and 
+        particle.getProcessType() == 
+        ldmx::SimParticle::ProcessType::eDarkBrem) {
+      return {trackID, &particle};
+    }
   }
+  // only get here if recoil electron was not "produced" by dark brem
+  //   in this case (bkgd), we interpret the primary electron as also the recoil electron
+  return {1, &(particleMap.at(1))};
 }
 
 const ldmx::SimParticle* getPNGamma(

--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -28,8 +28,18 @@ namespace Analysis {
 
 std::tuple<int, const ldmx::SimParticle*> getRecoil(
     const std::map<int, ldmx::SimParticle>& particleMap) {
-  // The recoil electron always has a track ID of 1.
-  return {1, &(particleMap.at(1))};
+  // The recoil electron is "produced" in the dark brem geneartion 
+  for (auto const& [trackID, particle] : particleMap) {
+	if (particle.getPdgID() == 11 and
+		particle.getProcessType() ==
+		ldmx::SimParticle::ProcessType::eDarkBrem) {
+	  return {trackID, &particle};
+	}
+	else if (particle.getPdgID() == 11 and trackID == 1) {
+	  // primary electron
+	  return {trackID, &particle};
+	}
+  }
 }
 
 const ldmx::SimParticle* getPNGamma(


### PR DESCRIPTION
It now checks for DarkBrem origin, or, returns trackID 1 <-- this last point might need some more thought before merging. I'd like to b able to use this method for getting the recoil electron also for other processes than dark brem. 

### What are the issues that this addresses?
This resolves #1153 and the same issue [reported as a bug in the Ecal repo](https://github.com/LDMX-Software/Ecal/issues/46) 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.
I now see non-zero entries in the recoil momentum and containment variables collections. 
This was done with both re-recoing a small number of 1 GeV signal events produced with v3.2.2, and an inclusive e sample to see that things didn't break wildly. 

- [N/A] I attached any sub-module related changes to this PR.
