### PR TITLE
1220 filter and handle missing entries in the validation module

### DIFF
--- a/Validation/src/Validation/__main__.py
+++ b/Validation/src/Validation/__main__.py
@@ -45,6 +45,9 @@ if __name__ == '__main__' :
     parser.add_argument('--param',
                         nargs='+',
                         help='parameter(s) in filename to use as file labels')
+    parser.add_argument('--input-files', nargs='+', type=str,
+                        help="""Specify the name of the root files directly (either
+                        full/relative path or name of files in the input data directory)""")
 
     arg = parser.parse_args()
 
@@ -79,8 +82,17 @@ if __name__ == '__main__' :
 
     logging.debug(f'Deduced Args: label = {label} out_dir = {out_dir}')
 
-    root_files = [ File.from_path(os.path.join(data,f), legendlabel_parameter = arg.param) 
-        for f in os.listdir(data) if f.endswith('.root') ]
+    if arg.input_files:
+        input_files = [os.path.join(data, f)
+                       if not f.startswith(data)
+                       else f
+                       for f in arg.input_files
+                       ]
+        root_files = [File.from_path(f, legendlabel_parameter=arg.param)
+                      for f in input_files]
+    else:
+        root_files = [ File.from_path(os.path.join(data,f), legendlabel_parameter = arg.param)
+                       for f in os.listdir(data) if f.endswith('.root') ]
 
     logging.debug(f'ROOT Files: {root_files}')
 

--- a/Validation/src/Validation/__main__.py
+++ b/Validation/src/Validation/__main__.py
@@ -45,6 +45,9 @@ if __name__ == '__main__' :
     parser.add_argument('--param',
                         nargs='+',
                         help='parameter(s) in filename to use as file labels')
+    parser.add_argument('--input-file-filter', type=str,
+                        help="""Filter which root files in the input data directory to
+                        use using a regular expression""")
     parser.add_argument('--input-files', nargs='+', type=str,
                         help="""Specify the name of the root files directly (either
                         full/relative path or name of files in the input data directory)""")
@@ -93,6 +96,12 @@ if __name__ == '__main__' :
     else:
         root_files = [ File.from_path(os.path.join(data,f), legendlabel_parameter = arg.param)
                        for f in os.listdir(data) if f.endswith('.root') ]
+
+    if arg.input_file_filter:
+        # Not sure if this can be done in one step so doing it in two
+        filtered_files = [f for f in root_files
+                          if re.search(arg.input_file_filter, f.path) ]
+        root_files = filtered_files
 
     logging.debug(f'ROOT Files: {root_files}')
 

--- a/Validation/src/Validation/_differ.py
+++ b/Validation/src/Validation/_differ.py
@@ -7,6 +7,7 @@ import re
 # external dependencies
 import matplotlib.pyplot as plt
 import matplotlib
+import uproot
 # us
 from ._file import File
 
@@ -110,7 +111,11 @@ class Differ :
         ax = fig.subplots()
 
         for f in self.files :
-            weights, bins, patches = f.plot1d(ax, column, **hist_kwargs)
+            try:
+                weights, bins, patches = f.plot1d(ax, column, **hist_kwargs)
+            except uproot.KeyInFileError:
+                f.log.warn(f"Key {column} doesn't exist in {self}, skipping")
+                continue
 
         ax.set_xlabel(xlabel)
         ax.set_ylabel(ylabel)

--- a/Validation/src/Validation/_file.py
+++ b/Validation/src/Validation/_file.py
@@ -28,7 +28,6 @@ class File :
         self.__file = uproot.open(filepath, **open_kwargs)
         self.__colmod = colmod
         self.__df = None
-        self.path = filepath
 
         if 'histtype' not in hist_kwargs :
             hist_kwargs['histtype'] = 'step'
@@ -105,7 +104,12 @@ class File :
         Otherwise, we assume that it is a histogram file.
         """
         return 'LDMX_Events' in self.__file
-    
+
+    @property
+    def path(self):
+        """Retrun the path to the file on disk"""
+        return self.__file.file_path
+
     def events(self, **kwargs) :
         """Callback for retrieving a full in-memory data frame of the events
         

--- a/Validation/src/Validation/_file.py
+++ b/Validation/src/Validation/_file.py
@@ -28,6 +28,7 @@ class File :
         self.__file = uproot.open(filepath, **open_kwargs)
         self.__colmod = colmod
         self.__df = None
+        self.path = filepath
 
         if 'histtype' not in hist_kwargs :
             hist_kwargs['histtype'] = 'step'


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

I've added two new command line parameters for the validation module, one which lets you specify exactly which files you want to compare (as opposed to all files in the input data directory). You can either specify the name of a file in the input directory or give the entire path to the file.  The other parameter lets you filter the list of root-files (a use-case for this in my case would be filtering on the number of events in a pile of files). 

Also added an exception handling step in Differ to handle missing histograms gracefully. 

Example usage: 
Assuming you have three files in the hists/ folder 
- ecal_trunk_10000_events.root 
- ecal_trunk_100_events.root 
- ecal_PR_10000_events.root
- hcal_trunk_10000_events.root 

Running 
```
ldmx python3 -m Validation hists --input-files ecal_trunk_10000_events.root hists/ecal_PR_10000_events.root  ...
```
Would only plot the two ecal files with 10k events 
Running 
```
ldmx python3 -m Validation hists --input-file-filter="ecal" ...
```
Would use the three files including "ecal" in the name 

etc 
### What are the issues that this addresses?
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
This resolves #1220  
## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.
Tested both the new parameters and handling of missing histograms. Worked like a charm :) 

- [x] I attached any sub-module related changes to this PR.
N/A

### Related Sub-Module PRs
N/A 
