### PR TITLE
start performance plotting within Validation py module

### DIFF
--- a/Validation/src/Validation/__init__.py
+++ b/Validation/src/Validation/__init__.py
@@ -8,3 +8,4 @@ from . import hcal
 from . import photonuclear
 from . import dark_brem
 from . import simparticles
+from . import performance

--- a/Validation/src/Validation/performance.py
+++ b/Validation/src/Validation/performance.py
@@ -1,0 +1,25 @@
+"""Plotting of performance plots"""
+
+from ._differ import Differ
+from ._plotter import plotter
+import logging
+
+log = logging.getLogger('performance')
+
+@plotter(hist=True,event=False)
+def event_timing(d : Differ, out_dir = None) :
+    """Plot time it took to process events
+
+    Parameters
+    ----------
+    d : Differ
+        Differ containing files that are not event files (presumably histogram files)
+    """
+
+    # just plotting the __ALL__ branch which represents all processors in the sequence,
+    # however, if we introduce some introspection into the Differ class, we could deduce
+    # the other branch names and plot the duration of different processors specifically
+    for processor in ['__ALL__']:
+        branch = f'performance/by_event/{processor}./{processor}.duration_'
+        log.info(f'plotting event time for {processor}')
+        d.plot1d(branch, f'{processor} Event Time [s]', out_dir = out_dir, legend_kw = dict(loc='upper right'))


### PR DESCRIPTION
I wanted to show the time separation between 4GeV and 8GeV and I figured
this is a general enough plot that it should go into Validation.

This just plots the `__ALL__` duration since I couldn't find an obvious
way to deduce what the processor names were given the current
infrastructure. The `__ALL__` duration is just timing how long the entire
event takes to process (including all processors). The plot I show in my
release slides only has the simulation processor so it is comparing the
simulation times.