### PR TITLE
Add scripts to compile, and recompile and fire a config (intro of `ldmx compile` and `ldmx recompFire`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@
   - **Note**: You need to [setup an SSH-key with your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) on the computer you are using.
 - Setup the environment (in bash): `source ldmx-sw/scripts/ldmx-env.sh`
   - **Note**: If you are working with ldmx-sw at SLAC's SDF, you will need to set the `TMPDIR` environment variable so that program running the container has more than ~5GB of space to write intermediate files. The default temporary space (`/tmp`) is often full of other files already. A decent replacement is `TMPDIR=${SCRATCH}` which gives the program plenty of room for the files it needs to manipulate.
-- Make a build directory: `cd ldmx-sw; mkdir build; cd build;`
-- Configure the build: `ldmx cmake ..`
-- Build and Install: `ldmx make install -j2`
+- Configure and compile: `ldmx compile`
 - Now you can run any processor in _ldmx-sw_ through `ldmx fire myconfig.py`
+- If you are developing and need to recompile and run `ldmx fire`, you can use `ldmx recompFire myconfig.py`
 
 ## Documentation 
 The full documentation for **ldmx-sw** is available on [github pages](https://ldmx-software.github.io/).
@@ -40,7 +39,9 @@ Command | Purpose
 `ldmx cmake ..` | Configure the ldmx-sw build
 `ldmx make` | Compile/build ldmx-sw
 `ldmx make install` | Install ldmx-sw
+`ldmx compile` | Configure and compile ldmx-sw
 `ldmx fire config.py` | Use ldmx-sw application and processors with input python configuration
+`ldmx recompFire config.py` | Recompile and run fire on a config file
 `ldmx python3 analysis.py` | Run python-based analysis
 `ldmx ./bin/mg5_aMC` | Run MadGraph5 inside (ubuntu-based) container
 

--- a/scripts/ldmx-compile.sh
+++ b/scripts/ldmx-compile.sh
@@ -4,7 +4,7 @@
 # ldmx ./scripts/ldmx-compile.sh
 # for changing the defaults
 # ldmx setenv LDMX_COMPILE_CORES=<num cores to be used>, i.e.
-# ldmx setenv LDMX_COMPILE_CORES=8
+# ldmx setenv LDMX_COMPILE_CORES=16
 # or
 # ldmx setenv LDMX_COMPILE_BUILD=<build location>
 
@@ -19,5 +19,5 @@ fi
 echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} cores"
 
 # Compile ldmx-sw
-cmake -B ${LDMX_COMPILE_BUILD}/build -S .
+cmake -B ${LDMX_COMPILE_BUILD}/build -S ${LDMX_COMPILE_BUILD}
 cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}

--- a/scripts/ldmx-compile.sh
+++ b/scripts/ldmx-compile.sh
@@ -1,33 +1,23 @@
+#!/bin/bash
+
 ############################# Usage #############################
-# source scripts/ldmx-compile.sh.sh [-j <numCores>] [-b <buildLocation>]
-# e.g. source scripts/ldmx-compile.sh
-# or   source scripts/ldmx-compile.sh -j 16 -b ${LDMX_BASE}/ldmx-sw
+# ldmx ./scripts/ldmx-compile.sh
+# for changing the defaults
+# ldmx setenv LDMX_COMPILE_CORES=<num cores to be used>, i.e.
+# ldmx setenv LDMX_COMPILE_CORES=8
+# or
+# ldmx setenv LDMX_COMPILE_BUILD=<build location>
 
-# set number of cores to be used, build location
-while [[ $# -gt 0 ]]; do
-  # number of cores
-  if [[ $1 == "-j"* ]]; then
-      if [[ $1 =~ ^-j\s*[=]?\s*([0-9]+)$ ]]; then
-          CORES=${BASH_REMATCH[1]}
-      fi
-  else
-    CORES=$(nproc)
-  fi
-  # build directory
-  if [[ $1 == "-b"* ]]; then
-      if [[ $1 =~ ^-b\s*[=]?\s*([a-zA-Z0-9]+)$ ]]; then
-          BUILD=${BASH_REMATCH[1]}
-      fi
-  else
-      BUILD=${LDMX_BASE}/ldmx-sw
-  fi
-  shift
-done
+if [ -z "$LDMX_COMPILE_CORES" ]; then
+    LDMX_COMPILE_CORES=$(nproc)
+fi
 
-echo "-- Compiling ldmx-sw in ${BUILD} with ${CORES} cores"
+if [ -z "$LDMX_COMPILE_BUILD" ]; then
+    LDMX_COMPILE_BUILD=${LDMX_BASE}/ldmx-sw/
+fi
+
+echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} cores"
 
 # Compile ldmx-sw
-cd ${BUILD}
-ldmx cmake -B ${BUILD}/build -S .
-ldmx cmake --build ${BUILD}/build --target install -j=$CORES
-cd -
+cmake -B ${LDMX_COMPILE_BUILD}/build -S .
+cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}

--- a/scripts/ldmx-compile.sh
+++ b/scripts/ldmx-compile.sh
@@ -19,5 +19,5 @@ fi
 echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} cores"
 
 # Compile ldmx-sw
-cmake -B ${LDMX_COMPILE_BUILD}/build -S ${LDMX_COMPILE_BUILD}
+cmake -B ${LDMX_COMPILE_BUILD}/build -S ${LDMX_COMPILE_BUILD} $@
 cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}

--- a/scripts/ldmx-compile.sh
+++ b/scripts/ldmx-compile.sh
@@ -1,0 +1,33 @@
+############################# Usage #############################
+# source scripts/ldmx-compile.sh.sh [-j <numCores>] [-b <buildLocation>]
+# e.g. source scripts/ldmx-compile.sh
+# or   source scripts/ldmx-compile.sh -j 16 -b ${LDMX_BASE}/ldmx-sw
+
+# set number of cores to be used, build location
+while [[ $# -gt 0 ]]; do
+  # number of cores
+  if [[ $1 == "-j"* ]]; then
+      if [[ $1 =~ ^-j\s*[=]?\s*([0-9]+)$ ]]; then
+          CORES=${BASH_REMATCH[1]}
+      fi
+  else
+    CORES=$(nproc)
+  fi
+  # build directory
+  if [[ $1 == "-b"* ]]; then
+      if [[ $1 =~ ^-b\s*[=]?\s*([a-zA-Z0-9]+)$ ]]; then
+          BUILD=${BASH_REMATCH[1]}
+      fi
+  else
+      BUILD=${LDMX_BASE}/ldmx-sw
+  fi
+  shift
+done
+
+echo "-- Compiling ldmx-sw in ${BUILD} with ${CORES} cores"
+
+# Compile ldmx-sw
+cd ${BUILD}
+ldmx cmake -B ${BUILD}/build -S .
+ldmx cmake --build ${BUILD}/build --target install -j=$CORES
+cd -

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -465,6 +465,8 @@ __ldmx_clean() {
   return ${rc}
 }
 
+
+
 ###############################################################################
 # __ldmx_source
 #   Run all the sub-commands in the provided file from the directory it is in.
@@ -538,6 +540,24 @@ __ldmx_checkout() {
 }
 
 ###############################################################################
+# __ldmx_compile
+#   Compile ldmx-sw
+###############################################################################
+
+__ldmx_compile() {
+  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-compile.sh
+}
+
+###############################################################################
+# __ldmx_recompFire
+#   Recompile ldmx-sw and run fire on the first argument
+###############################################################################
+
+__ldmx_recompFire() {
+  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-compile.sh $1
+}
+
+###############################################################################
 # __ldmx_help
 #   Print some helpful message to the terminal
 ###############################################################################
@@ -599,7 +619,7 @@ ldmx() {
   [[ "$#" == "0" ]] && { __ldmx_help; return $?; }
   # divide commands by number of arguments
   case $1 in
-    help|config)
+    help|config|compile)
       if [[ "$#" != "1" ]]; then
         __ldmx_${1}
         echo "ERROR: 'ldmx ${1}' takes no arguments."
@@ -608,7 +628,7 @@ ldmx() {
       __ldmx_${1}
       return $?
       ;;
-    list|base|clean|mount|setenv|source)
+    list|base|clean|mount|setenv|recompFire|source)
       if [[ "$#" != "2" ]]; then
         __ldmx_help
         echo "ERROR: ldmx ${1} takes one argument."

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -554,7 +554,7 @@ __ldmx_compile() {
 ###############################################################################
 
 __ldmx_recompFire() {
-  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-recompileAndFire.sh $1
+  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-recompileAndFire.sh $@
 }
 
 ###############################################################################

--- a/scripts/ldmx-env.sh
+++ b/scripts/ldmx-env.sh
@@ -554,7 +554,7 @@ __ldmx_compile() {
 ###############################################################################
 
 __ldmx_recompFire() {
-  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-compile.sh $1
+  ldmx . ${LDMX_BASE}/ldmx-sw/scripts/ldmx-recompileAndFire.sh $1
 }
 
 ###############################################################################
@@ -570,6 +570,8 @@ __ldmx_help() {
   COMMANDS:
     help    : print this help message and exit
       ldmx help
+    compile : Compile ldmx-sw
+      ldmx compile
     list    : List the tag options for the input container repository
       ldmx list (dev | pro | local)
     clean   : Reset ldmx computing environment
@@ -599,6 +601,7 @@ __ldmx_help() {
       ldmx cmake ..
       ldmx make install
       ldmx fire config.py
+      ldmx recompFire config.py
       ldmx python3 ana.py
 
 HELP
@@ -628,7 +631,7 @@ ldmx() {
       __ldmx_${1}
       return $?
       ;;
-    list|base|clean|mount|setenv|recompFire|source)
+    list|base|clean|mount|setenv|source)
       if [[ "$#" != "2" ]]; then
         __ldmx_help
         echo "ERROR: ldmx ${1} takes one argument."
@@ -655,7 +658,7 @@ ldmx() {
       __ldmx_use "$2" "$3"
       return $?
       ;;
-    run|checkout)
+    run|checkout|recompFire)
       __ldmx_${1} ${@:2}
       return $?
       ;;
@@ -795,12 +798,12 @@ __ldmx_complete() {
 
   if [[ "$COMP_CWORD" = "1" ]]; then
     # tab completing a main argument
-    __ldmx_complete_command "list clean config checkout pull use run mount setenv base source"
+    __ldmx_complete_command "list clean config checkout pull use run mount setenv base source compile recompFire"
   elif [[ "$COMP_CWORD" = "2" ]]; then
     # tab complete a sub-argument,
     #   depends on the main argument
     case "${COMP_WORDS[1]}" in
-      config|setenv)
+      config|setenv|compile)
         # no more arguments
         __ldmx_dont_complete
         ;;
@@ -829,7 +832,7 @@ __ldmx_complete() {
     #   check base argument to see if we should continue
     case "${COMP_WORDS[1]}" in
       list|base|clean|config|pull|use|mount|setenv|source)
-        # these commands shouldn't have tab complete for the third argument 
+        # these commands shouldn't have tab complete for the third argument
         #   (or shouldn't have the third argument at all)
         __ldmx_dont_complete
         ;;

--- a/scripts/ldmx-recompileAndFire.sh
+++ b/scripts/ldmx-recompileAndFire.sh
@@ -1,0 +1,37 @@
+############################# Usage #############################
+# source scripts/ldmx-recompileAndFire.sh <config>.py [-j <numCores>] [-b <buildLocation>]
+# e.g. source scripts/ldmx-recompileAndFire.sh config.py
+# or   source scripts/ldmx-recompileAndFire.sh config.py -j 16 -b ${LDMX_BASE}/ldmx-sw
+
+# The input to fire has to be the first argument
+FIREINPUT=$1
+# set number of cores to be used, build location
+while [[ $# -gt 0 ]]; do
+  # number of cores
+  if [[ $1 == "-j"* ]]; then
+      if [[ $1 =~ ^-j\s*[=]?\s*([0-9]+)$ ]]; then
+          CORES=${BASH_REMATCH[1]}
+      fi
+  else
+    CORES=$(nproc)
+  fi
+  # build directory
+  if [[ $1 == "-b"* ]]; then
+      if [[ $1 =~ ^-b\s*[=]?\s*([a-zA-Z0-9]+)$ ]]; then
+          BUILD=${BASH_REMATCH[1]}
+      fi
+  else
+      BUILD=${LDMX_BASE}/ldmx-sw
+  fi
+  shift
+done
+
+echo "-- Compiling ldmx-sw in ${BUILD} with ${CORES} cores, then running $FIREINPUT"
+
+# Compile ldmx-sw
+cd ${BUILD}
+ldmx cmake -B ${BUILD}/build -S .
+ldmx cmake --build ${BUILD}/build --target install -j=$CORES
+# Run fire on the input config
+cd -
+ldmx fire $FIREINPUT

--- a/scripts/ldmx-recompileAndFire.sh
+++ b/scripts/ldmx-recompileAndFire.sh
@@ -8,7 +8,6 @@
 # or
 # ldmx setenv LDMX_COMPILE_BUILD=<build location>
 
-FIREINPUT=$1
 
 if [ -z "$LDMX_COMPILE_CORES" ]; then
     LDMX_COMPILE_CORES=$(nproc)
@@ -24,4 +23,4 @@ echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} c
 cmake -B ${LDMX_COMPILE_BUILD}/build -S ${LDMX_COMPILE_BUILD}
 cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}
 # Run fire on the input config
-fire $FIREINPUT
+fire $@

--- a/scripts/ldmx-recompileAndFire.sh
+++ b/scripts/ldmx-recompileAndFire.sh
@@ -4,7 +4,7 @@
 # ldmx ./scripts/ldmx-recompileAndFire.sh
 # for changing the defaults
 # ldmx setenv LDMX_COMPILE_CORES=<num cores to be used>, i.e.
-# ldmx setenv LDMX_COMPILE_CORES=8
+# ldmx setenv LDMX_COMPILE_CORES=16
 # or
 # ldmx setenv LDMX_COMPILE_BUILD=<build location>
 
@@ -21,7 +21,7 @@ fi
 echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} cores, and running "
 
 # Compile ldmx-sw
-cmake -B ${LDMX_COMPILE_BUILD}/build -S .
+cmake -B ${LDMX_COMPILE_BUILD}/build -S ${LDMX_COMPILE_BUILD}
 cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}
 # Run fire on the input config
 fire $FIREINPUT

--- a/scripts/ldmx-recompileAndFire.sh
+++ b/scripts/ldmx-recompileAndFire.sh
@@ -1,37 +1,27 @@
+#!/bin/bash
+
 ############################# Usage #############################
-# source scripts/ldmx-recompileAndFire.sh <config>.py [-j <numCores>] [-b <buildLocation>]
-# e.g. source scripts/ldmx-recompileAndFire.sh config.py
-# or   source scripts/ldmx-recompileAndFire.sh config.py -j 16 -b ${LDMX_BASE}/ldmx-sw
+# ldmx ./scripts/ldmx-recompileAndFire.sh
+# for changing the defaults
+# ldmx setenv LDMX_COMPILE_CORES=<num cores to be used>, i.e.
+# ldmx setenv LDMX_COMPILE_CORES=8
+# or
+# ldmx setenv LDMX_COMPILE_BUILD=<build location>
 
-# The input to fire has to be the first argument
 FIREINPUT=$1
-# set number of cores to be used, build location
-while [[ $# -gt 0 ]]; do
-  # number of cores
-  if [[ $1 == "-j"* ]]; then
-      if [[ $1 =~ ^-j\s*[=]?\s*([0-9]+)$ ]]; then
-          CORES=${BASH_REMATCH[1]}
-      fi
-  else
-    CORES=$(nproc)
-  fi
-  # build directory
-  if [[ $1 == "-b"* ]]; then
-      if [[ $1 =~ ^-b\s*[=]?\s*([a-zA-Z0-9]+)$ ]]; then
-          BUILD=${BASH_REMATCH[1]}
-      fi
-  else
-      BUILD=${LDMX_BASE}/ldmx-sw
-  fi
-  shift
-done
 
-echo "-- Compiling ldmx-sw in ${BUILD} with ${CORES} cores, then running $FIREINPUT"
+if [ -z "$LDMX_COMPILE_CORES" ]; then
+    LDMX_COMPILE_CORES=$(nproc)
+fi
+
+if [ -z "$LDMX_COMPILE_BUILD" ]; then
+    LDMX_COMPILE_BUILD=${LDMX_BASE}/ldmx-sw/
+fi
+
+echo "-- Compiling ldmx-sw in ${LDMX_COMPILE_BUILD} with ${LDMX_COMPILE_CORES} cores, and running "
 
 # Compile ldmx-sw
-cd ${BUILD}
-ldmx cmake -B ${BUILD}/build -S .
-ldmx cmake --build ${BUILD}/build --target install -j=$CORES
+cmake -B ${LDMX_COMPILE_BUILD}/build -S .
+cmake --build ${LDMX_COMPILE_BUILD}/build --target install -j=${LDMX_COMPILE_CORES}
 # Run fire on the input config
-cd -
-ldmx fire $FIREINPUT
+fire $FIREINPUT


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1278

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments

- [x] I ran my developments and the following shows that they are successful.

The way I ran this was to copy the pn validation config to my location and named it config.py, then run
```
############################# Usage #############################
# ldmx ./scripts/ldmx-recompileAndFire.sh
# for changing the defaults
# ldmx setenv LDMX_COMPILE_CORES=<num cores to be used>, i.e.
# ldmx setenv LDMX_COMPILE_CORES=16
# or
# ldmx setenv LDMX_COMPILE_BUILD=<build location>
```
also ran
```
ldmx compile
```
and
```
ldmx recompFire config.py
```

- [x] I attached any sub-module related changes to this PR.

N/A