### PR TITLE
Change default ElectronCounter input collection name

### DIFF
--- a/Recon/python/electronCounter.py
+++ b/Recon/python/electronCounter.py
@@ -16,7 +16,7 @@ class ElectronCounter(ldmxcfg.Producer) :
     def __init__(self,nSimBeamElectrons,name="ElectronCounter") :
         super().__init__(name,'recon::ElectronCounter','Recon')
 
-        self.input_collection = "TriggerPadTracks"
+        self.input_collection = "TriggerPadTracksY"
         self.input_pass_name = "truth"
         self.output_collection = "BeamElectronCount"
         self.simulated_electron_number = nSimBeamElectrons


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1163

The validation config https://github.com/LDMX-Software/ldmx-sw/blob/trunk/.github/validation_samples/inclusive/config.py currently gives the following msg per event:
```
[ ElectronCounter ] 4 : Attemping to use non-existing input collection TriggerPadTracks_ to count electrons! Exiting.
```

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

The print-out statements about the wrong collection are gone.

- [x] I attached any sub-module related changes to this PR.

N/A

