### PR TITLE
fatal error if we detect an in-source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,18 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
 endif()
 
+# make sure the source and binary directories are different
+# this is here to prevent so-called "in-source" builds where the root directory of the source
+# is also the root directory of the build
+get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+if ("${srcdir}" STREQUAL "${bindir}")
+  message(FATAL_ERROR "ldmx-sw does not support in-source builds.\n"
+    "  Call 'ldmx cmake ..' from within a 'build/' subdirectory or\n"
+    "  Tell cmake to use a different build directory with 'ldmx cmake -B build -S .'"
+  )
+endif()
+
 # Clear any variables cached during previous configuration cycles. 
 clear_cache_variables()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,17 @@
 # Set the minimum version of CMake that's required 
 cmake_minimum_required(VERSION 3.12)
 
+# make sure the source and binary directories are different
+# this is here to prevent so-called "in-source" builds where the root directory of the source
+# is also the root directory of the build
+get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+if ("${srcdir}" STREQUAL "${bindir}")
+  message(FATAL_ERROR "ldmx-sw does not support in-source builds.
+  Call 'ldmx cmake ..' from within a 'build/' subdirectory or
+  Tell cmake to use a different build directory with 'ldmx cmake -B build -S .'")
+endif()
+
 # Set the project name
 project(LDMX_SW VERSION 3.1.1
                 DESCRIPTION "The Light Dark Matter eXperiment simulation and reconstruction framework." 
@@ -38,18 +49,6 @@ set(default_build_type "Release")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
     set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
-endif()
-
-# make sure the source and binary directories are different
-# this is here to prevent so-called "in-source" builds where the root directory of the source
-# is also the root directory of the build
-get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
-get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
-if ("${srcdir}" STREQUAL "${bindir}")
-  message(FATAL_ERROR "ldmx-sw does not support in-source builds.\n"
-    "  Call 'ldmx cmake ..' from within a 'build/' subdirectory or\n"
-    "  Tell cmake to use a different build directory with 'ldmx cmake -B build -S .'"
-  )
 endif()
 
 # Clear any variables cached during previous configuration cycles. 


### PR DESCRIPTION
We don't want in source builds and we can ensure this at the first build step by requiring the full path to the binary and source directories to be different.
