### PR TITLE
Move msgs in EcalProcessFilter to logging system

### DIFF
--- a/Biasing/include/Biasing/EcalProcessFilter.h
+++ b/Biasing/include/Biasing/EcalProcessFilter.h
@@ -15,6 +15,7 @@
 /*   Framework   */
 /*~~~~~~~~~~~~~~~*/
 #include "Framework/Configure/Parameters.h"
+#include "Framework/EventProcessor.h"
 
 // Forward declaration
 class G4Step;
@@ -62,6 +63,9 @@ class EcalProcessFilter : public simcore::UserAction {
 
   /// Process to filter
   std::string process_{""};
+  
+  /// Enable logging
+  enableLogging("EcalProcessFilter")
 
 };  // EcalProcessFilter
 }  // namespace biasing

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -166,12 +166,12 @@ void EcalProcessFilter::stepping(const G4Step* step) {
       return;
     }
 
-    std::cout << "[ EcalProcessFilter ]: "
+    ldmx_log(debug) << "[ EcalProcessFilter ]: "
               << G4EventManager::GetEventManager()
                      ->GetConstCurrentEvent()
                      ->GetEventID()
               << " Brem photon produced " << secondaries->size()
-              << " particle via " << processName << " process." << std::endl;
+              << " particle via " << processName << " process.";
     trackInfo->tagBremCandidate(false);
     trackInfo->setSaveFlag(true);
     trackInfo->tagPNGamma();


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1250

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

Running 
```
ldmx fire ldmx-sw/.github/validation_samples/ecal_pn/config.py
```

Now the 
```
[ EcalProcessFilter ]: (event nb) Brem photon produced (some number of) particle via biasWrapper(photonNuclear) process.
```
 are not printed out by default.

- [x] I attached any sub-module related changes to this PR.

N/A
