### PR TITLE
1230 add the ability to updatereset environment variables

### DIFF
--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -391,21 +391,28 @@ __ldmx_setenv() {
   fi
 
   local envName=$(echo $_env_to_set | cut -d= -f1)
+  local KEY=$(echo $_env_to_set | cut -d= -f1)
+  local VALUE=$(echo $_env_to_set | cut -d= -f2-) # Field 2 and any further fields
+  local key_exists=false
 
-  # Loop over the indices of the array
-  for i in "${!LDMX_CONTAINER_ENVS[@]}"; do
-    # If the first part (the part before the =) matches the environment variable
-    # we are trying to update
-    #
-    # (cut -d= -f1) means cut the input using the = as delimeter and pick the first field
-    if [[ $(echo "${LDMX_CONTAINER_ENVS[$i]}" | cut -d= -f1) = $envName ]]; then
-      echo "Updating ${envName}: ${LDMX_CONTAINER_ENVS[$i]} -> $_env_to_set"
-      LDMX_CONTAINER_ENVS[$i]=$_env_to_set
-      export LDMX_CONTAINER_ENVS
-      return 0
+  for entry in "${!LDMX_CONTAINER_ENVS[@]}"; do
+    entry_key=$(echo "${LDMX_CONTAINER_ENVS[$entry]}" | cut -d= -f1)
+    if [ -z "${entry_key}" ]; then
+      continue
+    fi
+    if [ "${KEY}" == "${entry_key}" ]; then
+      echo "Updating environment variable ${KEY}: ${LDMX_CONTAINER_ENVS[$entry]} -> ${KEY}=${VALUE}"
+      LDMX_CONTAINER_ENVS[$entry]="${KEY}=${VALUE}"
+      key_exists=true
+      break
     fi
   done
-  LDMX_CONTAINER_ENVS+="$_env_to_set "
+  if [ "${key_exists}" == "false" ]; then
+    LDMX_CONTAINER_ENVS+=("${KEY}=${VALUE}")
+  fi
+
+
+  # Loop over the indices of the array
   export LDMX_CONTAINER_ENVS
   echo "Added container environment variable $_env_to_set"
   return 0

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -392,11 +392,17 @@ __ldmx_setenv() {
 
   local envName=$(echo $_env_to_set | cut -d= -f1)
 
-  for _already_set in ${LDMX_CONTAINER_ENVS[@]}; do
-    if [[ $(echo $_already_set | cut -d= -f1) = $envName ]]; then
-		echo "Already set a variable called $(echo $_already_set | cut -d= -f1);"
-		echo "Try a different name or re-source the setup script to clean your list."
-		return 1
+  # Loop over the indices of the array
+  for i in "${!LDMX_CONTAINER_ENVS[@]}"; do
+    # If the first part (the part before the =) matches the environment variable
+    # we are trying to update
+    #
+    # (cut -d= -f1) means cut the input using the = as delimeter and pick the first field
+    if [[ $(echo "${LDMX_CONTAINER_ENVS[$i]}" | cut -d= -f1) = $envName ]]; then
+      echo "Updating ${envName}: ${LDMX_CONTAINER_ENVS[$i]} -> $_env_to_set"
+      LDMX_CONTAINER_ENVS[$i]=$_env_to_set
+      export LDMX_CONTAINER_ENVS
+      return 0
     fi
   done
   LDMX_CONTAINER_ENVS+="$_env_to_set "


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1230  and contributes to the work that @bryngemark started with #1089 with https://github.com/LDMX-Software/ldmx-sw/pull/1095. It changes the behavior of `ldmx setenv` so that attempting to set an existing environment variable will update it rather than fail 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.
```shell
# Set up fresh environment 
> . scripts/ldmx-env.sh 
# Set foo to bar 
> ldmx setenv foo=bar
Added container environment variable foo=bar
# Check 
> ldmx config 
LDMX base directory: /Users/einarelen/ldmx
uname: Darwin velka.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Oct  4 21:26:23 PDT 2023; root:xnu-8796.141.3.701.17~4/RELEASE_ARM64_T6000 arm64
OSTYPE: darwin22
Bash version: 3.2.57(1)-release
Display Port: docker.for.mac.host.internal
Container Mounts: /Users/einarelen/ldmx
Container Environments: foo=bar
Docker Version: Docker version 24.0.6, build ed223bc
Docker Tag: ldmx/dev:latest
    Digest: ldmx/dev@sha256:7ee91da9328805f219dd4188e3d71571e2a29c933aab0a50f931524fd9b3a529
    
# Adding a new entry should update the container so that both entries are in the list 
> ldmx setenv baz=bonk 
Added container environment variable baz=bonk
> ldmx config 
LDMX base directory: /Users/einarelen/ldmx
uname: Darwin velka.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Oct  4 21:26:23 PDT 2023; root:xnu-8796.141.3.701.17~4/RELEASE_ARM64_T6000 arm64
OSTYPE: darwin22
Bash version: 3.2.57(1)-release
Display Port: docker.for.mac.host.internal
Container Mounts: /Users/einarelen/ldmx
Container Environments: foo=bar baz=bonk
Docker Version: Docker version 24.0.6, build ed223bc
Docker Tag: ldmx/dev:latest
    Digest: ldmx/dev@sha256:7ee91da9328805f219dd4188e3d71571e2a29c933aab0a50f931524fd9b3a529
# Adding an entry that already exists should update it 
> ldmx setenv foo=crimes 
Updating environment variable foo: foo=bar -> foo=crimes
Added container environment variable foo=crimes
> ldmx config 
LDMX base directory: /Users/einarelen/ldmx
uname: Darwin velka.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Oct  4 21:26:23 PDT 2023; root:xnu-8796.141.3.701.17~4/RELEASE_ARM64_T6000 arm64
OSTYPE: darwin22
Bash version: 3.2.57(1)-release
Display Port: docker.for.mac.host.internal
Container Mounts: /Users/einarelen/ldmx
Container Environments: foo=crimes baz=bonk
Docker Version: Docker version 24.0.6, build ed223bc
Docker Tag: ldmx/dev:latest
    Digest: ldmx/dev@sha256:7ee91da9328805f219dd4188e3d71571e2a29c933aab0a50f931524fd9b3a529
# Final check, check the actual environment inside the container 
> ldmx env | grep foo 
foo=crimes
> ldmx env | grep baz 
baz=bonk
```

