### PR TITLE
bump ldmx/pro base image to ldmx/dev:v4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #   for the development image, look at the LDMX-Software/docker repo
 ###############################################################################
 
-FROM ldmx/dev:v3.5.0
+FROM ldmx/dev:v4.0.0
 
 # install ldmx-sw into the container at /usr/local
 COPY . /code


### PR DESCRIPTION
The OS update will eventually cause breaking changes and so I'm pre-emptively updating the base image for the production container to the new version.

I am going to merge #1186 first and if dependabot does its job. This PR will be overshadowed by a auto-generated one by the bot.