### PR TITLE
Patch getPNGamma so PhotoNuclearDQM doesn't crash

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -61,5 +61,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack, 
-        count, TriggerProcessor('trigger')
+        count, TriggerProcessor('trigger'),
+        dqm.PhotoNuclearDQM(verbose=True),
         ] + dqm.all_dqm)

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -61,5 +61,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack,
-        count, TriggerProcessor('trigger')
+        count, TriggerProcessor('trigger'),
+        dqm.PhotoNuclearDQM(verbose=False),
         ] + dqm.all_dqm)

--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -95,8 +95,11 @@ p.sequence.extend([
     trigScintTrack,
     count, TriggerProcessor('trigger'),
     dqm.SimObjects(sim_pass=thisPassName),
-    ecalDigiVerify,dqm.EcalShowerFeatures(), 
-    dqm.HCalDQM()]+dqm.recoil_dqm+dqm.trigger_dqm)
+    ecalDigiVerify,dqm.EcalShowerFeatures(),
+        dqm.PhotoNuclearDQM(verbose=False),
+    dqm.HCalDQM(),
+
+]+dqm.recoil_dqm+dqm.trigger_dqm)
 
 p.inputFiles = ['ecal_pn.root']
 p.outputFiles= ['events.root']

--- a/DQM/include/DQM/PhotoNuclearDQM.h
+++ b/DQM/include/DQM/PhotoNuclearDQM.h
@@ -70,6 +70,8 @@ class PhotoNuclearDQM : public framework::Analyzer {
   int classifyCompactEvent(
       const ldmx::SimParticle* pnGamma,
       const std::vector<const ldmx::SimParticle*> daughters, double threshold);
+
+  bool verbose_;
 };
 
 }  // namespace dqm

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -202,9 +202,10 @@ class PhotoNuclearDQM(ldmxcfg.Analyzer) :
         p.sequence.append( dqm.PhotoNuclearDQM() )
     """
 
-    def __init__(self,name='PN') :
+    def __init__(self,name='PN', verbose=False) :
         super().__init__(name,'dqm::PhotoNuclearDQM','DQM')
 
+        self.verbose = verbose
         self.build1DHistogram("event_type"         , "", 24, -1, 23)
         self.build1DHistogram("event_type_500mev"  , "", 24, -1, 23)
         self.build1DHistogram("event_type_2000mev" , "", 24, -1, 23)

--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -99,7 +99,9 @@ void PhotoNuclearDQM::onProcessStart() {
   }
 }
 
-void PhotoNuclearDQM::configure(framework::config::Parameters& parameters) {}
+void PhotoNuclearDQM::configure(framework::config::Parameters &parameters) {
+  verbose_ = parameters.getParameter<bool>("verbose");
+}
 
 void PhotoNuclearDQM::analyze(const framework::Event& event) {
   // Get the particle map from the event.  If the particle map is empty,
@@ -120,8 +122,10 @@ void PhotoNuclearDQM::analyze(const framework::Event& event) {
   // photo-nuclear reaction.
   auto pnGamma{Analysis::getPNGamma(particleMap, recoil, 2500.)};
   if (pnGamma == nullptr) {
-    std::cout << "[ PhotoNuclearDQM ]: PN Daughter is lost, skipping."
-              << std::endl;
+    if (verbose_) {
+      std::cout << "[ PhotoNuclearDQM ]: PN Daughter is lost, skipping."
+                << std::endl;
+    }
     return;
   }
 
@@ -484,6 +488,6 @@ std::vector<int> PhotoNuclearDQM::printDaughters(
   }
 }
 
-}  // namespace dqm
+} // namespace dqm
 
 DECLARE_ANALYZER_NS(dqm, PhotoNuclearDQM)

--- a/Tools/include/Tools/AnalysisUtils.h
+++ b/Tools/include/Tools/AnalysisUtils.h
@@ -21,13 +21,6 @@ namespace ldmx {
 class SimParticle;
 }
 
-/*
-struct TrackMaps {
-  std::unordered_map<int, const FindableTrackResult *> findable;
-  std::unordered_map<int, const FindableTrackResult *> loose;
-  std::unordered_map<int, const FindableTrackResult *> axial;
-};*/
-
 namespace Analysis {
 
 /**
@@ -38,7 +31,18 @@ namespace Analysis {
  * @return[out] Pointer to sim particle labeled as recoil electron (nullptr if
  * not found)
  */
-std::tuple<int, const ldmx::SimParticle *> getRecoil(
+std::tuple<int, const ldmx::SimParticle *>
+getRecoil(const std::map<int, ldmx::SimParticle> &particleMap);
+
+/**
+ * Helper function to getPNGamma. Checks if a particle has daughter particles
+ * produced by the photonNuclear process type that are present in the particle
+ * map.
+ *
+ * */
+
+bool doesParticleHavePNDaughters(
+    const ldmx::SimParticle &gamma,
     const std::map<int, ldmx::SimParticle> &particleMap);
 
 /**
@@ -57,16 +61,10 @@ std::tuple<int, const ldmx::SimParticle *> getRecoil(
  * @return[out] Pointer to sim particle labeled as PN Gamma photon (nullptr if
  * not found)
  */
-const ldmx::SimParticle *getPNGamma(
-    const std::map<int, ldmx::SimParticle> &particleMap,
-    const ldmx::SimParticle *recoil, const float &energyThreshold);
+const ldmx::SimParticle *
+getPNGamma(const std::map<int, ldmx::SimParticle> &particleMap,
+           const ldmx::SimParticle *recoil, const float &energyThreshold);
 
-/**
- * Sort tracks depending on how finable they are.
- */
-// TrackMaps getFindableTrackMaps(const std::vector<FindableTrackResult>
-// &tracks);
+} // namespace Analysis
 
-}  // namespace Analysis
-
-#endif  // _ANALYSIS_UTILS_H_
+#endif // _ANALYSIS_UTILS_H_

--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -15,7 +15,6 @@
 //----------//
 //   ldmx   //
 //----------//
-//#include "Event/FindableTrackResult.h"
 #include "Framework/Exception/Exception.h"
 #include "SimCore/Event/SimParticle.h"
 
@@ -26,72 +25,63 @@
 
 namespace Analysis {
 
-std::tuple<int, const ldmx::SimParticle*> getRecoil(
-    const std::map<int, ldmx::SimParticle>& particleMap) {
-  // The recoil electron is "produced" in the dark brem geneartion 
-  for (const auto& [trackID, particle] : particleMap) {
-    if (particle.getPdgID() == 11 and 
-        particle.getProcessType() == 
-        ldmx::SimParticle::ProcessType::eDarkBrem) {
+std::tuple<int, const ldmx::SimParticle *>
+getRecoil(const std::map<int, ldmx::SimParticle> &particleMap) {
+  // The recoil electron is "produced" in the dark brem geneartion
+  for (const auto &[trackID, particle] : particleMap) {
+    if (particle.getPdgID() == 11 and
+        particle.getProcessType() ==
+            ldmx::SimParticle::ProcessType::eDarkBrem) {
       return {trackID, &particle};
     }
   }
   // only get here if recoil electron was not "produced" by dark brem
-  //   in this case (bkgd), we interpret the primary electron as also the recoil electron
+  //   in this case (bkgd), we interpret the primary electron as also the recoil
+  //   electron
   return {1, &(particleMap.at(1))};
 }
 
-const ldmx::SimParticle* getPNGamma(
-    const std::map<int, ldmx::SimParticle>& particleMap,
-    const ldmx::SimParticle* recoil, const float& energyThreshold) {
-  // Get all of the daughter track IDs
-  auto daughterTrackIDs{recoil->getDaughters()};
+// Search the recoil electrons daughters for a photon
+// Check if the photon has daughters and if so, if they were produced by PN
+//
 
-  auto pit = std::find_if(
-      daughterTrackIDs.begin(), daughterTrackIDs.end(),
-      [energyThreshold, particleMap](const int& id) {
-        // Get the SimParticle from the map
-        auto daughter{particleMap.at(id)};
+bool doesParticleHavePNDaughters(
+    const ldmx::SimParticle &gamma,
+    const std::map<int, ldmx::SimParticle> &particleMap) {
+  for (auto daughterID : gamma.getDaughters()) {
+    if (particleMap.find(daughterID) != std::end(particleMap)) {
+      const auto daughter{particleMap.at(daughterID)};
+      const auto processType{daughter.getProcessType()};
+      if (processType == ldmx::SimParticle::ProcessType::photonNuclear) {
+        return true;
+      } // Was it PN?
+    }   // Was it in the map?
+  }
 
-        // If the particle doesn't have any daughters, return false
-        if (daughter.getDaughters().size() == 0
-            or 
-            particleMap.find(daughter.getDaughters().front()) != particleMap.end()
-           ) return false;
+  return false;
+}
 
-        // If the particle has daughters that were a result of a
-        // photo-nuclear reaction, and its energy is above threshold,
-        // then tag it as the PN gamma.
-        return (
-            (particleMap.at(daughter.getDaughters().front()).getProcessType() ==
-             ldmx::SimParticle::ProcessType::photonNuclear) &&
-            (daughter.getEnergy() >= energyThreshold));
-      });
-
-  // If a PN daughter was found, return it.
-  if (pit != daughterTrackIDs.end()) return &particleMap.at(*pit);
-
+const ldmx::SimParticle *
+getPNGamma(const std::map<int, ldmx::SimParticle> &particleMap,
+           const ldmx::SimParticle *recoil, const float &energyThreshold) {
+  auto recoilDaughters{recoil->getDaughters()};
+  for (auto recoilDaughterID : recoilDaughters) {
+    // Have we stored the recoil daughter?
+    if (particleMap.find(recoilDaughterID) != std::end(particleMap)) {
+      auto recoilDaughter{particleMap.at(recoilDaughterID)};
+      // Is it a gamma?
+      if (recoilDaughter.getPdgID() == 22) {
+        // Does it have enough energy?
+        if (recoilDaughter.getEnergy() >= energyThreshold) {
+          // Are its daughters PN products?
+          if (doesParticleHavePNDaughters(recoilDaughter, particleMap)) {
+            return &particleMap.at(recoilDaughterID);
+          }
+        }
+      }
+    }
+  }
   return nullptr;
 }
 
-/*
-TrackMaps getFindableTrackMaps(const std::vector<FindableTrackResult> &tracks) {
-
-    TrackMaps map;
-
-    for (const FindableTrackResult &track : tracks ) {
-        if (track.is4sFindable() || track.is3s1aFindable() ||
-track.is2s2aFindable()) { map.findable[track.getParticleTrackID()] =  &track;
-        }
-
-        if (track.is2sFindable()) map.loose[track.getParticleTrackID()] =
-&track;
-
-        if (track.is2aFindable()) map.axial[track.getParticleTrackID()] =
-&track;
-    }
-
-    return map;
-}*/
-
-}  // namespace Analysis
+} // namespace Analysis


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1069 by rewriting the getPNGamma function. I'm still not sure what the issue with the original code was but this rewrite should be solid. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.

- [x] I ran my developments and the following shows that they are successful.

I ran the Ecal PN validation sample and added in the PhotoNuclearDQM and it ran without issue. Hard to compare it with existing validation because we currently aren't running it as part of the validation routine. However, I did run it on my own samples with single neutron events only/nothing hard events only and checked that they were all classified correctly. From running a quick grep over the codebase, the `getPNGamma` function isn't used anywhere outside of the PN DQM so nowhere else that we can check. In principle, we could add some test cases though.


