### PR TITLE
Iss1181 - Hcal position reconstruction + geometry verifier

### DIFF
--- a/DQM/include/DQM/HcalGeometryVerifier.h
+++ b/DQM/include/DQM/HcalGeometryVerifier.h
@@ -1,0 +1,59 @@
+#ifndef HCALGEOMETRYVERIFIER_H
+#define HCALGEOMETRYVERIFIER_H
+#include <TCanvas.h>
+
+#include <iomanip>
+#include <sstream>
+
+#include "DetDescr/HcalGeometry.h"
+#include "DetDescr/HcalID.h"
+#include "Framework/Configure/Parameters.h"
+#include "Framework/Event.h"
+#include "Framework/EventProcessor.h"
+#include "Hcal/Event/HcalHit.h"
+#include "SimCore/Event/SimCalorimeterHit.h"
+
+namespace dqm {
+
+class HcalGeometryVerifier : public framework::Analyzer {
+ public:
+  HcalGeometryVerifier(const std::string &name, framework::Process &process)
+      : framework::Analyzer{name, process} {}
+  void configure(framework::config::Parameters &parameters) override;
+  /*
+   *
+   * Determine which of x/y/z corresponds to the direction along, across, and
+   * through the bar respectively. Along corresponding to the length of the bar,
+   * across to the width of the bar, and through to the thickness of the bar.
+   *
+   *
+   */
+  std::array<int, 3> determine_indices(const ldmx::HcalID id);
+
+  /*
+   *
+   * Check if the hit at position `position` is within the bounds of the
+   * scintillator bar with HcalID `id`.
+   *
+   * @note: On error, this function will raise an exception if `stop_on_error`
+   * is set to true or log the issue if false.
+   *
+   */
+  bool hit_ok(const ldmx::HcalID id, const std::array<double, 3> &position);
+
+  void analyze(const framework::Event &event) override;
+
+ private:
+  std::string hcalSimHitsCollection_{"HcalSimHits"};
+  std::string hcalRecHitsCollection_{"HcalRecHits"};
+  std::string hcalSimHitsPassName_{""};
+  std::string hcalRecHitsPassName_{""};
+
+  // Maximum difference between position and bounds of the scintillator bar that
+  // will be accepted [mm]
+  double tolerance{};
+  bool stop_on_error{};
+};
+}  // namespace dqm
+
+#endif /* HCALGEOMETRYVERIFIER_H */

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -1,6 +1,44 @@
 """Configuration for DQM analyzers"""
 
 from LDMX.Framework import ldmxcfg
+
+class HCalGeometryVerifier(ldmxcfg.Analyzer) :
+    """Configured HCalGeometryVerifier python object
+
+    Contains an instance of the verifier that has already been configured.
+
+    This analyzer verifies that all simhits and rechits for the hcal are within
+    the bounds of the scintillator strips as set in the geometry condition.
+
+    If the analyzer encounters an error and `stop_on_error` is true, raises an
+    exception with details about the issue. Otherwise, the error is logged and
+    histograms for each section is produced.
+
+    Examples
+    --------
+        from LDMX.DQM import dqm
+        p.sequence.append( dqm.HcalGeometryVerifier() )
+
+    """
+
+    def __init__(self,name="hcal_geometry_verifier", stop_on_error=False) :
+        section_names = ['back', 'top', 'bottom', 'right', 'left']
+        super().__init__(name,'dqm::HcalGeometryVerifier','DQM')
+        self.rec_coll_name = 'HcalRecHits'
+        self.rec_pass_name = ''
+        self.sim_coll_name = 'HcalSimHits'
+        self.sim_pass_name = ''
+        self.stop_on_error=stop_on_error
+        self.tolerance=1e-3 # mm
+        self.build1DHistogram('passes_sim', 'Simulated hits within scintillator bounds?', 2, 0,2)
+        self.build1DHistogram('passes_rec', 'Reconstructed hits within scintillator bounds?', 2, 0,2)
+        section_names = ['back', 'top', 'bottom', 'right', 'left']
+        for name in section_names:
+            self.build1DHistogram(f'passes_sim_{name}', f'Simulated hits within scintillator bounds? ({name})', 2, 0,2)
+            self.build1DHistogram(f'passes_rec_{name}', f'Reconstructed hits within scintillator bounds? Passing ({name})', 2, 0,2)
+
+
+
 class HCalDQM(ldmxcfg.Analyzer) :
     """Configured HCalDQM python object
 

--- a/DQM/src/DQM/HcalGeometryVerfifier.cxx
+++ b/DQM/src/DQM/HcalGeometryVerfifier.cxx
@@ -1,0 +1,188 @@
+#include "DQM/HcalGeometryVerifier.h"
+namespace dqm {
+
+void HcalGeometryVerifier::configure(
+    framework::config::Parameters &parameters) {
+  hcalSimHitsCollection_ =
+      parameters.getParameter<std::string>("sim_coll_name");
+  hcalRecHitsCollection_ =
+      parameters.getParameter<std::string>("rec_coll_name");
+  hcalSimHitsPassName_ = parameters.getParameter<std::string>("sim_pass_name");
+  hcalRecHitsPassName_ = parameters.getParameter<std::string>("rec_pass_name");
+  stop_on_error = parameters.getParameter<bool>("stop_on_error");
+  tolerance = parameters.getParameter<double>("tolerance");
+}
+void HcalGeometryVerifier::analyze(const framework::Event &event) {
+  const auto hcalSimHits = event.getCollection<ldmx::SimCalorimeterHit>(
+      hcalSimHitsCollection_, hcalSimHitsPassName_);
+  const auto hcalRecHits = event.getCollection<ldmx::HcalHit>(
+      hcalRecHitsCollection_, hcalRecHitsPassName_);
+
+  for (const auto &hit : hcalSimHits) {
+    const ldmx::HcalID id{hit.getID()};
+    const auto position{hit.getPosition()};
+    auto ok{hit_ok(id, {position[0], position[1], position[2]})};
+    histograms_.fill("passes_sim", ok);
+    switch (id.section()) {
+      case ldmx::HcalID::HcalSection::BACK:
+        histograms_.fill("passes_sim_back", ok);
+        break;
+      case ldmx::HcalID::HcalSection::TOP:
+        histograms_.fill("passes_sim_top", ok);
+        break;
+      case ldmx::HcalID::HcalSection::BOTTOM:
+        histograms_.fill("passes_sim_bottom", ok);
+        break;
+      case ldmx::HcalID::HcalSection::LEFT:
+        histograms_.fill("passes_sim_left", ok);
+        break;
+      case ldmx::HcalID::HcalSection::RIGHT:
+        histograms_.fill("passes_sim_right", ok);
+        break;
+    }
+  }
+  for (const auto &hit : hcalRecHits) {
+    const ldmx::HcalID id{hit.getID()};
+    auto ok{hit_ok(id, {hit.getXPos(), hit.getYPos(), hit.getZPos()})};
+    histograms_.fill("passes_rec", ok);
+    switch (id.section()) {
+      case ldmx::HcalID::HcalSection::BACK:
+        histograms_.fill("passes_rec_back", ok);
+        break;
+      case ldmx::HcalID::HcalSection::TOP:
+        histograms_.fill("passes_rec_top", ok);
+        break;
+      case ldmx::HcalID::HcalSection::BOTTOM:
+        histograms_.fill("passes_rec_bottom", ok);
+        break;
+      case ldmx::HcalID::HcalSection::LEFT:
+        histograms_.fill("passes_rec_left", ok);
+        break;
+      case ldmx::HcalID::HcalSection::RIGHT:
+        histograms_.fill("passes_rec_right", ok);
+        break;
+    }
+  }
+
+}  // Analyze
+bool HcalGeometryVerifier::hit_ok(const ldmx::HcalID id,
+                                  const std::array<double, 3> &position) {
+  const auto &geometry = getCondition<ldmx::HcalGeometry>(
+      ldmx::HcalGeometry::CONDITIONS_OBJECT_NAME);
+  auto [index_along, index_across, index_through]{determine_indices(id)};
+  const auto center{geometry.getStripCenterPosition(id)};
+  const auto length{geometry.getScintillatorLength(id)};
+  bool outside_bounds_along{
+      std::abs(position[index_along] - center[index_along]) >
+      length / 2 + tolerance};
+
+  const auto width{geometry.getScintillatorWidth()};
+  bool outside_bounds_across{
+      std::abs(position[index_across] - center[index_across]) >
+      width / 2 + tolerance};
+
+  const auto thickness{geometry.getScintillatorThickness()};
+  bool outside_bounds_through{
+      std::abs(position[index_through] - center[index_through]) >
+      thickness / 2 + tolerance};
+
+  if (outside_bounds_along || outside_bounds_across || outside_bounds_through) {
+    std::stringstream ss;
+    if (tolerance < 1) {
+      // Assume tolerance is of form 1e-N
+      //
+      // Set precision so it will be clear if it is a floating point precision
+      // issue or a problem
+      ss.precision(-std::log10(tolerance) + 1);
+    }
+    ss << std::boolalpha;
+    double x{position[0]};
+    double y{position[1]};
+    double z{position[2]};
+    ss << id << " has hit position at (" << x << ", " << y << ", " << z
+       << ")\nwhich is not within the bounds of the Hcal strip center ("
+       << center[0] << ", " << center[1] << ", " << center[2]
+       << ") with tolerance " << tolerance << std::endl;
+    ss << "Position along the bar: " << position[index_along] << " outside "
+       << center[index_along] << " +- " << length / 2 << "? "
+       << outside_bounds_along << std::endl;
+    ss << "Position across the bar: " << position[index_across] << " outside "
+       << center[index_across] << " +- " << width / 2 << "? "
+       << outside_bounds_across << std::endl;
+    ss << "Position through the bar: " << position[index_through] << " outside "
+       << center[index_through] << " +- " << thickness / 2 << "? "
+       << outside_bounds_through << std::endl;
+
+    if (stop_on_error) {
+      EXCEPTION_RAISE("InvalidPosition", ss.str());
+    } else {
+      ldmx_log(warn) << ss.str();
+    }
+    return false;
+  }
+  return true;
+}
+std::array<int, 3> HcalGeometryVerifier::determine_indices(
+    const ldmx::HcalID id) {
+  const auto &geometry = getCondition<ldmx::HcalGeometry>(
+      ldmx::HcalGeometry::CONDITIONS_OBJECT_NAME);
+  const auto orientation{geometry.getScintillatorOrientation(id)};
+  const auto isLR{id.section() == ldmx::HcalID::HcalSection::LEFT ||
+                  id.section() == ldmx::HcalID::HcalSection::RIGHT};
+
+  int index_along{};
+  int index_across{};
+  int index_through{};
+  if (id.section() == ldmx::HcalID::HcalSection::BACK) {
+    index_through = 2;  // z
+    if (orientation ==
+        ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
+      index_along = 0;   // x
+      index_across = 1;  // y
+    } else {
+      index_across = 0;  // x
+      index_along = 1;   // y
+    }
+  } else if (geometry.hasSide3DReadout()) {
+    switch (orientation) {
+      case ldmx::HcalGeometry::ScintillatorOrientation::horizontal:
+        index_across = 2;   // z
+        index_along = 0;    // x
+        index_through = 1;  // y
+        // Horizontal bar in side hcal -> x length, z width, y thick
+        break;
+      case ldmx::HcalGeometry::ScintillatorOrientation::vertical:
+        // Vertical bar in side hcal -> y length, z width, x thick
+        index_across = 2;   // z
+        index_along = 1;    // y
+        index_through = 0;  // x
+        break;
+      case ldmx::HcalGeometry::ScintillatorOrientation::depth:
+        index_along = 2;  // z
+        if (isLR) {
+          // Depth bar in side hcal (LR) -> z length, x thick, y width
+          index_through = 0;  // x
+          index_across = 1;   // y
+        } else {
+          // Depth bar in side hcal (TB) -> z length, y thick, x width
+          index_through = 1;  // y
+          index_across = 0;   // x
+        }
+        break;
+    }
+  } else {
+    // v12 Side hcal
+    index_across = 2;  // z
+    if (orientation ==
+        ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
+      index_along = 0;    // x
+      index_through = 1;  // y
+    } else {
+      index_along = 1;    // y
+      index_through = 0;  // x
+    }
+  }
+  return {index_along, index_across, index_through};
+}
+}  // namespace dqm
+DECLARE_ANALYZER_NS(dqm, HcalGeometryVerifier);

--- a/DetDescr/include/DetDescr/HcalGeometry.h
+++ b/DetDescr/include/DetDescr/HcalGeometry.h
@@ -32,7 +32,7 @@ class HcalGeometryProvider;
  *
  */
 class HcalGeometry : public framework::ConditionsObject {
-public:
+ public:
   /**
    * Conditions object:
    *  The name of the python configuration calling this class
@@ -60,8 +60,8 @@ public:
    */
   ~HcalGeometry() = default;
 
-  ScintillatorOrientation
-  getScintillatorOrientation(const ldmx::HcalID id) const;
+  ScintillatorOrientation getScintillatorOrientation(
+      const ldmx::HcalID id) const;
 
   /**
    * Get a strip center position from a combined hcal ID.
@@ -187,11 +187,10 @@ public:
    * does not have a dependency on Geant4/CLHEP so we are taking the position
    * as a vector of floats (which is what is used by SimCalorimeterHit)
    **/
-  std::vector<double>
-  rotateGlobalToLocalBarPosition(const std::vector<double> &globalPosition,
-                                 const ldmx::HcalID &id) const;
+  std::vector<double> rotateGlobalToLocalBarPosition(
+      const std::vector<double> &globalPosition, const ldmx::HcalID &id) const;
 
-private:
+ private:
   /**
    * Class constructor, for use only by the provider
    *
@@ -230,7 +229,7 @@ private:
     }
   }
 
-private:
+ private:
   /// Parameters that apply to all types of geometries
   /// Verbosity, not configurable but helpful if developing
   int verbose_{0};
@@ -259,6 +258,7 @@ private:
 
   // Offset of the entire Hcal geometry in y (mm)
   double y_offset_;
+
   // Defines what parity (0/1, i.e. even/odd parity) of a layer number in the
   // geometry that corresponds to a horizontal layer (scintillator bar length
   // along the x-axis) in the back HCal.
@@ -285,6 +285,6 @@ private:
   std::map<ldmx::HcalID, TVector3> strip_position_map_;
 };
 
-} // namespace ldmx
+}  // namespace ldmx
 
 #endif

--- a/DetDescr/include/DetDescr/HcalGeometry.h
+++ b/DetDescr/include/DetDescr/HcalGeometry.h
@@ -257,6 +257,8 @@ private:
   double ecal_dx_;
   double ecal_dy_;
 
+  // Offset of the entire Hcal geometry in y (mm)
+  double y_offset_;
   // Defines what parity (0/1, i.e. even/odd parity) of a layer number in the
   // geometry that corresponds to a horizontal layer (scintillator bar length
   // along the x-axis) in the back HCal.

--- a/DetDescr/include/DetDescr/HcalGeometry.h
+++ b/DetDescr/include/DetDescr/HcalGeometry.h
@@ -116,6 +116,11 @@ class HcalGeometry : public framework::ConditionsObject {
   double getScintillatorWidth() const { return scint_width_; }
 
   /**
+   * Get the scitillator thickness
+   */
+  double getScintillatorThickness() const { return scint_thickness_; }
+
+  /**
    * Get the number of sections.
    */
   int getNumSections() const { return num_sections_; }

--- a/DetDescr/python/HcalGeometry.py
+++ b/DetDescr/python/HcalGeometry.py
@@ -40,6 +40,8 @@ class HcalReadoutGeometry:
         0.
     back_horizontal_parity:
         Layers with odd parity (1) are horizontal on the x-axis in the back HCal
+    y_offset
+        Offset of the entire Hcal geometry to be taken into account
     """
 
     def __init__(self):
@@ -61,6 +63,7 @@ class HcalReadoutGeometry:
         self.verbose = 0
         self.back_horizontal_parity = 1
         self.side_3d_readout = 0
+        self.y_offset=0.
 
     def __str__(self):
         """Stringify this configuration class"""
@@ -78,6 +81,7 @@ class HcalReadoutGeometry:
                 Scintillator length: {} [mm]
             }},
             Ecal DX, DY: {}, {} [mm],
+            Y offset: {},
             Valid detector regexps: {}
         }}
         """.format(
@@ -93,6 +97,7 @@ class HcalReadoutGeometry:
             self.scint_length,
             self.ecal_dx,
             self.ecal_dy,
+            self.y_offset,
             self.detectors_valid,
         )
         return s
@@ -194,6 +199,8 @@ class HcalGeometry:
         # along the x-axis) in the back hcal
         self.v13.back_horizontal_parity = 1
         self.v13.side_3d_readout = 0
+        # TODO: Check this
+        self.v13.y_offset = 0.
 
     def make_v1_prototype(self):
         """Create the HcalGeometry with the testbeam prototype geometry parameters"""
@@ -247,6 +254,8 @@ class HcalGeometry:
         # along the x-axis) in the back HCal
         self.v1_prototype.back_horizontal_parity = 1
         self.v1_prototype.side_3d_readout = 0
+        # TODO: Check this
+        self.v1_prototype.y_offset = 0.
 
     def make_v2_prototype(self):
         """Create the HcalGeometry with the testbeam prototype geometry parameters"""
@@ -310,6 +319,8 @@ class HcalGeometry:
         # along the x-axis) in the back HCal
         self.v2_prototype.back_horizontal_parity = 0
         self.v2_prototype.side_3d_readout = 0
+        # TODO: Check this
+        self.v2_prototype.y_offset = 0.
 
     def make_v14(self):
         self.v14 = HcalReadoutGeometry()
@@ -475,3 +486,4 @@ class HcalGeometry:
             zero_strip_side[3],
         ]
         self.v14.detectors_valid = ["ldmx-det-v14"]
+        self.v14.y_offset = 19.05

--- a/DetDescr/python/HcalGeometry.py
+++ b/DetDescr/python/HcalGeometry.py
@@ -395,13 +395,6 @@ class HcalGeometry:
         self.v14.side_num_modules = side_hcal_numModules
         # In back hcal: odd layers are horizontal, even layers are vertical
         self.v14.back_horizontal_parity = 1
-        # In side hcal: odd layers have strips oriented in z
-        zero_strip_odd = [
-            -ecal_side_dx / 2.0,
-            ecal_side_dx / 2.0,
-            -ecal_side_dy / 2.0,
-            ecal_side_dy / 2.0,
-        ]
 
         self.v14.scint_length = [[back_hcal_scint_length for layer in range(back_hcal_numLayers)],
                                  [0.] * side_hcal_numTotalLayers, # Filled below
@@ -440,6 +433,12 @@ class HcalGeometry:
                     half_total_width_side.append(side_hcal_scint_length[m] / 2)
                     num_strips_side.append(int(side_hcal_numScintZ[m]))
 
+        zero_strip_odd = [
+            -ecal_side_dx / 2.0,  # Top
+            ecal_side_dx / 2.0,   # Bottom
+            -ecal_side_dy / 2.0,  # Right
+            ecal_side_dy / 2.0,   # Left
+        ]
         zero_strip_side = []
         for s in range(side_hcal_numSections):
             zero_strip_section = []

--- a/DetDescr/python/HcalGeometry.py
+++ b/DetDescr/python/HcalGeometry.py
@@ -433,6 +433,8 @@ class HcalGeometry:
                     half_total_width_side.append(side_hcal_scint_length[m] / 2)
                     num_strips_side.append(int(side_hcal_numScintZ[m]))
 
+        # In side hcal: odd layers have strips oriented in z
+        zero_strip_even = ecal_front_z
         zero_strip_odd = [
             -ecal_side_dx / 2.0,  # Top
             ecal_side_dx / 2.0,   # Bottom
@@ -445,7 +447,7 @@ class HcalGeometry:
             for m in range(self.v14.side_num_modules):
                 for l in range(side_hcal_numLayers[m] * 2):
                     if (l + 1) % 2 == 0:
-                        zero_strip_section.append(ecal_front_z)
+                        zero_strip_section.append(zero_strip_even)
                     else:
                         zero_strip_section.append(zero_strip_odd[s])
             zero_strip_side.append(zero_strip_section)

--- a/DetDescr/src/DetDescr/HcalGeometry.cxx
+++ b/DetDescr/src/DetDescr/HcalGeometry.cxx
@@ -119,6 +119,11 @@ HcalGeometry::ScintillatorOrientation HcalGeometry::getScintillatorOrientation(
     case ldmx::HcalID::HcalSection::LEFT:
     case ldmx::HcalID::HcalSection::RIGHT:
       return ScintillatorOrientation::vertical;
+    case ldmx::HcalID::HcalSection::BACK:
+      // Configurable
+      return id.layer() % 2 == back_horizontal_parity_
+                 ? ScintillatorOrientation::horizontal
+                 : ScintillatorOrientation::vertical;
   }  // v13/v12 detector
 }
 void HcalGeometry::printPositionMap(int section) const {

--- a/DetDescr/src/DetDescr/HcalGeometry.cxx
+++ b/DetDescr/src/DetDescr/HcalGeometry.cxx
@@ -25,8 +25,8 @@ HcalGeometry::HcalGeometry(const framework::config::Parameters &ps)
 
   auto detectors_valid =
       ps.getParameter<std::vector<std::string>>("detectors_valid");
-  // If one of the strings in detectors_valid is "ldmx-hcal-prototype", we will
-  // use prototype geometry initialization
+  // If one of the strings in detectors_valid is "ldmx-hcal-prototype", we
+  // will use prototype geometry initialization
   is_prototype_ = std::find_if(detectors_valid.cbegin(), detectors_valid.cend(),
                                [](const auto detector) {
                                  return detector.find("ldmx-hcal-prototype") !=
@@ -41,86 +41,85 @@ HcalGeometry::HcalGeometry(const framework::config::Parameters &ps)
       ps.getParameter<std::vector<std::vector<double>>>("scint_length");
 
   buildStripPositionMap();
+
   if (verbose_ > 0) {
     printPositionMap();
   }
 }
-
 std::vector<double> HcalGeometry::rotateGlobalToLocalBarPosition(
     const std::vector<double> &globalPosition, const ldmx::HcalID &id) const {
   const auto orientation{getScintillatorOrientation(id)};
   switch (id.section()) {
-  case ldmx::HcalID::HcalSection::BACK:
-    switch (orientation) {
-    case ScintillatorOrientation::horizontal:
-      return {globalPosition[2], globalPosition[1], globalPosition[0]};
-    case ScintillatorOrientation::vertical:
-      return {globalPosition[2], globalPosition[0], globalPosition[1]};
-    }
-  case ldmx::HcalID::HcalSection::TOP:
-  case ldmx::HcalID::HcalSection::BOTTOM:
-    switch (orientation) {
-    case ScintillatorOrientation::horizontal:
-      return {globalPosition[1], globalPosition[2], globalPosition[0]};
-    case ScintillatorOrientation::depth:
-      return {globalPosition[1], globalPosition[0], globalPosition[2]};
-    }
-  case ldmx::HcalID::HcalSection::LEFT:
-  case ldmx::HcalID::HcalSection::RIGHT:
-    switch (orientation) {
-    case ScintillatorOrientation::vertical:
-      return {globalPosition[0], globalPosition[2], globalPosition[1]};
-    case ScintillatorOrientation::depth:
-      return globalPosition;
-    }
+    case ldmx::HcalID::HcalSection::BACK:
+      switch (orientation) {
+        case ScintillatorOrientation::horizontal:
+          return {globalPosition[2], globalPosition[1], globalPosition[0]};
+        case ScintillatorOrientation::vertical:
+          return {globalPosition[2], globalPosition[0], globalPosition[1]};
+      }
+    case ldmx::HcalID::HcalSection::TOP:
+    case ldmx::HcalID::HcalSection::BOTTOM:
+      switch (orientation) {
+        case ScintillatorOrientation::horizontal:
+          return {globalPosition[1], globalPosition[2], globalPosition[0]};
+        case ScintillatorOrientation::depth:
+          return {globalPosition[1], globalPosition[0], globalPosition[2]};
+      }
+    case ldmx::HcalID::HcalSection::LEFT:
+    case ldmx::HcalID::HcalSection::RIGHT:
+      switch (orientation) {
+        case ScintillatorOrientation::vertical:
+          return {globalPosition[0], globalPosition[2], globalPosition[1]};
+        case ScintillatorOrientation::depth:
+          return globalPosition;
+      }
   }
 }
 
-HcalGeometry::ScintillatorOrientation
-HcalGeometry::getScintillatorOrientation(const ldmx::HcalID id) const {
+HcalGeometry::ScintillatorOrientation HcalGeometry::getScintillatorOrientation(
+    const ldmx::HcalID id) const {
   if (hasSide3DReadout()) {
     // v14 or later detector
     switch (id.section()) {
-    case ldmx::HcalID::HcalSection::TOP:
-    case ldmx::HcalID::HcalSection::BOTTOM:
-      // Odd layers are in z/depth direction, even are in the x/horizontal
-      // direction
-      return id.layer() % 2 == 0 ? ScintillatorOrientation::horizontal
-                                 : ScintillatorOrientation::depth;
+      case ldmx::HcalID::HcalSection::TOP:
+      case ldmx::HcalID::HcalSection::BOTTOM:
+        // Odd layers are in z/depth direction, even are in the x/horizontal
+        // direction
+        return id.layer() % 2 == 0 ? ScintillatorOrientation::horizontal
+                                   : ScintillatorOrientation::depth;
 
-    case ldmx::HcalID::HcalSection::LEFT:
-    case ldmx::HcalID::HcalSection::RIGHT:
-      // Odd layers are in the z/depth direction, even are in the y/vertical
-      // direction
-      return id.layer() % 2 == 0 ? ScintillatorOrientation::vertical
-                                 : ScintillatorOrientation::depth;
-    case ldmx::HcalID::HcalSection::BACK:
-      // Configurable
-      return id.layer() % 2 == back_horizontal_parity_
-                 ? ScintillatorOrientation::horizontal
-                 : ScintillatorOrientation::vertical;
-    } // V14 or later detector
+      case ldmx::HcalID::HcalSection::LEFT:
+      case ldmx::HcalID::HcalSection::RIGHT:
+        // Odd layers are in the z/depth direction, even are in the y/vertical
+        // direction
+        return id.layer() % 2 == 0 ? ScintillatorOrientation::vertical
+                                   : ScintillatorOrientation::depth;
+      case ldmx::HcalID::HcalSection::BACK:
+        // Configurable
+        return id.layer() % 2 == back_horizontal_parity_
+                   ? ScintillatorOrientation::horizontal
+                   : ScintillatorOrientation::vertical;
+    }  // V14 or later detector
   }
   if (isPrototype()) {
-
     // The prototype only has the back section. However, the orientation
     // depends on the configuration so we delegate to the
     // back_horizontal_parity parameter
     return id.layer() % 2 == back_horizontal_parity_
                ? ScintillatorOrientation::horizontal
                : ScintillatorOrientation::vertical;
-  } // Prototype detector
+  }  // Prototype detector
   // v13/v12
   switch (id.section()) {
-  // For the v13 side hcal, the bars in each section have the same
-  // orientation
-  case ldmx::HcalID::HcalSection::TOP:
-  case ldmx::HcalID::HcalSection::BOTTOM:
-    return ScintillatorOrientation::horizontal;
-  case ldmx::HcalID::HcalSection::LEFT:
-  case ldmx::HcalID::HcalSection::RIGHT:
-    return ScintillatorOrientation::vertical;
-  } // v13/v12 detector
+    // For the v13 side hcal, the bars in each section have the same
+    // orientation
+    case ldmx::HcalID::HcalSection::TOP:
+    case ldmx::HcalID::HcalSection::BOTTOM:
+      return ScintillatorOrientation::horizontal;
+    case ldmx::HcalID::HcalSection::LEFT:
+    case ldmx::HcalID::HcalSection::RIGHT:
+      return ScintillatorOrientation::vertical;
+  }  // v13/v12 detector
 }
 void HcalGeometry::printPositionMap(int section) const {
   // Note that layer numbering starts at 1 rather than 0
@@ -136,6 +135,7 @@ void HcalGeometry::printPositionMap(int section) const {
     }
   }
 }
+
 void HcalGeometry::buildStripPositionMap() {
   // We hard-code the number of sections as seen in HcalID
   for (int section = 0; section < num_sections_; section++) {
@@ -163,18 +163,19 @@ void HcalGeometry::buildStripPositionMap() {
              For back Hcal:
              - layers in z
              - strips occupy thickness of scintillator in z (e.g. 20mm)
-             - strips orientation is in x(y) depending on back_horizontal parity
+             - strips orientation is in x(y) depending on back_horizontal
+             parity
           */
           // z position: zero-layer(z) + layer_z + scint_thickness / 2
           z = zero_layer_.at(section) + layercenter;
 
           /**
-            Now compute, y(x) position for horizontal(vertical) layers, relative
-            to the center of detector. Strips enumeration starts from -y(-x)
-            stripcenter will be large for +y(+x) and the half width of the strip
-            needs to be subtracted The halfwidth of the scintillator is given by
-            half_total_width_.
-            The x(y) position is set to the center of the strip (0).
+            Now compute, y(x) position for horizontal(vertical) layers,
+            relative to the center of detector. Strips enumeration starts from
+            -y(-x) stripcenter will be large for +y(+x) and the half width of
+            the strip needs to be subtracted The halfwidth of the scintillator
+            is given by half_total_width_. The x(y) position is set to the
+            center of the strip (0).
           */
           if (orientation == ScintillatorOrientation::horizontal) {
             y = stripcenter - getZeroStrip(section, layer);
@@ -236,9 +237,9 @@ void HcalGeometry::buildStripPositionMap() {
         TVector3 pos;
         pos.SetXYZ(x, y, z);
         strip_position_map_[ldmx::HcalID(section, layer, strip)] = pos;
-      } // loop over strips
-    }   // loop over layers
-  }     // loop over sections
-} // strip position map
+      }  // loop over strips
+    }    // loop over layers
+  }      // loop over sections
+}  // strip position map
 
-} // namespace ldmx
+}  // namespace ldmx

--- a/DetDescr/src/DetDescr/HcalGeometry.cxx
+++ b/DetDescr/src/DetDescr/HcalGeometry.cxx
@@ -21,6 +21,7 @@ HcalGeometry::HcalGeometry(const framework::config::Parameters &ps)
   verbose_ = ps.getParameter<int>("verbose");
   back_horizontal_parity_ = ps.getParameter<int>("back_horizontal_parity");
   side_3d_readout_ = ps.getParameter<int>("side_3d_readout");
+  y_offset_ = ps.getParameter<double>("y_offset");
 
   auto detectors_valid =
       ps.getParameter<std::vector<std::string>>("detectors_valid");
@@ -230,6 +231,8 @@ void HcalGeometry::buildStripPositionMap() {
             }
           }
         }
+
+        y += y_offset_;
         TVector3 pos;
         pos.SetXYZ(x, y, z);
         strip_position_map_[ldmx::HcalID(section, layer, strip)] = pos;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1181 and patches one part of #1166 (missing case statement in `getScintillatorOrientation`. 

This updates the hcal geometry condition so that the map of strip centers aligns with the GDML. I will say that there almost certainly are more elegant expressions than what I ended up using, so if anyone has a suggestion then feel more than free to suggest them. 

One thing which caused me quite a lot of headache before I caught it was that _the entire Hcal geometry is offset by 19.05 mm in y_. I'm not entirely sure why this is, but I've added a configuration parameter that handles this. 

Since this was quite fiddly, I wanted to make sure we really got this right so I also added an analyzer in the DQM module which goes through all simulated and reconstructed hits in the hcal and checks if the position is within the bounding box of the corresponding scintillator bar. For the v14 geometry this is 100% correct, excluding reco issues in https://github.com/LDMX-Software/ldmx-sw/issues/1348. 

I have not gone through a similar exercise for v12.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.
See analyzer above.

- [x] I attached any sub-module related changes to this PR.
N/A

### Related Sub-Module PRs
N/A 
