### PR TITLE
add check on actions we use

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this will check and bump actions versions we use in our workflows when they are released, it checks once a week which is plenty of time given our pace of development

This also is a double check that the PR Validation action updates in #1198 were successful since this change obviously does not change the code and so should pass the validations.