### PR TITLE
enable debug-level to the terminal in validation sample configs

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -22,6 +22,7 @@ p.run = int(os.environ['LDMX_RUN_NUMBER'])
 
 p.histogramFile = f'hist.root'
 p.outputFiles = [f'events.root']
+p.termLogLevel = 0
 
 import LDMX.Ecal.EcalGeometry
 import LDMX.Ecal.ecal_hardcoded_conditions

--- a/.github/validation_samples/hcal/config.py
+++ b/.github/validation_samples/hcal/config.py
@@ -47,6 +47,7 @@ p.maxEvents = int(os.environ['LDMX_NUM_EVENTS'])
 
 p.histogramFile = 'hist.root'
 p.outputFiles = ['events.root']
+p.termLogLevel = 0
 
 import LDMX.Ecal.EcalGeometry
 import LDMX.Ecal.ecal_hardcoded_conditions

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -22,6 +22,7 @@ p.maxEvents = int(os.environ['LDMX_NUM_EVENTS'])
 
 p.histogramFile = 'hist.root'
 p.outputFiles = ['events.root']
+p.termLogLevel = 0
 
 import LDMX.Ecal.EcalGeometry
 import LDMX.Ecal.ecal_hardcoded_conditions

--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -14,6 +14,7 @@ p=ldmxcfg.Process(thisPassName)
 
 p.run = int(os.environ['LDMX_RUN_NUMBER'])
 p.maxEvents = int(os.environ['LDMX_NUM_EVENTS'])
+p.termLogLevel = 0
 
 from LDMX.Recon.overlay import OverlayProducer
 overlay=OverlayProducer('pileup.root')

--- a/.github/validation_samples/signal/config.py
+++ b/.github/validation_samples/signal/config.py
@@ -27,6 +27,7 @@ p.run = int(os.environ['LDMX_RUN_NUMBER'])
 
 p.histogramFile = f'hist.root'
 p.outputFiles = [f'events.root']
+p.termLogLevel = 0
 
 import LDMX.Ecal.EcalGeometry
 import LDMX.Ecal.ecal_hardcoded_conditions


### PR DESCRIPTION
not doing it in the configs that prepare input files for `it_pileup` since both of those configs are tested elsewhere already (`inclusive` and `ecal_pn`).

### What are the issues that this addresses?
This resolves #1280
.

I am leaving the testing to the CI. This should fail all of the validation tests but only when checking the logs.