### PR TITLE
Iss1265

### DIFF
--- a/Recon/CMakeLists.txt
+++ b/Recon/CMakeLists.txt
@@ -30,6 +30,8 @@ if(BUILD_EVENT_ONLY)
                        register_event_object( module_path "Recon/Event" 
                          namespace "ldmx" class "CaloTrigPrim" 
                          type "collection" )
+  register_event_object( module_path "Recon/Event" namespace "ldmx"
+  						 class "BeamElectronTruth" type "collection" )
    setup_library(module Recon name Event
                  dependencies ROOT::Core
                  register_target)

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -15,9 +15,13 @@ namespace recon {
 /**
  * Electron counting processor.
  *
- * This processor will use objects reconstructed in the trigger scintillators,
- * or truth info on the number of electrons, and set the electron count in the
- * event.
+ * This processor uses calo simhits in e.g. the target to get truth info
+ * about beam electrons. The hits associated with beam electrons can already
+ * be isolated by the truth hit collection producer. However, the simhits
+ * have approximately infinite resolution. This processor's raison d'être 
+ * is to run some sort of  grouping, to ensure we have at most one 
+ * reconstructed truth information object per electron.
+ *
  */
 class BeamElectronLocator : public framework::Producer {
  public:
@@ -37,13 +41,18 @@ class BeamElectronLocator : public framework::Producer {
    * Configure the processor using the given user specified parameters.
    *
    * The user specified parameters that are availabed are defined
-   * in the python configuration class. Look at the my_processor.py
-   * module of the EventProc python for the python structure.
+   * in the python configuration class. Look at the beamElecronLocator.py
+   * in Recon/python for the python structure.
    *
    * @param parameters Set of parameters used to configure this processor.
    */
   void configure(framework::config::Parameters &parameters) final override;
 
+  /**
+   * Prints the configuration to log in debug mode
+   */
+  void onProcessStart() ;
+  
   /**
    * Process the event and put new data products into it.
    *
@@ -67,13 +76,31 @@ class BeamElectronLocator : public framework::Producer {
    * variables
    */
   std::string outputColl_;
-
+  
   /**
-   * The granularity of the TS in X, in mm 
+   * The min value measured by the system (edge) in X, in mm 
+   **/
+  double minXmm_;
+  /**
+   * The max value measured by the system (edge) in X, in mm 
+   **/
+  double maxXmm_;
+  
+  /**
+   * The min value measured by the system (edge) in Y, in mm 
+   **/
+  double minYmm_;
+  /**
+   * The max value measured by the system (edge) in Y, in mm 
+   **/
+  double maxYmm_;
+  
+  /**
+   * The granularity of the detector (e.g. TS) in X, in mm 
    **/
   double granularityXmm_;
   /**
-   * The granularity of the TS in Y, in mm 
+   * The granularity of the detector (e.g. TS) in Y, in mm 
    **/
   double granularityYmm_;
 
@@ -83,8 +110,19 @@ class BeamElectronLocator : public framework::Producer {
    **/
   double tolerance_;
 
+  /** 
+   * Indicate verbose printout to log according to log level. 
+   */
   bool verbose_{false};
-  
+
+  /**
+   * Bins coordinates according to some given granularity (passed as argument).
+   * Returns the lower bin edge. -1 for underflow (coordinate < min_in_mm); 
+   * with a system of N bins, returns n = N if coordinate > max_in_mm.
+   * 
+   * TODO also implement a function that returns the grid of non-empty hit coordinates,
+   * which accounts for that we don't know the multiplicity at a location
+   */
   int bin(float coordinate, float binWidth, float min, float max);
   
 };  // BeamElectronLocator

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -8,6 +8,7 @@
 
 //---< Recon >---//
 #include "Recon/Event/BeamElectronTruth.h"
+#include "SimCore/Event/SimCalorimeterHit.h"
 
 namespace recon {
 
@@ -70,11 +71,11 @@ class BeamElectronLocator : public framework::Producer {
   /**
    * The granularity of the TS in X, in mm 
    **/
-  float TSgranularityXmm_;
+  float granularityXmm_;
   /**
    * The granularity of the TS in Y, in mm 
    **/
-  float TSgranularityYmm_;
+  float granularityYmm_;
 
   /**
    * The tolerance within which simhits are considered to belong to 
@@ -82,6 +83,7 @@ class BeamElectronLocator : public framework::Producer {
    **/
   float tolerance_;
 
+  int bin(float coordinate, float binWidth, float min, float max);
   
 };  // BeamElectronLocator
 }  // namespace recon

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -18,8 +18,8 @@ namespace recon {
  * This processor uses calo simhits in e.g. the target to get truth info
  * about beam electrons. The hits associated with beam electrons can already
  * be isolated by the truth hit collection producer. However, the simhits
- * have approximately infinite resolution. This processor's raison d'être 
- * is to run some sort of  grouping, to ensure we have at most one 
+ * have approximately infinite resolution. This processor's raison d'être
+ * is to run some sort of  grouping, to ensure we have at most one
  * reconstructed truth information object per electron.
  *
  */
@@ -51,8 +51,8 @@ class BeamElectronLocator : public framework::Producer {
   /**
    * Prints the configuration to log in debug mode
    */
-  void onProcessStart() ;
-  
+  void onProcessStart();
+
   /**
    * Process the event and put new data products into it.
    *
@@ -76,55 +76,56 @@ class BeamElectronLocator : public framework::Producer {
    * variables
    */
   std::string outputColl_;
-  
+
   /**
-   * The min value measured by the system (edge) in X, in mm 
+   * The min value measured by the system (edge) in X, in mm
    **/
   double minXmm_;
   /**
-   * The max value measured by the system (edge) in X, in mm 
+   * The max value measured by the system (edge) in X, in mm
    **/
   double maxXmm_;
-  
+
   /**
-   * The min value measured by the system (edge) in Y, in mm 
+   * The min value measured by the system (edge) in Y, in mm
    **/
   double minYmm_;
   /**
-   * The max value measured by the system (edge) in Y, in mm 
+   * The max value measured by the system (edge) in Y, in mm
    **/
   double maxYmm_;
-  
+
   /**
-   * The granularity of the detector (e.g. TS) in X, in mm 
+   * The granularity of the detector (e.g. TS) in X, in mm
    **/
   double granularityXmm_;
   /**
-   * The granularity of the detector (e.g. TS) in Y, in mm 
+   * The granularity of the detector (e.g. TS) in Y, in mm
    **/
   double granularityYmm_;
 
   /**
-   * The tolerance within which simhits are considered to belong to 
+   * The tolerance within which simhits are considered to belong to
    * the same electron.
    **/
   double tolerance_;
 
-  /** 
-   * Indicate verbose printout to log according to log level. 
+  /**
+   * Indicate verbose printout to log according to log level.
    */
   bool verbose_{false};
 
   /**
    * Bins coordinates according to some given granularity (passed as argument).
-   * Returns the lower bin edge. -1 for underflow (coordinate < min_in_mm); 
+   * Returns the lower bin edge. -1 for underflow (coordinate < min_in_mm);
    * with a system of N bins, returns n = N if coordinate > max_in_mm.
-   * 
-   * TODO also implement a function that returns the grid of non-empty hit coordinates,
-   * which accounts for that we don't know the multiplicity at a location
+   *
+   * TODO also implement a function that returns the grid of non-empty hit
+   * coordinates, which accounts for that we don't know the multiplicity at a
+   * location
    */
   int bin(float coordinate, float binWidth, float min, float max);
-  
+
 };  // BeamElectronLocator
 }  // namespace recon
 

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -1,0 +1,89 @@
+
+#ifndef RECON_BEAMELECTRONLOCATOR_H
+#define RECON_BEAMELECTRONLOCATOR_H
+
+//---< Framework >---//
+#include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h"
+
+//---< Recon >---//
+#include "Recon/Event/BeamElectronTruth.h"
+
+namespace recon {
+
+/**
+ * Electron counting processor.
+ *
+ * This processor will use objects reconstructed in the trigger scintillators,
+ * or truth info on the number of electrons, and set the electron count in the
+ * event.
+ */
+class BeamElectronLocator : public framework::Producer {
+ public:
+  /**
+   * Constructor.
+   *
+   * @param name Name for this instance of the class.
+   * @param process The Process class associated with EventProcessor,
+   * provided by the framework.
+   */
+  BeamElectronLocator(const std::string &name, framework::Process &process);
+
+  /// Destructor
+  virtual ~BeamElectronLocator();
+
+  /**
+   * Configure the processor using the given user specified parameters.
+   *
+   * The user specified parameters that are availabed are defined
+   * in the python configuration class. Look at the my_processor.py
+   * module of the EventProc python for the python structure.
+   *
+   * @param parameters Set of parameters used to configure this processor.
+   */
+  void configure(framework::config::Parameters &parameters) final override;
+
+  /**
+   * Process the event and put new data products into it.
+   *
+   * @param event The event to process.
+   */
+  void produce(framework::Event &event) final override;
+
+ private:
+  /**
+   * The name of the input collection used for counting electrons
+   */
+  std::string inputColl_;
+
+  /**
+   * The pass name of the input collection used for counting electrons
+   */
+  std::string inputPassName_;
+
+  /**
+   * The name of the output collection used to save some electron counting
+   * variables
+   */
+  std::string outputColl_;
+
+  /**
+   * The granularity of the TS in X, in mm 
+   **/
+  float TSgranularityXmm_;
+  /**
+   * The granularity of the TS in Y, in mm 
+   **/
+  float TSgranularityYmm_;
+
+  /**
+   * The tolerance within which simhits are considered to belong to 
+   * the same electron.
+   **/
+  float tolerance_;
+
+  
+};  // BeamElectronLocator
+}  // namespace recon
+
+#endif  // RECON_BEAMELECTRONLOCATOR_H

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -40,7 +40,7 @@ class BeamElectronLocator : public framework::Producer {
   /**
    * Configure the processor using the given user specified parameters.
    *
-   * The user specified parameters that are availabed are defined
+   * The user specified parameters that are available are defined
    * in the python configuration class. Look at the beamElecronLocator.py
    * in Recon/python for the python structure.
    *
@@ -51,7 +51,7 @@ class BeamElectronLocator : public framework::Producer {
   /**
    * Prints the configuration to log in debug mode
    */
-  void onProcessStart();
+  void onProcessStart() final override;
 
   /**
    * Process the event and put new data products into it.

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -124,7 +124,7 @@ class BeamElectronLocator : public framework::Producer {
    * coordinates, which accounts for that we don't know the multiplicity at a
    * location
    */
-  int bin(float coordinate, float binWidth, float min, float max);
+  int bin(float coordinate, double binWidth, double min, double max);
 
 };  // BeamElectronLocator
 }  // namespace recon

--- a/Recon/include/Recon/BeamElectronLocator.h
+++ b/Recon/include/Recon/BeamElectronLocator.h
@@ -71,18 +71,20 @@ class BeamElectronLocator : public framework::Producer {
   /**
    * The granularity of the TS in X, in mm 
    **/
-  float granularityXmm_;
+  double granularityXmm_;
   /**
    * The granularity of the TS in Y, in mm 
    **/
-  float granularityYmm_;
+  double granularityYmm_;
 
   /**
    * The tolerance within which simhits are considered to belong to 
    * the same electron.
    **/
-  float tolerance_;
+  double tolerance_;
 
+  bool verbose_{false};
+  
   int bin(float coordinate, float binWidth, float min, float max);
   
 };  // BeamElectronLocator

--- a/Recon/include/Recon/Event/BeamElectronTruth.h
+++ b/Recon/include/Recon/Event/BeamElectronTruth.h
@@ -1,6 +1,6 @@
 /**
- * @file BeamElectronTruth.h 
- * @brief Class that represents the truth information about 
+ * @file BeamElectronTruth.h
+ * @brief Class that represents the truth information about
  * beam electron at the target. Can be used for incoming/recoil
  * electron.
  * @author Lene Kristian Bryngemark, Lund University
@@ -26,18 +26,18 @@ class BeamElectronTruth {
   /**
    * Class constructor.
    */
-  BeamElectronTruth()  = default;
+  BeamElectronTruth() = default;
 
   /**
    * Class destructor.
    */
-  virtual ~BeamElectronTruth() {};
+  virtual ~BeamElectronTruth(){};
 
   /**
    * Print a description of this object.
    */
   void Print() const;
-  
+
   /**
    * Clear the data in the object.
    */
@@ -47,163 +47,158 @@ class BeamElectronTruth {
    * Set x coordinate of the found beam electron.
    * @param x The x coordinate of the found beam electron.
    */
-  void setX(double x) {x_ = x; }
-  
+  void setX(double x) { x_ = x; }
+
   /**
    * Set y coordinate of the found beam electron.
    * @param y The y coordinate of the found beam electron.
    */
-  void setY(double y) {y_ = y; }
-  
+  void setY(double y) { y_ = y; }
+
   /**
    * Set z coordinate of the found beam electron.
    * @param z The z coordinate of the found beam electron.
    */
-  void setZ(double z) {z_ = z; }
+  void setZ(double z) { z_ = z; }
 
   /**
-   * Set all three spatial coordinates  at once 
+   * Set all three spatial coordinates  at once
    * @param x The x coordinate of the found beam electron.
     * @param y The y coordinate of the found beam electron.
    * @param z The z coordinate of the found beam electron.
 
    */
-  void setXYZ(double x, double y, double z) {x_ = x; y_ = y; z_ = z;}
-
+  void setXYZ(double x, double y, double z) {
+    x_ = x;
+    y_ = y;
+    z_ = z;
+  }
 
   /**
    * Get x coordinate of the beam electron.
    * @return x The x coordinate of the found beam electron.
    */
-  double getX() {return x_; }
-  
+  double getX() { return x_; }
+
   /**
    * Get y coordinate of the beam electron.
    * @return y The y coordinate of the found beam electron.
    */
-  double getY() {return y_; }
-  
+  double getY() { return y_; }
+
   /**
    * Get z coordinate of the beam electron.
    * @return z The z coordinate of the found beam electron.
    */
-  double getZ() {return z_; }
+  double getZ() { return z_; }
 
+  // binned coordinates, according to some detector granularity. here, assume TS
 
-  //binned coordinates, according to some detector granularity. here, assume TS
-
-    
   /**
    * SetBinned x coordinate of the found beam electron.
    * @param x The x coordinate of the found beam electron.
    */
-  void setBinnedX(double x) {binnedX_ = x; }
-  
+  void setBinnedX(double x) { binnedX_ = x; }
+
   /**
    * SetBinned y coordinate of the found beam electron.
    * @param y The y coordinate of the found beam electron.
    */
-  void setBinnedY(double y) {binnedY_ = y; }
+  void setBinnedY(double y) { binnedY_ = y; }
 
   /**
-   * Set all three binned spatial coordinates at once 
+   * Set all three binned spatial coordinates at once
    * @param x The binned x coordinate of the found beam electron.
    * @param y The binned y coordinate of the found beam electron.
    */
-  void setBinnedXY(double x, double y) {binnedX_ = x; binnedY_ = y;}
-
+  void setBinnedXY(double x, double y) {
+    binnedX_ = x;
+    binnedY_ = y;
+  }
 
   /**
    * Get binned x coordinate of the beam electron.
    * @return x The x coordinate of the found beam electron.
    */
-  double getBinnedX() {return binnedX_; }
-  
+  double getBinnedX() { return binnedX_; }
+
   /**
    * GetBinned y coordinate of the beam electron.
    * @return y The y coordinate of the found beam electron.
    */
-  double getBinnedY() {return binnedY_; }
-  
+  double getBinnedY() { return binnedY_; }
 
-  //repeat for bar numbers instead of a spatial (bar center) coordinate 
-    
+  // repeat for bar numbers instead of a spatial (bar center) coordinate
+
   /**
    * Set x bar number of the found beam electron.
    * @param x The x (vertical) bar number of the found beam electron.
    */
-  void setBarX(double x) {barX_ = x; }
-  
+  void setBarX(double x) { barX_ = x; }
+
   /**
    * Set y bar number of the found beam electron.
    * @param y The y (horizontal) bar number of the found beam electron.
    */
-  void setBarY(double y) {barY_ = y; }
+  void setBarY(double y) { barY_ = y; }
 
   /**
-   * Set both bar number coordinates at once 
+   * Set both bar number coordinates at once
    * @param x The x (vertical) bar number of the found beam electron.
    * @param y The y (horizontal) bar number of the found beam electron.
    */
-  void setBarXY(double x, double y) {barX_ = x; barY_ = y;}
-
+  void setBarXY(double x, double y) {
+    barX_ = x;
+    barY_ = y;
+  }
 
   /**
    * Get x bar number of the found beam electron.
    * @return x The x (vertical) bar number of the found beam electron.
    */
-  double getBarX() {return barX_; }
-  
+  double getBarX() { return barX_; }
+
   /**
    * Get y bar number of the found beam electron.
    * @return y The y (horizontal) bar number of the found beam electron.
    */
-  double getBarY() {return barY_; }
-  
+  double getBarY() { return barY_; }
 
-  
-  
-  //TODO could add separate setters for each momentum component 
-  
+  // TODO could add separate setters for each momentum component
+
   /**
-   * Set the entire three-momentum at once 
-   * @param px The x component of the three-momentum 
-   * @param py The y component of the three-momentum 
-   * @param pz The z component of the three-momentum 
+   * Set the entire three-momentum at once
+   * @param px The x component of the three-momentum
+   * @param py The y component of the three-momentum
+   * @param pz The z component of the three-momentum
    */
   void setThreeMomentum(double px, double py, double pz);
-
 
   /**
    * Get px component of the beam electron momentum.
    * @return px The px component of the beam electron momentum.
    */
-  double getPx() {return px_; }
+  double getPx() { return px_; }
 
   /**
    * Get py component of the beam electron momentum.
    * @return py The py component of the beam electron momentum.
    */
-  double getPy() {return py_; }
+  double getPy() { return py_; }
 
   /**
    * Get pz component of the beam electron momentum.
    * @return pz The pz component of the beam electron momentum.
    */
-  double getPz() {return pz_; }
+  double getPz() { return pz_; }
 
   /**
-   * some sorting operator is mandatory 
-   * sort on hit Z coordinate 
-   */  
-   bool operator<( BeamElectronTruth &rhs) { 
-     return this->getZ() < rhs.getZ(); 
-   } 
+   * some sorting operator is mandatory
+   * sort on hit Z coordinate
+   */
+  bool operator<(BeamElectronTruth &rhs) { return this->getZ() < rhs.getZ(); }
 
-  
-  
  private:
-
   /* Algorithm variable results from simhit associations. */
 
   /** x coordinate ("truth" resolution, but within merging tolerance) **/
@@ -223,7 +218,7 @@ class BeamElectronTruth {
 
   /** TS vertical bar number overlapping with x coordinate **/
   double barX_{-1};
-  
+
   /** TS horizontal bar number overlapping with y coordinate **/
   double barY_{-1};
 
@@ -234,9 +229,8 @@ class BeamElectronTruth {
   /** z momentum component **/
   double pz_{-999};
 
-
   ClassDef(BeamElectronTruth, 1);
-}; // class BeamElectronTruth 
+};  // class BeamElectronTruth
 }  // namespace ldmx
 
 #endif

--- a/Recon/include/Recon/Event/BeamElectronTruth.h
+++ b/Recon/include/Recon/Event/BeamElectronTruth.h
@@ -207,32 +207,32 @@ class BeamElectronTruth {
   /* Algorithm variable results from simhit associations. */
 
   /** x coordinate ("truth" resolution, but within merging tolerance) **/
-  double x_;
+  double x_{-999};
 
   /** y coordinate ("truth" resolution, but within merging tolerance) **/
-  double y_;
+  double y_{-999};
 
   /** z coordinate ("truth" resolution, in practice, set to taget z = 0 **/
-  double z_;
+  double z_{-9999};
 
   /** x coordinate (with TS resolution) **/
-  double binnedX_;
+  double binnedX_{-999};
 
   /** y coordinate (with TS resolution) **/
-  double binnedY_;
+  double binnedY_{-999};
 
   /** TS vertical bar number overlapping with x coordinate **/
-  double barX_;
+  double barX_{-1};
   
   /** TS horizontal bar number overlapping with y coordinate **/
-  double barY_;
+  double barY_{-1};
 
   /** x momentum component **/
-  double px_;
+  double px_{-999};
   /** y momentum component **/
-  double py_;
+  double py_{-999};
   /** z momentum component **/
-  double pz_;
+  double pz_{-999};
 
 
   ClassDef(BeamElectronTruth, 1);

--- a/Recon/include/Recon/Event/BeamElectronTruth.h
+++ b/Recon/include/Recon/Event/BeamElectronTruth.h
@@ -26,7 +26,7 @@ class BeamElectronTruth {
   /**
    * Class constructor.
    */
-  BeamElectronTruth();
+  BeamElectronTruth()  = default;
 
   /**
    * Class destructor.

--- a/Recon/include/Recon/Event/BeamElectronTruth.h
+++ b/Recon/include/Recon/Event/BeamElectronTruth.h
@@ -1,0 +1,242 @@
+/**
+ * @file BeamElectronTruth.h 
+ * @brief Class that represents the truth information about 
+ * beam electron at the target. Can be used for incoming/recoil
+ * electron.
+ * @author Lene Kristian Bryngemark, Lund University
+ */
+
+#ifndef RECON_EVENT_BEAMELECTRONTRUTH_H_
+#define RECON_EVENT_BEAMELECTRONTRUTH_H_
+
+// ROOT
+#include "TObject.h"  //ClassDef
+
+// STL
+#include <iostream>
+
+namespace ldmx {
+
+/**
+ * @class BeamElectronTruth
+ * @brief Represents the truth information on beam electrons at the target
+ */
+class BeamElectronTruth {
+ public:
+  /**
+   * Class constructor.
+   */
+  BeamElectronTruth();
+
+  /**
+   * Class destructor.
+   */
+  virtual ~BeamElectronTruth() {};
+
+  /**
+   * Print a description of this object.
+   */
+  void Print() const;
+  
+  /**
+   * Clear the data in the object.
+   */
+  void Clear();
+
+  /**
+   * Set x coordinate of the found beam electron.
+   * @param x The x coordinate of the found beam electron.
+   */
+  void setX(double x) {x_ = x; }
+  
+  /**
+   * Set y coordinate of the found beam electron.
+   * @param y The y coordinate of the found beam electron.
+   */
+  void setY(double y) {y_ = y; }
+  
+  /**
+   * Set z coordinate of the found beam electron.
+   * @param z The z coordinate of the found beam electron.
+   */
+  void setZ(double z) {z_ = z; }
+
+  /**
+   * Set all three spatial coordinates  at once 
+   * @param x The x coordinate of the found beam electron.
+    * @param y The y coordinate of the found beam electron.
+   * @param z The z coordinate of the found beam electron.
+
+   */
+  void setXYZ(double x, double y, double z) {x_ = x; y_ = y; z_ = z;}
+
+
+  /**
+   * Get x coordinate of the beam electron.
+   * @return x The x coordinate of the found beam electron.
+   */
+  double getX() {return x_; }
+  
+  /**
+   * Get y coordinate of the beam electron.
+   * @return y The y coordinate of the found beam electron.
+   */
+  double getY() {return y_; }
+  
+  /**
+   * Get z coordinate of the beam electron.
+   * @return z The z coordinate of the found beam electron.
+   */
+  double getZ() {return z_; }
+
+
+  //binned coordinates, according to some detector granularity. here, assume TS
+
+    
+  /**
+   * SetBinned x coordinate of the found beam electron.
+   * @param x The x coordinate of the found beam electron.
+   */
+  void setBinnedX(double x) {binnedX_ = x; }
+  
+  /**
+   * SetBinned y coordinate of the found beam electron.
+   * @param y The y coordinate of the found beam electron.
+   */
+  void setBinnedY(double y) {binnedY_ = y; }
+
+  /**
+   * Set all three binned spatial coordinates at once 
+   * @param x The binned x coordinate of the found beam electron.
+   * @param y The binned y coordinate of the found beam electron.
+   */
+  void setBinnedXY(double x, double y) {binnedX_ = x; binnedY_ = y;}
+
+
+  /**
+   * Get binned x coordinate of the beam electron.
+   * @return x The x coordinate of the found beam electron.
+   */
+  double getBinnedX() {return binnedX_; }
+  
+  /**
+   * GetBinned y coordinate of the beam electron.
+   * @return y The y coordinate of the found beam electron.
+   */
+  double getBinnedY() {return binnedY_; }
+  
+
+  //repeat for bar numbers instead of a spatial (bar center) coordinate 
+    
+  /**
+   * Set x bar number of the found beam electron.
+   * @param x The x (vertical) bar number of the found beam electron.
+   */
+  void setBarX(double x) {barX_ = x; }
+  
+  /**
+   * Set y bar number of the found beam electron.
+   * @param y The y (horizontal) bar number of the found beam electron.
+   */
+  void setBarY(double y) {barY_ = y; }
+
+  /**
+   * Set both bar number coordinates at once 
+   * @param x The x (vertical) bar number of the found beam electron.
+   * @param y The y (horizontal) bar number of the found beam electron.
+   */
+  void setBarXY(double x, double y) {barX_ = x; barY_ = y;}
+
+
+  /**
+   * Get x bar number of the found beam electron.
+   * @return x The x (vertical) bar number of the found beam electron.
+   */
+  double getBarX() {return barX_; }
+  
+  /**
+   * Get y bar number of the found beam electron.
+   * @return y The y (horizontal) bar number of the found beam electron.
+   */
+  double getBarY() {return barY_; }
+  
+
+  
+  
+  //TODO could add separate setters for each momentum component 
+  
+  /**
+   * Set the entire three-momentum at once 
+   * @param px The x component of the three-momentum 
+   * @param py The y component of the three-momentum 
+   * @param pz The z component of the three-momentum 
+   */
+  void setThreeMomentum(double px, double py, double pz);
+
+
+  /**
+   * Get px component of the beam electron momentum.
+   * @return px The px component of the beam electron momentum.
+   */
+  double getPx() {return px_; }
+
+  /**
+   * Get py component of the beam electron momentum.
+   * @return py The py component of the beam electron momentum.
+   */
+  double getPy() {return py_; }
+
+  /**
+   * Get pz component of the beam electron momentum.
+   * @return pz The pz component of the beam electron momentum.
+   */
+  double getPz() {return pz_; }
+
+  /**
+   * some sorting operator is mandatory 
+   * sort on hit Z coordinate 
+   */  
+   bool operator<( BeamElectronTruth &rhs) { 
+     return this->getZ() < rhs.getZ(); 
+   } 
+
+  
+  
+ private:
+
+  /* Algorithm variable results from simhit associations. */
+
+  /** x coordinate ("truth" resolution, but within merging tolerance) **/
+  double x_;
+
+  /** y coordinate ("truth" resolution, but within merging tolerance) **/
+  double y_;
+
+  /** z coordinate ("truth" resolution, in practice, set to taget z = 0 **/
+  double z_;
+
+  /** x coordinate (with TS resolution) **/
+  double binnedX_;
+
+  /** y coordinate (with TS resolution) **/
+  double binnedY_;
+
+  /** TS vertical bar number overlapping with x coordinate **/
+  double barX_;
+  
+  /** TS horizontal bar number overlapping with y coordinate **/
+  double barY_;
+
+  /** x momentum component **/
+  double px_;
+  /** y momentum component **/
+  double py_;
+  /** z momentum component **/
+  double pz_;
+
+
+  ClassDef(BeamElectronTruth, 1);
+}; // class BeamElectronTruth 
+}  // namespace ldmx
+
+#endif

--- a/Recon/include/Recon/Event/HgcrocDigiCollection.h
+++ b/Recon/include/Recon/Event/HgcrocDigiCollection.h
@@ -444,7 +444,7 @@ class HgcrocDigiCollection {
    public:
     /// Connect the parent collection with an index to this iterator
     explicit iterator(HgcrocDigiCollection& c, long index = 0)
-        : coll_{c}, digi_index_{index} {}
+	  : digi_index_{index}, coll_{c} {}
     /// Increment the digi index and return the iterator afterwards
     iterator& operator++() {
       digi_index_++;

--- a/Recon/python/beamElectronLocator.py
+++ b/Recon/python/beamElectronLocator.py
@@ -1,0 +1,48 @@
+"""Example configuration object for a processor"""
+
+# We need the ldmx configuration package to construct the processor objects
+from LDMX.Framework import ldmxcfg
+
+class BeamElectronLocator(ldmxcfg.Producer) :
+    """The name is purely conventional to match the C++ class name for clarity
+
+    The line
+        super().__init__( name , "recon::BeamElectronLocator" , "Recon" )
+
+    Calls the constructor for ldmxcfg.Producer, which is how we have handles
+    on this processor. You need to give the actual C++ class name with 
+    namespace(s) as the second entry, and the name of the module the C++ class
+    is in as the third entry.
+
+    Any other lines define parameters that are accessible in the C++
+    configure method. For example, the line
+        self.my_parameter = 20
+
+    defines a integer parameter for this class which can be accessed
+    in the configure method with
+        int my_parameter = parameters.getParameter<int>("my_parameter");
+
+    Examples
+    --------
+
+    Creating the configuration object gives the parameters set
+    in __init__.
+        beamEleFinder = BeamElectronLocator( 'beamEleFinder')
+
+    You can also change the parameters after creating this object.
+        beamELeFinder.my_parameter = 50
+
+    Then you put your processor into the sequence of the process.
+        p.sequence.append( beamEleFinder )
+    """
+
+    def __init__(self, name ):
+        super().__init__( name , "recon::BeamElectronLocator" , 'Recon' )
+
+        self.input_collection = "TruthBeamElectronsTarget"
+        self.input_passname  = ""
+        self.output_collection = "BeamElectronTruthInfo"
+        self.granularity_X_mm = 1.
+        self.granularity_Y_mm = 1.
+        self.min_granularity_mm = 0.1
+

--- a/Recon/python/beamElectronLocator.py
+++ b/Recon/python/beamElectronLocator.py
@@ -40,9 +40,10 @@ class BeamElectronLocator(ldmxcfg.Producer) :
         super().__init__( name , "recon::BeamElectronLocator" , 'Recon' )
 
         self.input_collection = "TruthBeamElectronsTarget"
-        self.input_passname  = ""
+        self.input_pass_name  = ""
         self.output_collection = "BeamElectronTruthInfo"
-        self.granularity_X_mm = 1.
-        self.granularity_Y_mm = 1.
+        self.granularity_X_mm = 0.9
+        self.granularity_Y_mm = 0.9
         self.min_granularity_mm = 0.1
+        self.verbose = False
 

--- a/Recon/python/beamElectronLocator.py
+++ b/Recon/python/beamElectronLocator.py
@@ -1,36 +1,38 @@
-"""Example configuration object for a processor"""
+"""Configuration for beam electron locator 
+
+Attributes:
+-------------
+input_collection : string
+    Name of the input collection, should be one that holds sim hits 
+input_pass_name : string
+    Pass name of the input collection
+output_collection : string
+    Name of the output collection, holding the condensed list of beam electron locations
+granularity_X_mm : float
+    The expected actual resolution or the bar width in mm of the TS in the X direction
+granularity_Y_mm : float
+    The expected actual resolution or the bar width in mm of the TS in the Y direction
+min_granularity_mm : float
+    The maximum distance between SimHits that are grouped together as one beam electron
+verbose : boolean
+    If set to true, more information is spit out to either Info or Debug log level
 
 # We need the ldmx configuration package to construct the processor objects
+"""
+
 from LDMX.Framework import ldmxcfg
 
 class BeamElectronLocator(ldmxcfg.Producer) :
     """The name is purely conventional to match the C++ class name for clarity
 
-    The line
-        super().__init__( name , "recon::BeamElectronLocator" , "Recon" )
-
-    Calls the constructor for ldmxcfg.Producer, which is how we have handles
-    on this processor. You need to give the actual C++ class name with 
-    namespace(s) as the second entry, and the name of the module the C++ class
-    is in as the third entry.
-
-    Any other lines define parameters that are accessible in the C++
-    configure method. For example, the line
-        self.my_parameter = 20
-
-    defines a integer parameter for this class which can be accessed
-    in the configure method with
-        int my_parameter = parameters.getParameter<int>("my_parameter");
-
     Examples
     --------
 
-    Creating the configuration object gives the parameters set
-    in __init__.
-        beamEleFinder = BeamElectronLocator( 'beamEleFinder')
+    from LDMX.Recon.beamElectronLocator import BeamElectronLocator
+    beamEleFinder= BeamELectronLocator('beamEleFinder')
 
-    You can also change the parameters after creating this object.
-        beamELeFinder.my_parameter = 50
+    You can change the parameters after creating this object.
+        beamEleFinder.my_parameter = 50
 
     Then you put your processor into the sequence of the process.
         p.sequence.append( beamEleFinder )
@@ -39,11 +41,11 @@ class BeamElectronLocator(ldmxcfg.Producer) :
     def __init__(self, name ):
         super().__init__( name , "recon::BeamElectronLocator" , 'Recon' )
 
-        self.input_collection = "TruthBeamElectronsTarget"
+        self.input_collection = "truthBeamElectronsTarget"
         self.input_pass_name  = ""
         self.output_collection = "BeamElectronTruthInfo"
-        self.granularity_X_mm = 0.9
-        self.granularity_Y_mm = 0.9
+        self.granularity_X_mm = 20./8.
+        self.granularity_Y_mm = 80./48.
         self.min_granularity_mm = 0.1
         self.verbose = False
 

--- a/Recon/python/beamElectronLocator.py
+++ b/Recon/python/beamElectronLocator.py
@@ -47,5 +47,9 @@ class BeamElectronLocator(ldmxcfg.Producer) :
         self.granularity_X_mm = 20./8.
         self.granularity_Y_mm = 80./48.
         self.min_granularity_mm = 0.1
+        self.min_X_mm = -10.
+        self.max_X_mm = 10.
+        self.min_Y_mm = -40.
+        self.max_Y_mm = 40.
         self.verbose = False
 

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -107,9 +107,7 @@ int BeamElectronLocator::bin(float coordinate, double binWidth, double min,
     n++;
     if (min + n * binWidth > max) {
       // don't go out of bounds, but, still indicate overflow by increasing n
-      // once more. this compensates for the stepping back that happens in the
-      // return which would otherwise always give us the last bin before max.
-      //n++;
+	  // before breaking
       break;
     }
   }

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -31,27 +31,7 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
 }
 
   void BeamElectronLocator::produce(framework::Event &event) {
-	//* steps
-	//1. find those hits in the target sim hit collection that are associated with the electron
-	//            -- this can be done using the existing truth hit producer 
-	//2. figure out how to select only one location per electron
-	//3. if using TS granularity, send to function binning them in X and Y, depending on choice in config
-	//4. set the hit coordinates and add "nice-to-haves" like its momentum 
-	//*/
-	
-	// this relies on having run the electron counter, 
-	int nElectrons = event.getElectronCount();
-  
-	if (nElectrons < 0) {
-	  ldmx_log(fatal)
-		<< "Can't use unset number of counted electrons as electron count! "
-		"Run the electron counter first!";
-	  // TODO: throw an exeption instead
-	  // TODO decide if this umber is actually used in some clustering, or remove 
-	  return;
-
-	}
-  
+	  
    
 	// Check if the input collection exists. If not,
 	// don't bother processing the event.
@@ -62,8 +42,9 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
 	  return;
 	}
 
-	// the simhits have approximately infinite resolution. run some sort of grouping.
-	// 
+	
+	// the simhits have approximately infinite resolution.
+	// this processor's raison d'être is to run some sort of grouping.
 
 
 	std::vector<ldmx::BeamElectronTruth> beamElectronInfo;
@@ -98,9 +79,6 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
 	    electronInfo.setXYZ( pos[0], pos[1], pos[2]);
 	    //find a way to do this later
 	    //electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
-
-	    //for these, i should 	
-	    //set up a 2d array, with some n number of bins set by the total width and granularity
 
 	    //TODO make min and max configurable 
 	    electronInfo.setBarX( bin(pos[0], granularityXmm_, -10, 10) );

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -100,8 +100,8 @@ void BeamElectronLocator::produce(framework::Event &event) {
   event.add(outputColl_, beamElectronInfo);
 }
 
-int BeamElectronLocator::bin(float coordinate, float binWidth, float min,
-                             float max) {
+int BeamElectronLocator::bin(float coordinate, double binWidth, double min,
+                             double max) {
   int n = 0;
   while (coordinate > min + n * binWidth) {
     n++;
@@ -109,7 +109,7 @@ int BeamElectronLocator::bin(float coordinate, float binWidth, float min,
       // don't go out of bounds, but, still indicate overflow by increasing n
       // once more. this compensates for the stepping back that happens in the
       // return which would otherwise always give us the last bin before max.
-      n++;
+      //n++;
       break;
     }
   }

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -87,9 +87,9 @@ void BeamElectronLocator::produce(framework::Event &event) {
       electronInfo.setBarX(bin(pos[0], granularityXmm_, minXmm_, maxXmm_));
       electronInfo.setBarY(bin(pos[1], granularityYmm_, minYmm_, maxYmm_));
       // set coordinates to bin center
-      electronInfo.setBinnedX(minXmm_ + (electronInfo.getBarX() + 1 / 2.) *
+      electronInfo.setBinnedX(minXmm_ + (electronInfo.getBarX() + 0.5) *
                                             granularityXmm_);
-      electronInfo.setBinnedY(minYmm_ + (electronInfo.getBarY() + 1 / 2.) *
+      electronInfo.setBinnedY(minYmm_ + (electronInfo.getBarY() + 0.5) *
                                             granularityYmm_);
 
       beamElectronInfo.push_back(electronInfo);

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -2,7 +2,8 @@
 
 namespace recon {
 
-BeamElectronLocator::BeamElectronLocator(const std::string& name, framework::Process& process)
+BeamElectronLocator::BeamElectronLocator(const std::string &name,
+                                         framework::Process &process)
     : framework::Producer(name, process) {}
 
 BeamElectronLocator::~BeamElectronLocator() {}
@@ -11,120 +12,111 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
   inputColl_ = parameters.getParameter<std::string>("input_collection");
   inputPassName_ = parameters.getParameter<std::string>("input_pass_name");
   outputColl_ = parameters.getParameter<std::string>("output_collection");
-  granularityXmm_ =
-      parameters.getParameter<double>("granularity_X_mm");
-  granularityYmm_ =
-      parameters.getParameter<double>("granularity_Y_mm");
-  tolerance_ =
-      parameters.getParameter<double>("min_granularity_mm");
-  minXmm_ =
-      parameters.getParameter<double>("min_X_mm");
-  maxXmm_ =
-      parameters.getParameter<double>("max_X_mm");
-  minYmm_ =
-      parameters.getParameter<double>("min_Y_mm");
-  maxYmm_ =
-      parameters.getParameter<double>("max_Y_mm");
-  verbose_ =  
-    parameters.getParameter<bool>("verbose");
-
+  granularityXmm_ = parameters.getParameter<double>("granularity_X_mm");
+  granularityYmm_ = parameters.getParameter<double>("granularity_Y_mm");
+  tolerance_ = parameters.getParameter<double>("min_granularity_mm");
+  minXmm_ = parameters.getParameter<double>("min_X_mm");
+  maxXmm_ = parameters.getParameter<double>("max_X_mm");
+  minYmm_ = parameters.getParameter<double>("min_Y_mm");
+  maxYmm_ = parameters.getParameter<double>("max_Y_mm");
+  verbose_ = parameters.getParameter<bool>("verbose");
 }
-  void BeamElectronLocator::onProcessStart() {
-
+void BeamElectronLocator::onProcessStart() {
   ldmx_log(debug) << "BeamElectronLocator is using parameters: "
                   << " \n\tinput_collection = " << inputColl_
                   << " \n\tinput_pass_name = " << inputPassName_
                   << " \n\toutput_collection = " << outputColl_
                   << " \n\tgranularity_X_mm = " << granularityXmm_
                   << " \n\tgranularity_Y_mm = " << granularityYmm_
-                  << " \n\tmin_granularity_mm = " << tolerance_ 
+                  << " \n\tmin_granularity_mm = " << tolerance_
                   << " \n\tmin_X_mm = " << minXmm_
                   << " \n\tmax_X_mm = " << maxXmm_
                   << " \n\tmin_Y_mm = " << minYmm_
                   << " \n\tmax_Y_mm = " << maxYmm_
-                  << " \n\tverbose = " << verbose_ ;
+                  << " \n\tverbose = " << verbose_;
 }
 
-  void BeamElectronLocator::produce(framework::Event &event) {
-	  
-   
-	// Check if the input collection exists. If not,
-	// don't bother processing the event.
-	if (!event.exists(inputColl_, inputPassName_)) {
-	  ldmx_log(fatal) << "Attemping to use non-existing input collection "
-					  << inputColl_ << "_" << inputPassName_
-					  << " to locate electrons! Exiting.";
-	  return;
-	}
-
-	
-
-	std::vector<ldmx::BeamElectronTruth> beamElectronInfo;
-	const auto simHits{event.getCollection<ldmx::SimCalorimeterHit>(
-      inputColl_, inputPassName_)};
-
-	if (verbose_) {
-		ldmx_log(info) << "Looping through simhits in event " << event.getEventNumber() << "." ;
-	    }
-	
-	for (const auto &simHit : simHits) {
-	  //check if we already caught this position, else, add it 
-	  bool isMatched = false;
-	  std::vector<float> pos=simHit.getPosition();
-	  for (auto foundElectrons : beamElectronInfo ) {
-		//this check makes it square rather than a dR circle
-		if ( fabs( pos[0] - foundElectrons.getX() ) < tolerance_
-			 && fabs( pos[1] - foundElectrons.getY() ) < tolerance_ ) {
-		  if (verbose_) 
-		    ldmx_log(debug) << "\tHit at (x = " <<  pos[0] << ", y = " <<  pos[1]
-				    << " matches electron found at (x = " << foundElectrons.getX()
-				    << ", y = " << foundElectrons.getY() << "); skip this simhit";
-		  isMatched=true;
-		  break;  //finding a match means Move on	      
-		} // if coordinates match something we already found 
-	  }// over found electrons 
-	  if (!isMatched) {		  
-	    if (verbose_) {
-	      ldmx_log(info) << "\tHit at (x = " <<  pos[0] << ", y = " <<  pos[1] << " not formerly matched. Adding to collection.";
-	    }
-	    ldmx::BeamElectronTruth electronInfo;
-	    electronInfo.setXYZ( pos[0], pos[1], pos[2]);
-	    //find a way to do this later
-	    //electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
-
-	    electronInfo.setBarX( bin(pos[0], granularityXmm_, minXmm_, maxXmm_) );
-	    electronInfo.setBarY( bin(pos[1], granularityYmm_, minYmm_, maxYmm_) );
-	    //set coordinates to bin center 
-	    electronInfo.setBinnedX( minXmm_ + (electronInfo.getBarX()+1/2.)*granularityXmm_ );
-	    electronInfo.setBinnedY( minYmm_ + (electronInfo.getBarY()+1/2.)*granularityYmm_ );
-
-	    beamElectronInfo.push_back(electronInfo);
-	  }
-	}// over simhits in the collection 
- 
-	event.add(outputColl_, beamElectronInfo);
-
+void BeamElectronLocator::produce(framework::Event &event) {
+  // Check if the input collection exists. If not,
+  // don't bother processing the event.
+  if (!event.exists(inputColl_, inputPassName_)) {
+    ldmx_log(fatal) << "Attemping to use non-existing input collection "
+                    << inputColl_ << "_" << inputPassName_
+                    << " to locate electrons! Exiting.";
+    return;
   }
 
+  std::vector<ldmx::BeamElectronTruth> beamElectronInfo;
+  const auto simHits{
+      event.getCollection<ldmx::SimCalorimeterHit>(inputColl_, inputPassName_)};
 
-  int BeamElectronLocator::bin(float coordinate, float binWidth, float min, float max) {
-	int n=0;
-	while (coordinate > min + n*binWidth ) {
-	  n++;
-	  if  (min + n*binWidth > max) {
-		// don't go out of bounds, but, still indicate overflow by increasing n once more.
-		// this compensates for the stepping back that happens in the return which
-		// would otherwise always give us the last bin before max.
-		n++; 
-		break;
-	  }
-	}
-	// the n we have now is the first bin beyond our coordinate.
-	// better aligned with conventions to return the lower edge.
-	return n-1;
+  if (verbose_) {
+    ldmx_log(info) << "Looping through simhits in event "
+                   << event.getEventNumber() << ".";
   }
 
-  
-}  // namespace recon    
+  for (const auto &simHit : simHits) {
+    // check if we already caught this position, else, add it
+    bool isMatched = false;
+    std::vector<float> pos = simHit.getPosition();
+    for (auto foundElectrons : beamElectronInfo) {
+      // this check makes it square rather than a dR circle
+      if (fabs(pos[0] - foundElectrons.getX()) < tolerance_ &&
+          fabs(pos[1] - foundElectrons.getY()) < tolerance_) {
+        if (verbose_)
+          ldmx_log(debug) << "\tHit at (x = " << pos[0] << ", y = " << pos[1]
+                          << " matches electron found at (x = "
+                          << foundElectrons.getX()
+                          << ", y = " << foundElectrons.getY()
+                          << "); skip this simhit";
+        isMatched = true;
+        break;  // finding a match means Move on
+      }         // if coordinates match something we already found
+    }           // over found electrons
+    if (!isMatched) {
+      if (verbose_) {
+        ldmx_log(info) << "\tHit at (x = " << pos[0] << ", y = " << pos[1]
+                       << " not formerly matched. Adding to collection.";
+      }
+      ldmx::BeamElectronTruth electronInfo;
+      electronInfo.setXYZ(pos[0], pos[1], pos[2]);
+      // find a way to do this later
+      // electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(),
+      // simHit.getPz());
+
+      electronInfo.setBarX(bin(pos[0], granularityXmm_, minXmm_, maxXmm_));
+      electronInfo.setBarY(bin(pos[1], granularityYmm_, minYmm_, maxYmm_));
+      // set coordinates to bin center
+      electronInfo.setBinnedX(minXmm_ + (electronInfo.getBarX() + 1 / 2.) *
+                                            granularityXmm_);
+      electronInfo.setBinnedY(minYmm_ + (electronInfo.getBarY() + 1 / 2.) *
+                                            granularityYmm_);
+
+      beamElectronInfo.push_back(electronInfo);
+    }
+  }  // over simhits in the collection
+
+  event.add(outputColl_, beamElectronInfo);
+}
+
+int BeamElectronLocator::bin(float coordinate, float binWidth, float min,
+                             float max) {
+  int n = 0;
+  while (coordinate > min + n * binWidth) {
+    n++;
+    if (min + n * binWidth > max) {
+      // don't go out of bounds, but, still indicate overflow by increasing n
+      // once more. this compensates for the stepping back that happens in the
+      // return which would otherwise always give us the last bin before max.
+      n++;
+      break;
+    }
+  }
+  // the n we have now is the first bin beyond our coordinate.
+  // better aligned with conventions to return the lower edge.
+  return n - 1;
+}
+
+}  // namespace recon
 
 DECLARE_PRODUCER_NS(recon, BeamElectronLocator)

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -23,9 +23,9 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
                   << " \n\tinput_collection = " << inputColl_
                   << " \n\tinput_pass_name = " << inputPassName_
                   << " \n\toutput_collection = " << outputColl_
-                  << " \n\tgranularity_X_mm = " << TSgranularityXmm_
-                  << " \n\tgranularity_Y_mm = " << TSgranularityYmm_
-                  << " \n\tmin_granularity_mm = " << tolerance_
+                  << " \n\tgranularity_X_mm = " << granularityXmm_
+                  << " \n\tgranularity_Y_mm = " << granularityYmm_
+                  << " \n\tmin_granularity_mm = " << tolerance_ ;
 }
 
   void BeamElectronLocator::produce(framework::Event &event) {
@@ -64,26 +64,26 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
 	// 
 
 
-	// group the sim hits. loop over them.
-	vector <float> coordX;
-	vector <float> coordY;
-
 	std::vector<ldmx::BeamElectronTruth> beamElectronInfo;
-	
+	const auto simHits{event.getCollection<ldmx::SimCalorimeterHit>(
+      inputColl_, inputPassName_)};
+
 	for (const auto &simHit : simHits) {
 	  //check if we already caught this position, else, add it 
 	  bool isMatched = false;
+	  std::vector<float> pos=simHit.getPosition();
 	  for (auto foundElectrons : beamElectronInfo ) {
-		//this check makes it square rather than a dR circle 
-		if ( fabs( simHit.getXpos() - foundElectrons,getX() )> tolerance_
-			 && fabs( simHit.getYpos() - foundElectrons,getY() )> tolerance_ ) {
+		//this check makes it square rather than a dR circle
+		if ( fabs( pos[0] - foundElectrons.getX() )> tolerance_
+			 && fabs( pos[1] - foundElectrons.getY() )> tolerance_ ) {
 		  isMatched=true;
 		} // if coordinates match something we already found 
 	  }// over found electrons 
 	  if (!isMatched) {		  
 		ldmx::BeamElectronTruth electronInfo;
-		electronInfo.SetXYZ(simHit.getXpos(), simHit.getYpos(), simHit.getZpos()); 
-		electronInfo.SetThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
+		electronInfo.setXYZ( pos[0], pos[1], pos[2]);
+		//find a way to do this later
+		//electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
 		beamElectronInfo.push_back(electronInfo);
 	  }
 	}// over simhits in the collection 

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -63,12 +63,13 @@ void BeamElectronLocator::produce(framework::Event &event) {
       // this check makes it square rather than a dR circle
       if (fabs(pos[0] - foundElectrons.getX()) < tolerance_ &&
           fabs(pos[1] - foundElectrons.getY()) < tolerance_) {
-        if (verbose_)
+        if (verbose_) {
           ldmx_log(debug) << "\tHit at (x = " << pos[0] << ", y = " << pos[1]
                           << " matches electron found at (x = "
                           << foundElectrons.getX()
                           << ", y = " << foundElectrons.getY()
                           << "); skip this simhit";
+		}
         isMatched = true;
         break;  // finding a match means Move on
       }         // if coordinates match something we already found

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -12,12 +12,13 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
   inputPassName_ = parameters.getParameter<std::string>("input_pass_name");
   outputColl_ = parameters.getParameter<std::string>("output_collection");
   granularityXmm_ =
-      parameters.getParameter<float>("granularity_X_mm");
+      parameters.getParameter<double>("granularity_X_mm");
   granularityYmm_ =
-      parameters.getParameter<float>("granularity_Y_mm");
- tolerance_ =
-      parameters.getParameter<float>("min_granularity_mm");
- 
+      parameters.getParameter<double>("granularity_Y_mm");
+  tolerance_ =
+      parameters.getParameter<double>("min_granularity_mm");
+  verbose_ =  
+    parameters.getParameter<bool>("verbose");
 
   ldmx_log(debug) << "BeamElectronLocator is using parameters: "
                   << " \n\tinput_collection = " << inputColl_
@@ -25,7 +26,8 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
                   << " \n\toutput_collection = " << outputColl_
                   << " \n\tgranularity_X_mm = " << granularityXmm_
                   << " \n\tgranularity_Y_mm = " << granularityYmm_
-                  << " \n\tmin_granularity_mm = " << tolerance_ ;
+                  << " \n\tmin_granularity_mm = " << tolerance_ 
+                  << " \n\tverbose = " << verbose_ ;
 }
 
   void BeamElectronLocator::produce(framework::Event &event) {
@@ -68,30 +70,51 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
 	const auto simHits{event.getCollection<ldmx::SimCalorimeterHit>(
       inputColl_, inputPassName_)};
 
+	if (verbose_) {
+		ldmx_log(info) << "Looping through simhits in event " << event.getEventNumber() << "." ;
+	    }
+	
 	for (const auto &simHit : simHits) {
 	  //check if we already caught this position, else, add it 
 	  bool isMatched = false;
 	  std::vector<float> pos=simHit.getPosition();
 	  for (auto foundElectrons : beamElectronInfo ) {
 		//this check makes it square rather than a dR circle
-		if ( fabs( pos[0] - foundElectrons.getX() )> tolerance_
-			 && fabs( pos[1] - foundElectrons.getY() )> tolerance_ ) {
+		if ( fabs( pos[0] - foundElectrons.getX() ) < tolerance_
+			 && fabs( pos[1] - foundElectrons.getY() ) < tolerance_ ) {
+		  if (verbose_) 
+		    ldmx_log(debug) << "\tHit at (x = " <<  pos[0] << ", y = " <<  pos[1]
+				    << " matches electron found at (x = " << foundElectrons.getX()
+				    << ", y = " << foundElectrons.getY() << "); skip this simhit";
 		  isMatched=true;
+		  break;  //finding a match means Move on	      
 		} // if coordinates match something we already found 
 	  }// over found electrons 
 	  if (!isMatched) {		  
-		ldmx::BeamElectronTruth electronInfo;
-		electronInfo.setXYZ( pos[0], pos[1], pos[2]);
-		//find a way to do this later
-		//electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
-		beamElectronInfo.push_back(electronInfo);
+	    if (verbose_) {
+	      ldmx_log(info) << "\tHit at (x = " <<  pos[0] << ", y = " <<  pos[1] << " not formerly matched. Adding to collection.";
+	    }
+	    ldmx::BeamElectronTruth electronInfo;
+	    electronInfo.setXYZ( pos[0], pos[1], pos[2]);
+	    //find a way to do this later
+	    //electronInfo.setThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
+
+	    //for these, i should 	
+	    //set up a 2d array, with some n number of bins set by the total width and granularity
+
+	    //TODO make min and max configurable 
+	    electronInfo.setBarX( bin(pos[0], granularityXmm_, -10, 10) );
+	    electronInfo.setBarY( bin(pos[1], granularityYmm_, -40, 40) );
+	    //set coordinates to bin center 
+	    electronInfo.setBinnedX( -10. + (electronInfo.getBarX()+1/2.)*granularityXmm_ );
+	    electronInfo.setBinnedY( -40. + (electronInfo.getBarY()+1/2.)*granularityYmm_ );
+
+	    
+	    beamElectronInfo.push_back(electronInfo);
 	  }
 	}// over simhits in the collection 
  
-  
-  //for these, i should 	
-	//set up a 2d array, with some n number of bins set by the total width and granularity 
-
+	event.add(outputColl_, beamElectronInfo);
 
   }
 
@@ -101,15 +124,17 @@ void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
   int BeamElectronLocator::bin(float coordinate, float binWidth, float min, float max) {
 	// a function to discretize floating points to some precision 
 	int n=0;
-	while (coordinate < min + n*binWidth ) {
+	while (coordinate > min + n*binWidth ) {
 	  n++;
-	  if  (n*binWidth > max) {
+	  if  (min + n*binWidth > max) {
 		//n--; // this moves the point back, but, perhaps better to see that we go out of bounds on return 
 		break;
 	  }
 	}
-	// the resulting coordinate is between n which is the lower edge, and the next 
-	return n;
+	// the n we have is the first bin which is too large. 
+	// the resulting coordinate is between n which is the upper edge, and the previous
+	// return the lower edge 
+	return n-1;
   }
 
 

--- a/Recon/src/Recon/BeamElectronLocator.cxx
+++ b/Recon/src/Recon/BeamElectronLocator.cxx
@@ -1,0 +1,120 @@
+#include "Recon/BeamElectronLocator.h"
+
+namespace recon {
+
+BeamElectronLocator::BeamElectronLocator(const std::string& name, framework::Process& process)
+    : framework::Producer(name, process) {}
+
+BeamElectronLocator::~BeamElectronLocator() {}
+
+void BeamElectronLocator::configure(framework::config::Parameters &parameters) {
+  inputColl_ = parameters.getParameter<std::string>("input_collection");
+  inputPassName_ = parameters.getParameter<std::string>("input_pass_name");
+  outputColl_ = parameters.getParameter<std::string>("output_collection");
+  granularityXmm_ =
+      parameters.getParameter<float>("granularity_X_mm");
+  granularityYmm_ =
+      parameters.getParameter<float>("granularity_Y_mm");
+ tolerance_ =
+      parameters.getParameter<float>("min_granularity_mm");
+ 
+
+  ldmx_log(debug) << "BeamElectronLocator is using parameters: "
+                  << " \n\tinput_collection = " << inputColl_
+                  << " \n\tinput_pass_name = " << inputPassName_
+                  << " \n\toutput_collection = " << outputColl_
+                  << " \n\tgranularity_X_mm = " << TSgranularityXmm_
+                  << " \n\tgranularity_Y_mm = " << TSgranularityYmm_
+                  << " \n\tmin_granularity_mm = " << tolerance_
+}
+
+  void BeamElectronLocator::produce(framework::Event &event) {
+	//* steps
+	//1. find those hits in the target sim hit collection that are associated with the electron
+	//            -- this can be done using the existing truth hit producer 
+	//2. figure out how to select only one location per electron
+	//3. if using TS granularity, send to function binning them in X and Y, depending on choice in config
+	//4. set the hit coordinates and add "nice-to-haves" like its momentum 
+	//*/
+	
+	// this relies on having run the electron counter, 
+	int nElectrons = event.getElectronCount();
+  
+	if (nElectrons < 0) {
+	  ldmx_log(fatal)
+		<< "Can't use unset number of counted electrons as electron count! "
+		"Run the electron counter first!";
+	  // TODO: throw an exeption instead
+	  // TODO decide if this umber is actually used in some clustering, or remove 
+	  return;
+
+	}
+  
+   
+	// Check if the input collection exists. If not,
+	// don't bother processing the event.
+	if (!event.exists(inputColl_, inputPassName_)) {
+	  ldmx_log(fatal) << "Attemping to use non-existing input collection "
+					  << inputColl_ << "_" << inputPassName_
+					  << " to locate electrons! Exiting.";
+	  return;
+	}
+
+	// the simhits have approximately infinite resolution. run some sort of grouping.
+	// 
+
+
+	// group the sim hits. loop over them.
+	vector <float> coordX;
+	vector <float> coordY;
+
+	std::vector<ldmx::BeamElectronTruth> beamElectronInfo;
+	
+	for (const auto &simHit : simHits) {
+	  //check if we already caught this position, else, add it 
+	  bool isMatched = false;
+	  for (auto foundElectrons : beamElectronInfo ) {
+		//this check makes it square rather than a dR circle 
+		if ( fabs( simHit.getXpos() - foundElectrons,getX() )> tolerance_
+			 && fabs( simHit.getYpos() - foundElectrons,getY() )> tolerance_ ) {
+		  isMatched=true;
+		} // if coordinates match something we already found 
+	  }// over found electrons 
+	  if (!isMatched) {		  
+		ldmx::BeamElectronTruth electronInfo;
+		electronInfo.SetXYZ(simHit.getXpos(), simHit.getYpos(), simHit.getZpos()); 
+		electronInfo.SetThreeMomentum(simHit.getPx(), simHit.getPy(), simHit.getPz()); 
+		beamElectronInfo.push_back(electronInfo);
+	  }
+	}// over simhits in the collection 
+ 
+  
+  //for these, i should 	
+	//set up a 2d array, with some n number of bins set by the total width and granularity 
+
+
+  }
+
+
+  //rethink this... i want a grid with 0 and 1, simply. hit or no hit. 
+  
+  int BeamElectronLocator::bin(float coordinate, float binWidth, float min, float max) {
+	// a function to discretize floating points to some precision 
+	int n=0;
+	while (coordinate < min + n*binWidth ) {
+	  n++;
+	  if  (n*binWidth > max) {
+		//n--; // this moves the point back, but, perhaps better to see that we go out of bounds on return 
+		break;
+	  }
+	}
+	// the resulting coordinate is between n which is the lower edge, and the next 
+	return n;
+  }
+
+
+
+  
+}  // namespace recon    
+
+DECLARE_PRODUCER_NS(recon, BeamElectronLocator)

--- a/Recon/src/Recon/Event/BeamElectronTruth.cxx
+++ b/Recon/src/Recon/Event/BeamElectronTruth.cxx
@@ -1,0 +1,42 @@
+#include "Recon/Event/BeamElectronTruth.h"
+
+// STL
+#include <iostream>
+
+ClassImp(ldmx::BeamElectronTruth)
+
+namespace ldmx {
+  void BeamElectronTruth::Clear() {
+    x_ = -999;
+    y_ = -999;
+    z_ = -999;
+    px_ = -999;
+    py_ = -999;
+    pz_ = -999;
+    binnedX_ = -999;
+    binnedY_ = -999;
+  }
+
+  
+  //  std::ostream &operator<<(std::ostream &s, const ldmx::BeamElectronTruth &b) {
+  //   s << "BeamElectronTruth { "
+  // 	  << "(x = " << b.getX()
+  // 	  << ", y = " << b.getY()
+  // 	  << ", z = " << b.getZ()  << ") } ";
+  //   return s;
+  // }
+
+  
+  void BeamElectronTruth::Print() const {
+    std::cout << "BeamElectronTruth { "
+              << "(x: " << x_ 
+              << ", y: " << y_ 
+              << ", z: " << z_ << ")" 
+              << "; (binned X: " << binnedX_ 
+              << ", binned Y: " << binnedY_ << ")" 
+              << "; (px: " << px_ 
+              << ", py: " << py_ 
+              << ", pz: " << pz_ << ")" 
+			  << std::endl;
+  }
+}  // namespace ldmx

--- a/Recon/src/Recon/Event/BeamElectronTruth.cxx
+++ b/Recon/src/Recon/Event/BeamElectronTruth.cxx
@@ -5,7 +5,7 @@
 
 ClassImp(ldmx::BeamElectronTruth)
 
-namespace ldmx {
+    namespace ldmx {
   void BeamElectronTruth::Clear() {
     x_ = -999;
     y_ = -999;
@@ -17,8 +17,8 @@ namespace ldmx {
     binnedY_ = -999;
   }
 
-  
-  //  std::ostream &operator<<(std::ostream &s, const ldmx::BeamElectronTruth &b) {
+  //  std::ostream &operator<<(std::ostream &s, const ldmx::BeamElectronTruth
+  //  &b) {
   //   s << "BeamElectronTruth { "
   // 	  << "(x = " << b.getX()
   // 	  << ", y = " << b.getY()
@@ -26,17 +26,12 @@ namespace ldmx {
   //   return s;
   // }
 
-  
   void BeamElectronTruth::Print() const {
     std::cout << "BeamElectronTruth { "
-              << "(x: " << x_ 
-              << ", y: " << y_ 
-              << ", z: " << z_ << ")" 
-              << "; (binned X: " << binnedX_ 
-              << ", binned Y: " << binnedY_ << ")" 
-              << "; (px: " << px_ 
-              << ", py: " << py_ 
-              << ", pz: " << pz_ << ")" 
-			  << std::endl;
+              << "(x: " << x_ << ", y: " << y_ << ", z: " << z_ << ")"
+              << "; (binned X: " << binnedX_ << ", binned Y: " << binnedY_
+              << ")"
+              << "; (px: " << px_ << ", py: " << py_ << ", pz: " << pz_ << ")"
+              << std::endl;
   }
 }  // namespace ldmx

--- a/Recon/src/Recon/Event/BeamElectronTruth.cxx
+++ b/Recon/src/Recon/Event/BeamElectronTruth.cxx
@@ -17,21 +17,11 @@ ClassImp(ldmx::BeamElectronTruth)
     binnedY_ = -999;
   }
 
-  //  std::ostream &operator<<(std::ostream &s, const ldmx::BeamElectronTruth
-  //  &b) {
-  //   s << "BeamElectronTruth { "
-  // 	  << "(x = " << b.getX()
-  // 	  << ", y = " << b.getY()
-  // 	  << ", z = " << b.getZ()  << ") } ";
-  //   return s;
-  // }
-
   void BeamElectronTruth::Print() const {
     std::cout << "BeamElectronTruth { "
-              << "(x: " << x_ << ", y: " << y_ << ", z: " << z_ << ")"
-              << "; (binned X: " << binnedX_ << ", binned Y: " << binnedY_
-              << ")"
-              << "; (px: " << px_ << ", py: " << py_ << ", pz: " << pz_ << ")"
+              << "(x: " << x_ << ", y: " << y_ << ", z: " << z_
+              << "); (binned X: " << binnedX_ << ", binned Y: " << binnedY_
+              << "); (px: " << px_ << ", py: " << py_ << ", pz: " << pz_ << ")"
               << std::endl;
   }
 }  // namespace ldmx


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1265 , with the caveat that I don't have a way to get the particle momentum from the TargetSimHits but this might be added later from some other collection if people want to add this info. So I punt on that. 


## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

I ran the inclusive validation config once with 100 events, then ran it again with overlay generating 30 1e inclusive events on the fly, adding 2 pileup events to each. 

I ran `ldmx fire config.py` with the following config (first time `nEle=1`, second time `3`):
``` python
from LDMX.Framework import ldmxcfg

nEle=3
overlayString=""
thisPassName='sim'
if nEle > 1 :  #use overlay collection
    overlayString="Overlay"
    thisPassName='overlay'
pileupFilePassName='sim'  #to pull pileup from 
simPassName=thisPassName   #to pull "sim" event from -- this one; we run sim on the fly

p = ldmxcfg.Process(thisPassName)

from LDMX.SimCore import simulator as sim
mySim = sim.simulator( "mySim" )
mySim.setDetector( 'ldmx-det-v14' )
from LDMX.SimCore import generators as gen
mySim.generators.append( gen.single_4gev_e_upstream_tagger() )
mySim.beamSpotSmear = [20.,80.,0.]
mySim.description = 'Basic test Simulation'

p.sequence = [ mySim ]


##################################################################
# Below should be the same for all sim scenarios

import os
import sys

p.run = 1+nEle
p.maxEvents = 30


p.outputFiles = [f'events{nEle}e.root']


from LDMX.Recon.overlay import OverlayProducer
overlay=OverlayProducer('events1e.root')  #use an earlier iteration of this setup. with runNb=1
overlay.passName = simPassName                  #sim input event pass name
overlay.overlayPassName = pileupFilePassName    #pileup input event pass name
overlay.totalNumberOfInteractions = float(nEle)
overlay.overlayCaloHitCollections=[ 
        "TriggerPad1SimHits", "TriggerPad2SimHits", "TriggerPad3SimHits", "TargetSimHits" ]
overlay.verbosity=0

if nEle > 1 : 
    p.sequence.extend([overlay])

#usual imports
import LDMX.Ecal.EcalGeometry
import LDMX.Ecal.ecal_hardcoded_conditions
import LDMX.Hcal.HcalGeometry
import LDMX.Hcal.hcal_hardcoded_conditions

#TS stuff can be used for comparisons but not shown/done here 
from LDMX.TrigScint.trigScint import TrigScintDigiProducer
from LDMX.TrigScint.trigScint import TrigScintClusterProducer
from LDMX.TrigScint.trigScint import trigScintTrack
ts_digis = [
        TrigScintDigiProducer.pad1(),
        TrigScintDigiProducer.pad2(),
        TrigScintDigiProducer.pad3(),
        ]
for d in ts_digis :
    d.randomSeed = p.run
    d.input_collection = d.input_collection+overlayString

#run the truthhitprdocer on the target as this isolates truth beam electron hits and puts them in a new output collection
from LDMX.TrigScint.truthHits import TruthHitProducer
truthHits=TruthHitProducer('targetBeamElectrons')
truthHits.input_collection="TargetSimHits"+overlayString
truthHits.input_pass_name=thisPassName
truthHits.output_collection="truthBeamElectronsTarget"

#use the truthhit collection as input for this processor which picks out one location per beam electron
from LDMX.Recon.beamElectronLocator import BeamElectronLocator
beamLoc=BeamElectronLocator('BeamElectronLocator')
beamLoc.input_collection=truthHits.output_collection
beamLoc.input_pass_name = p.passName
beamLoc.granularity_X_mm = float(20/8)  # this is the envisioned TS granularity with vertical bars 
beamLoc.granularity_Y_mm = float(80/48) # this is the TS granularity in y
beamLoc.verbose = True

from LDMX.DQM import dqm

from LDMX.Recon.electronCounter import ElectronCounter
from LDMX.Recon.simpleTrigger import TriggerProcessor

count = ElectronCounter(nEle,'ElectronCounter')
count.input_pass_name = p.passName

p.termLogLevel=1

p.sequence.extend([
        *ts_digis,
        TrigScintClusterProducer.pad1(),
        TrigScintClusterProducer.pad2(),
        TrigScintClusterProducer.pad3(),
        trigScintTrack,
        count,
    truthHits,
    beamLoc
        ])


```

First plot shows, for one example 3e event (box option, size is proportional to counts), the (_x_,_y_) coordinates of TargetSimHits in black, the subset belonging to beam electrons in magenta, the locations found by the beam electron locator in dashed green, and the corresponding binned coordinates of the latter given a TS granularity in cyan. This all looks good. 

![3e_targetHitXYblack_beamEhitsXYmagenta_beamEectronTruthCollXYgreen_beamElectronTruthCollBinnedXYcyan](https://github.com/LDMX-Software/ldmx-sw/assets/42861632/fd2d8c6d-4867-4ac5-8d06-8f671590ea19)

In the next plot, the binned and "true" (within some minimum matching requirement window) _x_ coordinates from the beam locator are compared. If the actual _x_ coordinate is outside of the beam spot, its bin number is -1, corresponding to the "shifted" hits in the lower left corner. 
![3e_truthX_vs_binnedX_30events](https://github.com/LDMX-Software/ldmx-sw/assets/42861632/0361dbc8-3ae9-4b05-9d90-85eee4471c4f)
![3e_truthY_vs_binnedY_30events](https://github.com/LDMX-Software/ldmx-sw/assets/42861632/a75bf35e-ee9b-4f36-a093-dcc293395bae)

And the same distribution in _y_.
- [ ] I attached any sub-module related changes to this PR.
N/A

