### PR TITLE
add a script to print markdown list of submodule states

### DIFF
--- a/scripts/state
+++ b/scripts/state
@@ -1,0 +1,41 @@
+#!/bin/sh
+# scripts/state
+#   display the state of ldmx-sw
+#
+# REQUIREMENTS
+# - awk availabe
+# - git has the '-C' flag (>= 1.8.5)
+# - all the submodules have their remotes named 'origin'
+
+set -o errexit
+set -o nounset
+
+git submodule foreach --recursive git fetch --tags
+git submodule status --recursive | awk '{
+# git submodule status returns lines of the form
+#  <commit> <submodule> (<version>)
+# where <version> is either the tag, branch name, or something else
+# $1 - commit
+# $2 - submodule
+# $3 - version
+# strip the parentheses from the version string
+gsub(/\(|\)/,"",$3);
+# retrieve the URL to the repo
+#  assumes the remote is named "origin" in all the submodules
+git_repo_url="git -C "$2" remote get-url origin";
+git_repo_url | getline repo_url;
+close(git_repo_url);
+# change any SSH remote links back to https
+gsub(/.git$/,"",repo_url);
+gsub(/^git@/,"https://",repo_url);
+gsub(/com:/,"com/",repo_url);
+# if the version matches a version string, link to a release page,
+# otherwise just link to the commit page
+# this is where we use the fact that GitHub links are formulaic
+# across repositories
+if ($3 ~ /^v[0-9]*\.[0-9]*\.[0-9]*$/)
+  printf "- [%s %s](%s/releases/tag/%s)\n", $2, $3, repo_url, $3
+else
+  printf "- [%s %s](%s/commit/%s)\n", $2, substr($1,1,8), repo_url, $1
+}'
+


### PR DESCRIPTION
This script mainly uses awk to look through the submodule states and
retrieve their versions. If a submodule is not on a clean version tag,
then we fall back to just linking to the commit its on.

Besides awk, this script also requires a version of git that has the
`-C` flag (>= 1.8.5, very easy on any newer systems, I've only run into issues
with this requirement on CentOS7 systems.) and all submodules to have
their remote named `origin` which is the `git` default so I expect only
super-users to see issues.

## Use Case
This is helpful for anyone writing release notes. You can run this script and then copy the output into the release notes markdown to give an itemized list of the submodules linked to the commit/release that is included in that release.

In the future, we could look at including this script as part of a larger automatic release notes creation function. The current release notes generator just lists the PRs that were merged and then other notes are written manually. This script could be apart of a system that would itemize the list of PRs _and_ the submodule versions and then leave a space for manually written notes at the top.