### PR TITLE
Update beam energy and thresholds in simpleTrigger.py

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -5,7 +5,8 @@ p.maxTriesPerEvent = 10000
 
 from LDMX.Biasing import ecal
 from LDMX.SimCore import generators as gen
-mySim = ecal.photo_nuclear('ldmx-det-v14',gen.single_4gev_e_upstream_tagger())
+det = 'ldmx-det-v14'
+mySim = ecal.photo_nuclear(det,gen.single_4gev_e_upstream_tagger())
 mySim.beamSpotSmear = [20.,80.,0.]
 mySim.description = 'ECal PN Test Simulation'
 
@@ -62,6 +63,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack, 
-        count, TriggerProcessor('trigger'),
+        count, TriggerProcessor('trigger', 4000.),
         dqm.PhotoNuclearDQM(verbose=True),
         ] + dqm.all_dqm)

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -3,7 +3,8 @@ p = ldmxcfg.Process('test')
 
 from LDMX.SimCore import simulator as sim
 mySim = sim.simulator( "mySim" )
-mySim.setDetector( 'ldmx-det-v14-8gev', True )
+det = 'ldmx-det-v14-8gev'
+mySim.setDetector(det, True )
 from LDMX.SimCore import generators as gen
 mySim.generators.append( gen.single_8gev_e_upstream_tagger() )
 mySim.beamSpotSmear = [20.,80.,0.]
@@ -62,6 +63,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack,
-        count, TriggerProcessor('trigger'),
+        count, TriggerProcessor('trigger', 8000.),
         dqm.PhotoNuclearDQM(verbose=False),
         ] + dqm.all_dqm)

--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -12,6 +12,7 @@ pileupFilePassName="test"
 thisPassName="overlay"
 p=ldmxcfg.Process(thisPassName)
 
+det = 'ldmx-det-v14'
 p.run = int(os.environ['LDMX_RUN_NUMBER'])
 p.maxEvents = int(os.environ['LDMX_NUM_EVENTS'])
 p.termLogLevel = 0
@@ -94,7 +95,7 @@ p.sequence.extend([
     TrigScintClusterProducer.pad2(),
     TrigScintClusterProducer.pad3(),
     trigScintTrack,
-    count, TriggerProcessor('trigger'),
+    count, TriggerProcessor('trigger', 4000.),
     dqm.SimObjects(sim_pass=thisPassName),
     ecalDigiVerify,dqm.EcalShowerFeatures(),
         dqm.PhotoNuclearDQM(verbose=False),

--- a/.github/validation_samples/signal/config.py
+++ b/.github/validation_samples/signal/config.py
@@ -4,6 +4,7 @@ p = ldmxcfg.Process('test')
 p.maxTriesPerEvent = 10000
 
 from LDMX.Biasing import target
+det = 'ldmx-det-v14-8gev'
 mySim = target.dark_brem(
     #A' mass in MeV - set in init.sh to same value in GeV
     10.0,
@@ -11,7 +12,7 @@ mySim = target.dark_brem(
     #   easiest way to find this path out is by running `. init.sh` locally to see what
     #   is produced
     'electron_tungsten_MaxE_8.0_MinE_4.0_RelEStep_0.1_UndecayedAP_mA_0.01_run_1',
-    'ldmx-det-v14-8gev'
+    det
 )
 
 p.sequence = [ mySim ]
@@ -67,6 +68,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack, 
-        count, TriggerProcessor('trigger'),
+        count, TriggerProcessor('trigger', 8000.),
         dqm.DarkBremInteraction()
         ] + dqm.all_dqm)

--- a/Detectors/test/lyso_signal_10MeV_config.py
+++ b/Detectors/test/lyso_signal_10MeV_config.py
@@ -3,6 +3,7 @@ p = ldmxcfg.Process('test')
 
 p.maxTriesPerEvent = 10000
 
+det = 'ldmx-lyso-r1-v14-8gev'
 from LDMX.Biasing import target
 mySim = target.dark_brem(
     #A' mass in MeV - set in init.sh to same value in GeV
@@ -11,7 +12,7 @@ mySim = target.dark_brem(
     #   easiest way to find this path out is by running `. init.sh` locally to see what
     #   is produced
     'electron_lutetiumyttriumsiliconoxygen_MaxE_8.0_MinE_4.0_RelEStep_0.1_UndecayedAP_mA_0.01_run_3000',
-    'ldmx-lyso-r1-v14-8gev'
+    det
 )
 
 p.sequence = [ mySim ]
@@ -67,6 +68,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack, 
-        count, TriggerProcessor('trigger'),
+        count, TriggerProcessor('trigger', 8000.),
         dqm.DarkBremInteraction()
         ] + dqm.all_dqm)

--- a/Detectors/test/reducedLDMX_eGun_config.py
+++ b/Detectors/test/reducedLDMX_eGun_config.py
@@ -16,7 +16,8 @@ myGun.pdgID = 11
 myGun.enablePoisson = False #True   
 
 mySim = sim.simulator( "mySim" ) # Build simulator object
-mySim.setDetector( 'ldmx-reduced-v1', True )
+det = 'ldmx-reduced-v1'
+mySim.setDetector(det, True )
 mySim.beamSpotSmear = [20.,80.,0.]
 mySim.description = 'Reduced ECal Electron Gun Test Simulation'
 
@@ -72,6 +73,6 @@ p.sequence.extend([
         TrigScintClusterProducer.pad2(),
         TrigScintClusterProducer.pad3(),
         trigScintTrack, 
-        count, TriggerProcessor('trigger'),
+        count, TriggerProcessor('trigger', 4000.),
 #        ] + dqm.all_dqm)
         ])

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -36,11 +36,11 @@ from LDMX.Framework import ldmxcfg
 class TriggerProcessor(ldmxcfg.Producer) :
     """Configuration for the (multi-electron aware but simple) trigger on the ECal reco hits"""
 
-    def __init__(self,name) :
+    def __init__(self, name, beamEnergy) :
         super().__init__(name,'recon::TriggerProcessor','Recon')
-
-        self.beamEnergy = 8000.
-        self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]  #toy something up 
+          
+        self.beamEnergy = beamEnergy
+        self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]
         self.mode = 0
         self.start_layer = 0
         self.end_layer = 20
@@ -48,5 +48,5 @@ class TriggerProcessor(ldmxcfg.Producer) :
         self.input_pass = ''
         self.trigger_collection = "Trigger"
 
-simpleTrigger = TriggerProcessor("simpleTrigger")
+simpleTrigger = TriggerProcessor("simpleTrigger", 8000.)
 

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -39,8 +39,8 @@ class TriggerProcessor(ldmxcfg.Producer) :
     def __init__(self,name) :
         super().__init__(name,'recon::TriggerProcessor','Recon')
 
-        self.beamEnergy = 4000.
-        self.thresholds = [ 1500.0, 1000. + self.beamEnergy, 500. + 2*self.beamEnergy, 100. + 3*self.beamEnergy ]  #toy something up 
+        self.beamEnergy = 8000.
+        self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]  #toy something up 
         self.mode = 0
         self.start_layer = 0
         self.end_layer = 20


### PR DESCRIPTION
Added in some changes to the trigger processor defaults that I came across when setting up for Ecal PN production. Adding this to the list of changes needed for the filters and biasing etc, tracked in #1229. This will cause changes to gold histograms insofar as there are any for the trigger processor (less strict threshold when properly taking the higher beam energy into account --> more will pass)

### What are the issues that this addresses?
Partial solution to #1229. 
