### PR TITLE
patch location of gamma->mumu conversions

### DIFF
--- a/Biasing/python/ecal.py
+++ b/Biasing/python/ecal.py
@@ -74,3 +74,56 @@ def photo_nuclear( detector, generator ) :
     ])
 
     return sim
+
+def gamma_mumu(detector, generator) :
+    """Example configuration for biasing gamma to mu+ mu- conversions in the ecal.
+
+    In this particular example, 4 GeV elecrons are fired upstream of the
+    tagger tracker. The TargetBremFilter filters out all events that don't
+    produce a brem in the target with an energy greater than 2.5 GeV.
+
+    Parameters
+    ----------
+
+    detector : str
+        Path to the detector
+
+    Returns
+    -------
+    Instance of the sim configured for target gamma to muon conversions.
+
+    Example
+    -------
+
+        ecal_mumu_sim = ecal.gamma_mumu('ldmx-det-v12')
+
+    """
+
+    # Initiate the sim
+    sim = simulator.simulator("ecal_gammamumu")
+
+    # Set the path to the detector to use
+    # Also tell the simulator to include scoring planes
+    sim.setDetector( detector, True )
+
+    # Set run parameters
+    sim.description = "gamma --> mu+ mu-, xsec bias 3e4"
+    sim.beamSpotSmear = [20., 80., 0.]
+
+    sim.generators.append(generator)
+
+    # Enable and configure the biasing
+    sim.biasing_operators = [ bias_operators.GammaToMuPair('ecal', 3.E4, 2500.) ]
+
+    # the following filters are in a library that needs to be included
+    includeBiasing.library()
+
+    # Configure the sequence in which user actions should be called
+    sim.actions.extend([
+            filters.TaggerVetoFilter(),
+            filters.TargetBremFilter(),
+            filters.EcalProcessFilter(process='GammaToMuPair'),
+            util.TrackProcessFilter.gamma_mumu()
+    ])
+
+    return sim

--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -161,7 +161,7 @@ def gamma_mumu( detector, generator ) :
     sim.generators.append(generator)
 
     # Enable and configure the biasing
-    sim.biasing_operators = [ bias_operators.GammaToMuPair('target', 1.E6, 2500.) ]
+    sim.biasing_operators = [ bias_operators.GammaToMuPair('target', 1.E4, 2500.) ]
 
     # the following filters are in a library that needs to be included
     includeBiasing.library()
@@ -169,8 +169,10 @@ def gamma_mumu( detector, generator ) :
     # Configure the sequence in which user actions should be called.
     sim.actions.extend([
             # Only consider events where a hard brem occurs
+            filters.TaggerVetoFilter(),
             filters.TargetBremFilter(),
-            filters.TargetGammaMuMuFilter()
+            filters.TargetGammaMuMuFilter(),
+            util.TrackProcessFilter.gamma_mumu()
     ])
 
     return sim

--- a/Biasing/python/util.py
+++ b/Biasing/python/util.py
@@ -93,6 +93,15 @@ class TrackProcessFilter(BiasingUtilityAction):
         """
         return TrackProcessFilter('DarkBrem')
 
+    def gamma_mumu() :
+        """ Configuration used to tag all gamma --> mu+ mu- tracks to persist them to the event.
+
+        Return
+        ------
+        Instance of TrackProcessFilter configured to tag gamma --> mu+ mu- tracks.
+        """
+        return TrackProcessFilter('GammaToMuPair')
+
 class DecayChildrenKeeper(BiasingUtilityAction):
     """ Configuration used to store children of specific particle decays
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves an issue previously shown at a [sw-development meeting](https://indico.fnal.gov/event/58826/) (viewing this requires Indico access) in which muon conversion simulations create hard brem photons upstream of the target.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

<img width="831" alt="gammamumu_validation_1" src="https://github.com/LDMX-Software/ldmx-sw/assets/76532377/ca11057f-7bb9-4b9b-b1a4-9fb899a92a77">

The start z position of the hard brem before (left) and after (right) the change is implemented.

<img width="784" alt="Screenshot 2023-06-22 at 11 12 53 AM" src="https://github.com/LDMX-Software/ldmx-sw/assets/76532377/19872a35-6f6d-49f2-9854-91106502c9d5">

The start z position of the daughter particles of the hard brem before (left) and after (right) the change is implemented for a target gamma --> mu+ mu- simulation.

<img width="570" alt="gammamumu_validation_2" src="https://github.com/LDMX-Software/ldmx-sw/assets/76532377/b77b9a39-8ecc-425c-aa0a-ac5458c143c2">

The start z position of the daughter particles of the hard brem after the change is implemented for an Ecal gamma --> mu+ mu- simulation with a biasing factor of 3e4.

A short presentation on this change will be given at a future sw-development meeting.

- [x] I attached any sub-module related changes to this PR.
