### PR TITLE
Add new CaloCluster event class

### DIFF
--- a/Recon/CMakeLists.txt
+++ b/Recon/CMakeLists.txt
@@ -18,6 +18,8 @@ if(BUILD_EVENT_ONLY)
 
   register_event_object(module_path "Recon/Event" namespace "ldmx" 
                         class "CalorimeterHit" type "collection" )
+  register_event_object(module_path "Recon/Event" namespace "ldmx" 
+                        class "CaloCluster" type "collection" )
   register_event_object( module_path "Recon/Event" namespace "ldmx" 
                          class "TriggerResult" )
   register_event_object( module_path "Recon/Event" namespace "ldmx" 

--- a/Recon/include/Recon/Event/CaloCluster.h
+++ b/Recon/include/Recon/Event/CaloCluster.h
@@ -1,0 +1,165 @@
+/**
+ * @file CaloCluster.h
+ * @brief Class that stores calorimeter cluster information
+ */
+
+#ifndef EVENT_CALOCLUSTER_H_
+#define EVENT_CALOCLUSTER_H_
+
+// ROOT
+#include "TObject.h"  //For ClassDef
+#include "TString.h"
+
+// STL
+#include <iostream>
+#include <set>
+
+// ldmx-sw
+#include "Recon/Event/CalorimeterHit.h"
+
+namespace ldmx {
+
+/**
+ * @class CaloCluster
+ * @brief Stores cluster information from the ECal
+ */
+class CaloCluster {
+ public:
+  /**
+   * Class constructor.
+   */
+  CaloCluster();
+
+  /**
+   * Class destructor.
+   */
+  virtual ~CaloCluster();
+
+  /**
+   * Print a description of this object.
+   */
+  void Print() const;
+
+  /**
+   * Reset the CaloCluster object.
+   */
+  void Clear();
+
+  /**
+   * Take in the hits that make up the cluster.
+   * @param hit The digi hit's entry number in the events digi
+   * collection.
+   */
+  void addHits(const std::vector<const ldmx::CalorimeterHit*> hitsVec);
+
+  /**
+   * Sets total energy for the cluster.
+   * @param energy The total energy of the cluster.
+   */
+  void setEnergy(double energy) { energy_ = energy; }
+  
+  /**
+   * Sets total number of hits in the cluster.
+   * @param nHits The total number of hits.
+   */
+  void setNHits(int nHits) { nHits_ = nHits; }
+  
+  /**
+   * Sets a sorted vector for the IDs of the hits
+   * that make up the cluster.
+   * @param IDs Sorted vector of hit IDs.
+   */
+  void setIDs(std::vector<unsigned int>& hitIDs) { hitIDs_ = hitIDs; }
+
+  void setHitValsX(std::vector<float>& x) { hitX_ = x; }
+  void setHitValsY(std::vector<float>& x) { hitY_ = x; }
+  void setHitValsZ(std::vector<float>& x) { hitZ_ = x; }
+  void setHitValsE(std::vector<float>& x) { hitE_ = x; }
+
+  /**
+   * Sets the three coordinates of the cluster centroid
+   * @param x The x coordinate.
+   * @param y The y coordinate.
+   * @param z The z coordinate.
+   */
+  void setCentroidXYZ(double x, double y, double z) {
+    centroidX_ = x;
+    centroidY_ = y;
+    centroidZ_ = z;
+  }
+  void setRMSXYZ(double x, double y, double z) {
+    rmsX_ = x;
+    rmsY_ = y;
+    rmsZ_ = z;
+  }
+  void setDXDZ(double x) { DXDZ_=x; }
+
+  void setDYDZ(double x) { DYDZ_=x; }
+
+  void setEDXDZ(double x) { errDXDZ_=x; }
+
+  void setEDYDZ(double x) { errDYDZ_=x; }
+  
+  /////////////////////////////////////////////
+
+  // energy of cluster
+  double getEnergy() const { return energy_; }
+  
+  // number of hits - equivalent to number of strips
+  int getNHits() const { return nHits_; }
+
+  // position (weighted by energy)
+  double getCentroidX() const { return centroidX_; }
+  double getCentroidY() const { return centroidY_; }
+  double getCentroidZ() const { return centroidZ_; }
+  double getRMSX() const { return rmsX_; }
+  double getRMSY() const { return rmsY_; }
+  double getRMSZ() const { return rmsZ_; }
+
+  double getDXDZ() const { return DXDZ_; }
+
+  double getDYDZ() const { return DYDZ_; }
+
+  double getEDXDZ() const { return errDXDZ_; }
+
+  double getEDYDZ() const { return errDYDZ_; }
+
+  // get hit rawIDs (unused)
+  const std::vector<unsigned int>& getHitIDs() const { return hitIDs_; }
+
+  // ability to store limited hit info
+  const std::vector<float>& getHitX() const { return hitX_; }
+  const std::vector<float>& getHitY() const { return hitY_; }
+  const std::vector<float>& getHitZ() const { return hitZ_; }
+  const std::vector<float>& getHitE() const { return hitE_; }
+  
+  bool operator<(const CaloCluster& rhs) const {
+    return this->getEnergy() < rhs.getEnergy();
+  }
+
+ protected:
+  std::vector<unsigned int> hitIDs_;
+  double energy_{0};
+  int nHits_{0};
+  double centroidX_{0};
+  double centroidY_{0};
+  double centroidZ_{0};
+  double rmsX_{0};
+  double rmsY_{0};
+  double rmsZ_{0};
+  double DXDZ_{0};
+  double DYDZ_{0};
+  double errDXDZ_{0};
+  double errDYDZ_{0};
+  std::vector<float> hitX_;
+  std::vector<float> hitY_;
+  std::vector<float> hitZ_;
+  std::vector<float> hitE_;
+
+ private:
+
+  ClassDef(CaloCluster, 1);
+};
+}  // namespace ldmx
+
+#endif

--- a/Recon/src/Recon/Event/CaloCluster.cxx
+++ b/Recon/src/Recon/Event/CaloCluster.cxx
@@ -1,0 +1,42 @@
+#include "Recon/Event/CaloCluster.h"
+
+ClassImp(ldmx::CaloCluster)
+
+namespace ldmx {
+  CaloCluster::CaloCluster() {}
+
+  CaloCluster::~CaloCluster() { Clear(); }
+
+  void CaloCluster::Print() const {
+    std::cout << "CaloCluster { "
+              << "Energy: " << energy_ << ", "
+              << "Number of hits: " << nHits_ << " }" << std::endl;
+  }
+
+  void CaloCluster::Clear() {
+    hitIDs_.clear();
+    energy_ = 0;
+    nHits_ = 0;
+    centroidX_ = 0;
+    centroidY_ = 0;
+    centroidZ_ = 0;
+    rmsX_ = 0;
+    rmsY_ = 0;
+    rmsZ_ = 0;
+    DXDZ_ = 0;
+    DYDZ_ = 0;
+    errDXDZ_ = 0;
+    errDYDZ_ = 0;
+  }
+
+  void CaloCluster::addHits(const std::vector<const CalorimeterHit *> hitsVec) {
+    std::vector<unsigned int> vecIDs;
+    for (unsigned int iHit = 0; iHit < hitsVec.size(); iHit++) {
+      vecIDs.push_back(hitsVec[iHit]->getID());
+    }
+    setIDs(vecIDs);
+  }
+
+      
+
+}  // namespace ldmx


### PR DESCRIPTION
I'm adding a new CaloCluster class that EcalCluster and HcalCluster can inherit from, in order to reduce code duplication and increase usability of existing tools aiming at one class or the other.

### What are the issues that this addresses?
This is the first step needed to resolve #1177 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I re-ran clustering locally with an EcalCluster prototype based on this base class. Results were unchanged wrt the previous implementation.

I leave updates to the submodules for future work/reviews, and will follow that progress in the issue reference above.
