### PR TITLE
Issue #1239 bug fix

### DIFF
--- a/DQM/src/DQM/SampleValidation.cxx
+++ b/DQM/src/DQM/SampleValidation.cxx
@@ -36,7 +36,7 @@ namespace dqm {
 	if (parent_track_id == 0) {
 	  histograms_.fill("pdgid_primaries", pdgid_label(pdgid));
 	  histograms_.fill("energy_primaries", energy);
-	  hard_thresh = (2500/4000)*energy;
+	  hard_thresh = (2500./4000.)*energy;
 	  primary_daughters = daughters;
 	  for (const ldmx::SimTrackerHit &sphit : targetSPHits) {
 	    if (sphit.getTrackID() == it.first && sphit.getPosition()[2] < 0) {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves issue #1239 which was causing the variable hard_thresh to be assigned 0 instead of an appropriate fraction of the beam energy. The fraction (2500/4000) was replaced with (2500./4000.) so that the variable does not get converted to int.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful. I have attached two plots of the start/end z position of the "hard" primary daughter. See #1239 for how these plots look before bug fix.

![startZ_hardbrem](https://github.com/LDMX-Software/ldmx-sw/assets/76532377/5c1bbbff-3ea8-472e-8e84-1de8b8579e42)
![endZ_hardbrem](https://github.com/LDMX-Software/ldmx-sw/assets/76532377/f2be3699-74a9-43ed-aeb6-b827c894e79b)

We are now seeing hard primary daughters starting in the target and ending in the ecal, as expected for an ecal PN simulation. Print statements of the variable hard_thresh also confirm it is being assigned a value 2500 MeV on a 4 GeV beam simulation instead of 0 MeV.

Sorry for the inconvenience this oversight has caused!
