### PR TITLE
add config for studying ecal resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ EventDisplay/include/EventDisplay/EventDisplayLinkDef.h
 *.DS_Store
 *.vscode/*
 *__*
+
+# data files from running configs
+*.root
+# except special files storing test results
+!.github/validation_samples/**.root

--- a/Ecal/exampleConfigs/ecal-resolution-study-with-trig-prim-monoenergetic-beam.py
+++ b/Ecal/exampleConfigs/ecal-resolution-study-with-trig-prim-monoenergetic-beam.py
@@ -1,0 +1,85 @@
+"""Ecal-focused config script
+
+This config script allows the user to choose the energy and angle
+of the electron as it enters the front face of the ECal. After the
+simulation, it runs the EcalDigiProducer, EcalRecProducer, and
+EcalTrigPrimDigiProducer for studying how the Ecal handles the
+input electron.
+
+    ldmx fire ecal-resolution-study-with-trig-prim.py --help
+"""
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--n-events',default=10,type=int,help='number of events to simulate')
+parser.add_argument('--run',default=1,help='run number (controls random number seeding)')
+parser.add_argument('--out-dir',default=os.getcwd(),help='directory to put output file into')
+parser.add_argument('--energy',default=4.,help='energy of incident electron in GeV')
+parser.add_argument('--theta',default=0,help='angle incident electron makes with respect to z-axis in degrees')
+parser.add_argument('--phi', default=0, help='azimuthal angle incident electron makes')
+parser.add_argument('--angle-at-target',action='store_true', help='have the initial position shift so that the angles are from the target')
+
+arg = parser.parse_args()
+
+from LDMX.Framework import ldmxcfg
+
+if not os.path.isdir(arg.out_dir) :
+    raise KeyError(f'Need to create output directory {arg.out_dir}')
+
+p = ldmxcfg.Process( "valid" )
+p.run = arg.run
+p.maxEvents = arg.n_events
+p.maxTriesPerEvent = 10000
+file_stub = f'energy_{arg.energy}_theta_{arg.theta:02d}_phi_{arg.phi}_attarget_{arg.angle_at_target}_geometry_v14_events_{arg.n_events}_run_{arg.run}.root'
+p.outputFiles = [ arg.out_dir+'/type_events_'+file_stub ]
+
+# we want to see every event
+p.logFrequency = 1000
+p.termLogLevel = 0
+
+from LDMX.SimCore import simulator
+from LDMX.SimCore import generators
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Ecal.digi as ecal_digi
+import LDMX.Ecal.ecal_trig_digi as ecal_trig_digi
+
+electrons = generators.gun('ecal-electrons')
+electrons.particle = 'e-'
+electrons.energy = arg.energy
+from math import sin, cos, tan, pi
+phi = arg.phi * pi/180
+theta = arg.theta * pi/180
+electrons.direction = [sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta)]
+# the front of the ECal is at z=240mm
+# the last recoil tracking layer is at z=188mm
+# we don't want anything else mucking up the particle before hitting the Ecal
+#  so that we can easily know what the "true" value of something is, so
+#  we want to keep z between ~200 and 240
+z = 220. # mm - in front of ECal but skipping tracker/target material
+# if we wanted the angles to be angles _from the target_, we need to 
+#  shift the electron transverse (x and y) position as well so that
+#  the electron avoids material /and/ looks like it came from the target
+# or we could just have it be angles without moving the particle
+#  this would be helpful for seeing how the angle of the particle
+#  affects the resolution without having to worry about containment as much
+electrons.position = [z*tan(theta)*cos(phi), z*tan(theta)*sin(phi), z] if arg.angle_at_target else [0., 0., z]
+
+validator = simulator.simulator('plain')
+validator.setDetector(f'ldmx-det-v14', False)
+validator.description = 'Electrons straight into ECal for ECal geometry testing'
+validator.generators = [electrons]
+
+# turn off all PN interactions so we have a "clean" EM shower
+from LDMX.SimCore import photonuclear_models as pn
+validator.photonuclear_model = pn.NoPhotoNuclearModel()
+
+digi = ecal_digi.EcalDigiProducer()
+prec_rec = ecal_digi.EcalRecProducer()
+trig_digi = ecal_trig_digi.EcalTrigPrimDigiProducer()
+
+p.sequence = [ validator, digi, prec_rec, trig_digi ]

--- a/Ecal/exampleConfigs/ecal-resolution-study-with-trig-prim-uniform-energy-beam.py
+++ b/Ecal/exampleConfigs/ecal-resolution-study-with-trig-prim-uniform-energy-beam.py
@@ -1,0 +1,86 @@
+"""Ecal-focused config script
+
+This config script allows the user to choose the energy and angle
+of the electron as it enters the front face of the ECal. After the
+simulation, it runs the EcalDigiProducer, EcalRecProducer, and
+EcalTrigPrimDigiProducer for studying how the Ecal handles the
+input electron.
+
+    ldmx fire ecal-resolution-study-with-trig-prim-uniform-energy-beam.py --help
+"""
+
+import argparse
+import os
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--n-events',default=10,type=int,help='number of events to simulate')
+parser.add_argument('--run',default=3,help='run number (controls random number seeding)')
+parser.add_argument('--out-dir',default=os.getcwd(),help='directory to put output file into')
+parser.add_argument('--energy-min',default=1.,help='min energy of incident electron in GeV')
+parser.add_argument('--energy-max',default=4.,help='max energy of incident electron in GeV')
+
+arg = parser.parse_args()
+
+from LDMX.Framework import ldmxcfg
+
+if not os.path.isdir(arg.out_dir) :
+    raise KeyError(f'Need to create output directory {arg.out_dir}')
+
+p = ldmxcfg.Process( "valid" )
+p.run = arg.run
+p.maxEvents = arg.n_events
+p.maxTriesPerEvent = 10000
+file_stub = '_'.join([
+    'type', 'events',
+    'emin', str(arg.energy_min),
+    'emax', str(arg.energy_max),
+    'geometry', 'v14',
+    'events', str(arg.n_events),
+    'run', str(arg.run)
+])
+p.outputFiles = [ arg.out_dir+'/'+file_stub+'.root' ]
+
+# we want to see every event
+p.logFrequency = 1000
+p.termLogLevel = 0
+
+from LDMX.SimCore import simulator
+from LDMX.SimCore import generators
+import LDMX.Ecal.EcalGeometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Hcal.HcalGeometry
+import LDMX.Ecal.digi as ecal_digi
+import LDMX.Ecal.ecal_trig_digi as ecal_trig_digi
+
+electrons = generators.gps(
+    'ecal-electrons',
+    [
+        '/gps/particle e-',
+        '/gps/pos/type Point', #beamSpotSmear will smear for us
+        '/gps/pos/centre 0 0 220. mm', # start in from of ECal
+        '/gps/direction 0 0 1', # directly into ECal
+        '/gps/ene/type Lin',
+        f'/gps/ene/min {arg.energy_min} GeV',
+        f'/gps/ene/max {arg.energy_max} GeV',
+        '/gps/ene/gradient 0', # linear distribution flat so its uniform
+        '/gps/ene/intercept 1',
+        '/gps/pos/shape Square',
+        '/gps/number 1'
+    ]
+)
+
+validator = simulator.simulator('plain')
+validator.setDetector(f'ldmx-det-v14', False)
+validator.description = 'Electrons straight into ECal for ECal geometry testing'
+validator.generators = [electrons]
+
+# turn off all PN interactions so we have a "clean" EM shower
+from LDMX.SimCore import photonuclear_models as pn
+validator.photonuclear_model = pn.NoPhotoNuclearModel()
+
+digi = ecal_digi.EcalDigiProducer()
+prec_rec = ecal_digi.EcalRecProducer()
+trig_digi = ecal_trig_digi.EcalTrigPrimDigiProducer()
+
+p.sequence = [ validator, digi, prec_rec, trig_digi ]

--- a/Ecal/exampleConfigs/trig-prim-analyzer.py
+++ b/Ecal/exampleConfigs/trig-prim-analyzer.py
@@ -1,0 +1,48 @@
+"""Run TrigPrimResolutionAnalyzer over an already-created file
+
+    ldmx fire trig-prim-analyzer.py --help
+"""
+
+import argparse
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--max-events',default=None,type=int,help='maximum number of events to process (helpful to limit while test-running)')
+parser.add_argument('--out-dir',default=Path.cwd(),help='directory to put output histogram file')
+parser.add_argument('--out-name',default=None,help='name output histogram file (default is to deduce a name from the input file)')
+parser.add_argument('input_file',nargs='+',type=Path,help='input file(s) to run analyzer over')
+
+arg = parser.parse_args()
+
+if len(arg.input_file) > 1 and arg.out_name is None:
+    parser.error('Need to give --out-name if more than one input file is given.')
+elif arg.out_name is None:
+    arg.out_name = arg.input_file[0].stem
+    if 'type_events' in arg.out_name:
+        arg.out_name = arg.out_name.replace('events','histos')
+    else:
+        arg.out_name += '_histos'
+    arg.out_name += '.root'
+
+if not arg.out_dir.is_dir():
+    parser.error(f'Output directory {arg.out_dir} does not exist. Is it mounted to the container? Do you need to create it?')
+
+from LDMX.Framework import ldmxcfg
+
+p = ldmxcfg.Process( "valid" )
+if arg.max_events is not None:
+    p.maxEvents = arg.max_events
+
+p.inputFiles = [str(path) for path in arg.input_file]
+p.histogramFile = str(arg.out_dir / arg.out_name)
+
+# print updates every 1k events
+p.logFrequency = 1000
+p.termLogLevel = 0
+
+import LDMX.Ecal.EcalGeometry
+
+p.sequence = [
+    ldmxcfg.Analyzer('resolution','ldmx::ecal::TrigPrimResolutionAnalyzer','Ecal')
+]

--- a/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -1,12 +1,10 @@
-#include "Framework/EventProcessor.h"
-
-#include "Ecal/Event/EcalHit.h"
-#include "Recon/Event/HgcrocTrigDigi.h"
-#include "Recon/Event/HgcrocDigiCollection.h"
 #include "DetDescr/EcalID.h"
 #include "DetDescr/EcalTriggerID.h"
-
 #include "Ecal/EcalTriggerGeometry.h"
+#include "Ecal/Event/EcalHit.h"
+#include "Framework/EventProcessor.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+#include "Recon/Event/HgcrocTrigDigi.h"
 
 namespace ldmx::ecal {
 class TrigPrimResolutionAnalyzer : public framework::Analyzer {
@@ -16,21 +14,25 @@ class TrigPrimResolutionAnalyzer : public framework::Analyzer {
   std::string trig_pass_name_ = "";
   std::string hit_collection_name_ = "EcalRecHits";
   std::string hit_pass_name_ = "";
+
  public:
-  TrigPrimResolutionAnalyzer(const std::string& name, framework::Process& process)
-    : framework::Analyzer(name, process) {}
+  TrigPrimResolutionAnalyzer(const std::string& name,
+                             framework::Process& process)
+      : framework::Analyzer(name, process) {}
   virtual ~TrigPrimResolutionAnalyzer() = default;
   void configure(framework::config::Parameters& parameters) final;
   void onProcessStart() final;
   void analyze(const framework::Event& event) final;
 };
 
-void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parameters) {
+void TrigPrimResolutionAnalyzer::configure(
+    framework::config::Parameters& parameters) {
   /*
-   * Since I defined these member variables to have sensible values in the declaration above,
-   * we DO NOT get their parameter values from the python config. Below, I have written out
-   * the lines that we could use to get their values from the python config if changing them
-   * is desirable (e.g. if you want to run a few different passes of digi and recon with different
+   * Since I defined these member variables to have sensible values in the
+   * declaration above, we DO NOT get their parameter values from the python
+   * config. Below, I have written out the lines that we could use to get their
+   * values from the python config if changing them is desirable (e.g. if you
+   * want to run a few different passes of digi and recon with different
    * parameters and then want to analyze the different passes).
    */
   /*
@@ -41,30 +43,29 @@ void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parame
   hit_collection_name_ = parameters.getParameter("hit_collection_name");
   hit_pass_name_ = parameters.getParameter("hit_pass_name");
   */
-//  digiCollName_ = parameters.getParameter<std::string>("digiCollName");
-//  digiPassName = parameters.getParameter<std::string>("digiPassName");
-//  condObjName_ =
-//	  parameters.getParameter<std::string>("condObjName","EcalTrigPrimDigiConditions");
+  //  digiCollName_ = parameters.getParameter<std::string>("digiCollName");
+  //  digiPassName = parameters.getParameter<std::string>("digiPassName");
+  //  condObjName_ =
+  //	  parameters.getParameter<std::string>("condObjName","EcalTrigPrimDigiConditions");
 }
 
 void TrigPrimResolutionAnalyzer::onProcessStart() {
-
-
   // variable bins
-  std::vector<double> binsx = {0.,10.,20.,30.,40.,50.,60.,70.,80.,
-	  90.,100.,110.,120.,130.,140.,150.,300.,575.,1000.};
-  std::vector<double> binsy ={0.6  , 0.608, 0.616, 0.624, 0.632, 0.64 , 0.648, 0.656, 0.664,
-       0.672, 0.68 , 0.688, 0.696, 0.704, 0.712, 0.72 , 0.728, 0.736,
-       0.744, 0.752, 0.76 , 0.768, 0.776, 0.784, 0.792, 0.8  , 0.808,
-       0.816, 0.824, 0.832, 0.84 , 0.848, 0.856, 0.864, 0.872, 0.88 ,
-       0.888, 0.896, 0.904, 0.912, 0.92 , 0.928, 0.936, 0.944, 0.952,
-       0.96 , 0.968, 0.976, 0.984, 0.992, 1.   , 1.008, 1.016, 1.024,
-       1.032, 1.04 , 1.048, 1.056, 1.064, 1.072, 1.08 , 1.088, 1.096,
-       1.104, 1.112, 1.12 , 1.128, 1.136, 1.144, 1.152, 1.16 , 1.168,
-       1.176, 1.184, 1.192, 1.2  , 1.208, 1.216, 1.224, 1.232, 1.24 ,
-       1.248, 1.256, 1.264, 1.272, 1.28 , 1.288, 1.296, 1.304, 1.312,
-       1.32 , 1.328, 1.336, 1.344, 1.352, 1.36 , 1.368, 1.376, 1.384,
-       1.392, 1.4};
+  std::vector<double> binsx = {0.,   10.,  20.,  30.,  40.,  50.,  60.,
+                               70.,  80.,  90.,  100., 110., 120., 130.,
+                               140., 150., 300., 575., 1000.};
+  std::vector<double> binsy = {
+      0.6,  0.608, 0.616, 0.624, 0.632, 0.64, 0.648, 0.656, 0.664, 0.672,
+      0.68, 0.688, 0.696, 0.704, 0.712, 0.72, 0.728, 0.736, 0.744, 0.752,
+      0.76, 0.768, 0.776, 0.784, 0.792, 0.8,  0.808, 0.816, 0.824, 0.832,
+      0.84, 0.848, 0.856, 0.864, 0.872, 0.88, 0.888, 0.896, 0.904, 0.912,
+      0.92, 0.928, 0.936, 0.944, 0.952, 0.96, 0.968, 0.976, 0.984, 0.992,
+      1.,   1.008, 1.016, 1.024, 1.032, 1.04, 1.048, 1.056, 1.064, 1.072,
+      1.08, 1.088, 1.096, 1.104, 1.112, 1.12, 1.128, 1.136, 1.144, 1.152,
+      1.16, 1.168, 1.176, 1.184, 1.192, 1.2,  1.208, 1.216, 1.224, 1.232,
+      1.24, 1.248, 1.256, 1.264, 1.272, 1.28, 1.288, 1.296, 1.304, 1.312,
+      1.32, 1.328, 1.336, 1.344, 1.352, 1.36, 1.368, 1.376, 1.384, 1.392,
+      1.4};
 
   // initialize processing by making histograms and such
   // first, we get the directory for this processor in the histogram file
@@ -74,12 +75,10 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
       "total_trig_energy" /* name - as written in output ROOT file */,
       "Total of all Trig Digis [MeV]" /* xlabel - axis label of histogram */,
       100 /* number of bins */, 0 /* minimum value */, 8000 /* maximum value */
-  ); // WARNING: I don't think this binning is good!! I just picked a random number!!
-  histograms_.create(
-      "total_ampl_energy",
-      "Total of Precision Hit Amplitudes [MeV]",
-      100, 0, 8000
-  );
+  );  // WARNING: I don't think this binning is good!! I just picked a random
+      // number!!
+  histograms_.create("total_ampl_energy",
+                     "Total of Precision Hit Amplitudes [MeV]", 100, 0, 8000);
   /*
    * 2D Histograms are also possible
   histograms_.create(
@@ -88,135 +87,58 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
       "ylabel", nbins, ystart, yend
   );
   */
-  histograms_.create(
-      "total_trig_v_total_ampl",
-      "Total of all Trig Digis [MeV]",
-      1000, 0, 8000,
-      "Total of Precision Hit Amplitudes [MeV]",
-      100, 0, 8000
-  );
-  histograms_.create(
-      "trig_ampl_nominal",
-      "Total trig / total ampl",
-      100, 0.85, 1.15
-  );
-  histograms_.create(
-      "module_id",
-      "Module id",
-      7,0,7
-  );
-  histograms_.create(
-      "layer_id",
-      "Layer id",
-      34,0,34
-  );
-  histograms_.create(
-      "trig_sum_per_module",
-      "module trigger sum [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "ampl_sum_per_module",
-      "module precision ampl sum [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "trig_v_ampl_module",
-      "Module-sum full readout [MeV]",
-      100,0,2000,
-      "Module-sum trigger [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "trig_sum_per_layer",
-      "layer trigger sum [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "ampl_sum_per_layer",
-      "layer precision ampl sum [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "trig_v_ampl_layer",
-      "Layer trigger total [MeV]",
-      100,0,2500,
-      "Layer ampl total [MeV]",
-      100,0,2500
-  );
-  histograms_.create(
-      "trig_ampl_v_ampl",
-      "module precision ampl sum [MeV]",
-      100,0,1000,
-      "module trigger / module precision ampl",
-      100, 0.4, 1.2
-  );
-  histograms_.create(
-      "trig_ampl_v_ampl_binadjust",
-      "module precision trig sum [MeV]",
-      100,0,2000,
-      "module trigger / module precision ampl",
-      100, 0.4, 1.2
-  );
-  histograms_.create(
-      "trig_ampl_v_ampl_layer",
-      "layer precision ampl sum [MeV]",
-      100,0,1000,
-      "layer trigger / layer precision ampl",
-      100, 0.4, 1.2
-  );
-  histograms_.create(
-      "trig_ampl_v_ampl_total",
-      "total precision ampl sum [MeV]",
-      100,0,8000,
-      "total trigger / total precision ampl",
-      100, 0.9, 1.1
-  );
-  histograms_.create(
-      "trig_ampl_v_ampl_total_first20",
-      "Full readout sum [MeV]",
-      100,0,6000,
-      "Trigger / Full readout",
-      100, 0.95, 1.05
-  );
-  histograms_.create(
-      "trig_group",
-      "trigger group total precision hits [MeV]",
-      100,0,2000
-  );
-  histograms_.create(
-      "trig_group_trigger",
-      "trigger group trigger [MeV]",
-      100,0,8000
-  );
-  histograms_.create(
-      "trig_group_v_trig",
-      "trigger group total precision hits [MeV]",
-      100,0,2000,
-      "trigger group trigger [MeV]",
-      100,0,8000
-  );
-  histograms_.create(
-      "trig_group_ampl_v_ampl",
-      "Trigger group full readout [MeV]",
-      100,0,1000,
-      "Trigger group ratio / nominal",
-      200,0.6,1.4
-  );
-  histograms_.create(
-      "trig_group_ampl_v_ampl_varbin",
-      "Trigger group full readout [MeV]",
-      binsx,
-      "Trigger group ratio / nominal",
-      binsy
-  );
-  histograms_.create(
-      "trig_group_ampl_unweight",
-      "unweighted trigger group total precision hits [MeV]",
-      100,0,20,
-      "trigger group trigger / unweighted trigger group total prec hits / nominal",
-      200,0.6,1.4
-  );
+  histograms_.create("total_trig_v_total_ampl", "Total of all Trig Digis [MeV]",
+                     1000, 0, 8000, "Total of Precision Hit Amplitudes [MeV]",
+                     100, 0, 8000);
+  histograms_.create("trig_ampl_nominal", "Total trig / total ampl", 100, 0.85,
+                     1.15);
+  histograms_.create("module_id", "Module id", 7, 0, 7);
+  histograms_.create("layer_id", "Layer id", 34, 0, 34);
+  histograms_.create("trig_sum_per_module", "module trigger sum [MeV]", 100, 0,
+                     2000);
+  histograms_.create("ampl_sum_per_module", "module precision ampl sum [MeV]",
+                     100, 0, 2000);
+  histograms_.create("trig_v_ampl_module", "Module-sum full readout [MeV]", 100,
+                     0, 2000, "Module-sum trigger [MeV]", 100, 0, 2000);
+  histograms_.create("trig_sum_per_layer", "layer trigger sum [MeV]", 100, 0,
+                     2000);
+  histograms_.create("ampl_sum_per_layer", "layer precision ampl sum [MeV]",
+                     100, 0, 2000);
+  histograms_.create("trig_v_ampl_layer", "Layer trigger total [MeV]", 100, 0,
+                     2500, "Layer ampl total [MeV]", 100, 0, 2500);
+  histograms_.create("trig_ampl_v_ampl", "module precision ampl sum [MeV]", 100,
+                     0, 1000, "module trigger / module precision ampl", 100,
+                     0.4, 1.2);
+  histograms_.create("trig_ampl_v_ampl_binadjust",
+                     "module precision trig sum [MeV]", 100, 0, 2000,
+                     "module trigger / module precision ampl", 100, 0.4, 1.2);
+  histograms_.create("trig_ampl_v_ampl_layer", "layer precision ampl sum [MeV]",
+                     100, 0, 1000, "layer trigger / layer precision ampl", 100,
+                     0.4, 1.2);
+  histograms_.create("trig_ampl_v_ampl_total", "total precision ampl sum [MeV]",
+                     100, 0, 8000, "total trigger / total precision ampl", 100,
+                     0.9, 1.1);
+  histograms_.create("trig_ampl_v_ampl_total_first20", "Full readout sum [MeV]",
+                     100, 0, 6000, "Trigger / Full readout", 100, 0.95, 1.05);
+  histograms_.create("trig_group", "trigger group total precision hits [MeV]",
+                     100, 0, 2000);
+  histograms_.create("trig_group_trigger", "trigger group trigger [MeV]", 100,
+                     0, 8000);
+  histograms_.create("trig_group_v_trig",
+                     "trigger group total precision hits [MeV]", 100, 0, 2000,
+                     "trigger group trigger [MeV]", 100, 0, 8000);
+  histograms_.create("trig_group_ampl_v_ampl",
+                     "Trigger group full readout [MeV]", 100, 0, 1000,
+                     "Trigger group ratio / nominal", 200, 0.6, 1.4);
+  histograms_.create("trig_group_ampl_v_ampl_varbin",
+                     "Trigger group full readout [MeV]", binsx,
+                     "Trigger group ratio / nominal", binsy);
+  histograms_.create("trig_group_ampl_unweight",
+                     "unweighted trigger group total precision hits [MeV]", 100,
+                     0, 20,
+                     "trigger group trigger / unweighted trigger group total "
+                     "prec hits / nominal",
+                     200, 0.6, 1.4);
 }
 
 /**
@@ -249,9 +171,13 @@ const double total_ampl_mean = 48.805244;
 // const double nominal = total_trigger_mean / total_ampl_mean;
 // nominal adjust for presentation
 const double nominal = 18.14;
-const double secondOrderEnergyCorrection = 4000./3940.5;
+const double secondOrderEnergyCorrection = 4000. / 3940.5;
 const double mip_si_energy = 0.13;
-double layerWeights[34] = {2.312, 4.312, 6.522, 7.490, 8.595, 10.253, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 14.783, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 9.938};
+double layerWeights[34] = {
+    2.312,  4.312,  6.522,  7.490,  8.595,  10.253, 10.915, 10.915, 10.915,
+    10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915,
+    10.915, 10.915, 10.915, 10.915, 10.915, 14.783, 18.539, 18.539, 18.539,
+    18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 9.938};
 
 /**
  * ordering operator required for UniqueModule to be used as a key in std::map
@@ -265,14 +191,18 @@ bool operator<(const UniqueModule& lhs, const UniqueModule& rhs) {
 
 void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   // called once on each event, get objects and fill histograms
-  const auto& trigs = event.getCollection<ldmx::HgcrocTrigDigi>(trig_collection_name_, trig_pass_name_);
+  const auto& trigs = event.getCollection<ldmx::HgcrocTrigDigi>(
+      trig_collection_name_, trig_pass_name_);
   // trigs are a std::vector<ldmx::HgcrocTrigDigi>
-  const auto& digis = event.getObject<ldmx::HgcrocDigiCollection>(digi_collection_name_, digi_pass_name_);
+  const auto& digis = event.getObject<ldmx::HgcrocDigiCollection>(
+      digi_collection_name_, digi_pass_name_);
   // digis are a ldmx::HgcrocDigiCollection
-  const auto& hits  = event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
+  const auto& hits =
+      event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
   // hits are a std::vector<ldmx::EcalHit>
-  const ::ecal::EcalTriggerGeometry& geom = getCondition<::ecal::EcalTriggerGeometry>(
-    ::ecal::EcalTriggerGeometry::CONDITIONS_OBJECT_NAME);
+  const ::ecal::EcalTriggerGeometry& geom =
+      getCondition<::ecal::EcalTriggerGeometry>(
+          ::ecal::EcalTriggerGeometry::CONDITIONS_OBJECT_NAME);
 
   std::map<UniqueModule, std::pair<int, double>> module_sums;
   int trig_prim_total{0};
@@ -283,10 +213,16 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
     if (module_sums.find(mod) == module_sums.end()) {
       module_sums[mod] = {0, 0.0};
     }
-    module_sums[mod].first += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
-    trig_prim_total +=(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
+    module_sums[mod].first += (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                              secondOrderEnergyCorrection / nominal *
+                              get_estimate(trig);
+    trig_prim_total += (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                       secondOrderEnergyCorrection / nominal *
+                       get_estimate(trig);
     if (mod.layer_ <= 20) {
-      trig_prim_total_first20 += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
+      trig_prim_total_first20 +=
+          (1. + layerWeights[mod.layer_] / mip_si_energy) *
+          secondOrderEnergyCorrection / nominal * get_estimate(trig);
     }
   }
 
@@ -298,74 +234,100 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
     if (module_sums.find(mod) == module_sums.end()) {
       module_sums[mod] = {0, 0.0};
     }
-    module_sums[mod].second += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
-    prec_ampl_total += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+    module_sums[mod].second += (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                               secondOrderEnergyCorrection * hit.getAmplitude();
+    prec_ampl_total += (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                       secondOrderEnergyCorrection * hit.getAmplitude();
     if (mod.layer_ <= 20) {
-      prec_ampl_total_first20 += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+      prec_ampl_total_first20 +=
+          (1. + layerWeights[mod.layer_] / mip_si_energy) *
+          secondOrderEnergyCorrection * hit.getAmplitude();
     }
   }
 
   std::map<int, std::pair<int, double>> layer_sums;
   for (const auto& [unique_module, sum_pair] : module_sums) {
-    if(layer_sums.find(unique_module.layer_) == layer_sums.end()) {
+    if (layer_sums.find(unique_module.layer_) == layer_sums.end()) {
       // layer is not found in layer_sums map so start the sum at 0
-      layer_sums[unique_module.layer_] = {0,0.0};
+      layer_sums[unique_module.layer_] = {0, 0.0};
     }
     // add this module total to running total for the layer
     layer_sums[unique_module.layer_].first += sum_pair.first;
     layer_sums[unique_module.layer_].second += sum_pair.second;
   }
 
-  for (const auto& trig: trigs){
+  for (const auto& trig : trigs) {
     EcalTriggerID tid{trig.getId()};
     UniqueModule mod{tid};
     double trig_group_prec_total{0};
     double trig_group_prec_total_unweight{0};
     for (auto& prec_id : geom.contentsOfTriggerCell(tid)) {
-      for (const auto& hit : hits){
-        if(prec_id == hit.getID()){
-          trig_group_prec_total += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+      for (const auto& hit : hits) {
+        if (prec_id == hit.getID()) {
+          trig_group_prec_total +=
+              (1. + layerWeights[mod.layer_] / mip_si_energy) *
+              secondOrderEnergyCorrection * hit.getAmplitude();
           trig_group_prec_total_unweight += hit.getAmplitude();
-	}
+        }
       }
     }
 
     // have trig_group_total which is the sum of the precision hits
     // in that trigger group and get_estimate(trig) is the sum
     // as reported by the trigger itself
-    histograms_.fill("trig_group",trig_group_prec_total);
-    histograms_.fill("trig_group_trigger",(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig)); // get_estiamte instead of get_estimate(trig)
-    histograms_.fill("trig_group_v_trig",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig));
-    histograms_.fill("trig_group_ampl_v_ampl",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig) / trig_group_prec_total / nominal);
-    histograms_.fill("trig_group_ampl_v_ampl_varbin",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig) / trig_group_prec_total / nominal);
-    histograms_.fill("trig_group_ampl_unweight",trig_group_prec_total_unweight, get_estimate(trig) / trig_group_prec_total_unweight / nominal);
+    histograms_.fill("trig_group", trig_group_prec_total);
+    histograms_.fill(
+        "trig_group_trigger",
+        (1. + layerWeights[mod.layer_] / mip_si_energy) *
+            secondOrderEnergyCorrection *
+            get_estimate(trig));  // get_estiamte instead of get_estimate(trig)
+    histograms_.fill("trig_group_v_trig", trig_group_prec_total,
+                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                         secondOrderEnergyCorrection * get_estimate(trig));
+    histograms_.fill("trig_group_ampl_v_ampl", trig_group_prec_total,
+                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                         secondOrderEnergyCorrection * get_estimate(trig) /
+                         trig_group_prec_total / nominal);
+    histograms_.fill("trig_group_ampl_v_ampl_varbin", trig_group_prec_total,
+                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                         secondOrderEnergyCorrection * get_estimate(trig) /
+                         trig_group_prec_total / nominal);
+    histograms_.fill(
+        "trig_group_ampl_unweight", trig_group_prec_total_unweight,
+        get_estimate(trig) / trig_group_prec_total_unweight / nominal);
   }
 
   int layer_id_tmp = {0};
   int module_id_tmp = {0};
-  for (const auto& [mod_id,sum_pair] : module_sums){
-/*    std::cout << " layer id " << mod_id.layer_ << " mod id " << mod_id.module_ << std::endl; */
+  for (const auto& [mod_id, sum_pair] : module_sums) {
+    /*    std::cout << " layer id " << mod_id.layer_ << " mod id " <<
+     * mod_id.module_ << std::endl; */
     layer_id_tmp = mod_id.layer_;
     module_id_tmp = mod_id.module_;
-    histograms_.fill("layer_id",layer_id_tmp);
-    histograms_.fill("module_id",module_id_tmp);
+    histograms_.fill("layer_id", layer_id_tmp);
+    histograms_.fill("module_id", module_id_tmp);
     histograms_.fill("trig_sum_per_module", sum_pair.first);
     histograms_.fill("ampl_sum_per_module", sum_pair.second);
     histograms_.fill("trig_v_ampl_module", sum_pair.second, sum_pair.first);
-    histograms_.fill("trig_ampl_v_ampl", sum_pair.second, sum_pair.first / sum_pair.second);
-    histograms_.fill("trig_ampl_v_ampl_binadjust", sum_pair.second, sum_pair.first / sum_pair.second);
+    histograms_.fill("trig_ampl_v_ampl", sum_pair.second,
+                     sum_pair.first / sum_pair.second);
+    histograms_.fill("trig_ampl_v_ampl_binadjust", sum_pair.second,
+                     sum_pair.first / sum_pair.second);
   }
 
   for (const auto& [layer, layer_sum_pair] : layer_sums) {
     histograms_.fill("trig_sum_per_layer", layer_sum_pair.first);
     histograms_.fill("ampl_sum_per_layer", layer_sum_pair.second);
-    histograms_.fill("trig_v_ampl_layer", layer_sum_pair.first, layer_sum_pair.second);
-    histograms_.fill("trig_ampl_v_ampl_layer",layer_sum_pair.second, layer_sum_pair.first / layer_sum_pair.second);
+    histograms_.fill("trig_v_ampl_layer", layer_sum_pair.first,
+                     layer_sum_pair.second);
+    histograms_.fill("trig_ampl_v_ampl_layer", layer_sum_pair.second,
+                     layer_sum_pair.first / layer_sum_pair.second);
   }
 
   /*
    * after picking some dummy bins, I printout the values I'm going to fill
-   * so I can see what an actual binning should be. For 10 events, the output was
+   * so I can see what an actual binning should be. For 10 events, the output
+  was
    * 978
    * 949
    * 1070
@@ -383,21 +345,23 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   histograms_.fill("total_ampl_energy", prec_ampl_total);
   histograms_.fill("total_trig_v_total_ampl", trig_prim_total, prec_ampl_total);
   histograms_.fill("trig_ampl_nominal", trig_prim_total / prec_ampl_total);
-  histograms_.fill("trig_ampl_v_ampl_total",prec_ampl_total, trig_prim_total / prec_ampl_total);
-  histograms_.fill("trig_ampl_v_ampl_total_first20",prec_ampl_total_first20, trig_prim_total_first20 / prec_ampl_total_first20);
+  histograms_.fill("trig_ampl_v_ampl_total", prec_ampl_total,
+                   trig_prim_total / prec_ampl_total);
+  histograms_.fill("trig_ampl_v_ampl_total_first20", prec_ampl_total_first20,
+                   trig_prim_total_first20 / prec_ampl_total_first20);
 
-/*  for (const auto& [ unique_module, sum_pair ] : module_sums) {
-    std::cout << unique_module.layer_ << " " << unique_module.module_
-      << " -> " << sum_pair.first << " " << sum_pair.second << std::endl;
-  }
-  */
-  
+  /*  for (const auto& [ unique_module, sum_pair ] : module_sums) {
+      std::cout << unique_module.layer_ << " " << unique_module.module_
+        << " -> " << sum_pair.first << " " << sum_pair.second << std::endl;
+    }
+    */
+
   /*
    * 2D fill example
   histograms_.fill("name", xvalue, yvalue);
   */
 }
 
-}
+}  // namespace ldmx::ecal
 
 DECLARE_ANALYZER_NS(ldmx::ecal, TrigPrimResolutionAnalyzer);

--- a/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -1,0 +1,403 @@
+#include "Framework/EventProcessor.h"
+
+#include "Ecal/Event/EcalHit.h"
+#include "Recon/Event/HgcrocTrigDigi.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+#include "DetDescr/EcalID.h"
+#include "DetDescr/EcalTriggerID.h"
+
+#include "Ecal/EcalTriggerGeometry.h"
+
+namespace ldmx::ecal {
+class TrigPrimResolutionAnalyzer : public framework::Analyzer {
+  std::string digi_collection_name_ = "EcalDigis";
+  std::string digi_pass_name_ = "";
+  std::string trig_collection_name_ = "ecalTrigDigis";
+  std::string trig_pass_name_ = "";
+  std::string hit_collection_name_ = "EcalRecHits";
+  std::string hit_pass_name_ = "";
+ public:
+  TrigPrimResolutionAnalyzer(const std::string& name, framework::Process& process)
+    : framework::Analyzer(name, process) {}
+  virtual ~TrigPrimResolutionAnalyzer() = default;
+  void configure(framework::config::Parameters& parameters) final;
+  void onProcessStart() final;
+  void analyze(const framework::Event& event) final;
+};
+
+void TrigPrimResolutionAnalyzer::configure(framework::config::Parameters& parameters) {
+  /*
+   * Since I defined these member variables to have sensible values in the declaration above,
+   * we DO NOT get their parameter values from the python config. Below, I have written out
+   * the lines that we could use to get their values from the python config if changing them
+   * is desirable (e.g. if you want to run a few different passes of digi and recon with different
+   * parameters and then want to analyze the different passes).
+   */
+  /*
+  digi_collection_name_ = parameters.getParameter("digi_collection_name");
+  digi_pass_name_ = parameters.getParameter("digi_pass_name");
+  trig_collection_name_ = parameters.getParameter("trig_collection_name");
+  trig_pass_name_ = parameters.getParameter("trig_pass_name");
+  hit_collection_name_ = parameters.getParameter("hit_collection_name");
+  hit_pass_name_ = parameters.getParameter("hit_pass_name");
+  */
+//  digiCollName_ = parameters.getParameter<std::string>("digiCollName");
+//  digiPassName = parameters.getParameter<std::string>("digiPassName");
+//  condObjName_ =
+//	  parameters.getParameter<std::string>("condObjName","EcalTrigPrimDigiConditions");
+}
+
+void TrigPrimResolutionAnalyzer::onProcessStart() {
+
+
+  // variable bins
+  std::vector<double> binsx = {0.,10.,20.,30.,40.,50.,60.,70.,80.,
+	  90.,100.,110.,120.,130.,140.,150.,300.,575.,1000.};
+  std::vector<double> binsy ={0.6  , 0.608, 0.616, 0.624, 0.632, 0.64 , 0.648, 0.656, 0.664,
+       0.672, 0.68 , 0.688, 0.696, 0.704, 0.712, 0.72 , 0.728, 0.736,
+       0.744, 0.752, 0.76 , 0.768, 0.776, 0.784, 0.792, 0.8  , 0.808,
+       0.816, 0.824, 0.832, 0.84 , 0.848, 0.856, 0.864, 0.872, 0.88 ,
+       0.888, 0.896, 0.904, 0.912, 0.92 , 0.928, 0.936, 0.944, 0.952,
+       0.96 , 0.968, 0.976, 0.984, 0.992, 1.   , 1.008, 1.016, 1.024,
+       1.032, 1.04 , 1.048, 1.056, 1.064, 1.072, 1.08 , 1.088, 1.096,
+       1.104, 1.112, 1.12 , 1.128, 1.136, 1.144, 1.152, 1.16 , 1.168,
+       1.176, 1.184, 1.192, 1.2  , 1.208, 1.216, 1.224, 1.232, 1.24 ,
+       1.248, 1.256, 1.264, 1.272, 1.28 , 1.288, 1.296, 1.304, 1.312,
+       1.32 , 1.328, 1.336, 1.344, 1.352, 1.36 , 1.368, 1.376, 1.384,
+       1.392, 1.4};
+
+  // initialize processing by making histograms and such
+  // first, we get the directory for this processor in the histogram file
+  getHistoDirectory();
+  // then we can create histograms within it
+  histograms_.create(
+      "total_trig_energy" /* name - as written in output ROOT file */,
+      "Total of all Trig Digis [MeV]" /* xlabel - axis label of histogram */,
+      100 /* number of bins */, 0 /* minimum value */, 8000 /* maximum value */
+  ); // WARNING: I don't think this binning is good!! I just picked a random number!!
+  histograms_.create(
+      "total_ampl_energy",
+      "Total of Precision Hit Amplitudes [MeV]",
+      100, 0, 8000
+  );
+  /*
+   * 2D Histograms are also possible
+  histograms_.create(
+      "name",
+      "xlabel", nbins, xstart, xend,
+      "ylabel", nbins, ystart, yend
+  );
+  */
+  histograms_.create(
+      "total_trig_v_total_ampl",
+      "Total of all Trig Digis [MeV]",
+      1000, 0, 8000,
+      "Total of Precision Hit Amplitudes [MeV]",
+      100, 0, 8000
+  );
+  histograms_.create(
+      "trig_ampl_nominal",
+      "Total trig / total ampl",
+      100, 0.85, 1.15
+  );
+  histograms_.create(
+      "module_id",
+      "Module id",
+      7,0,7
+  );
+  histograms_.create(
+      "layer_id",
+      "Layer id",
+      34,0,34
+  );
+  histograms_.create(
+      "trig_sum_per_module",
+      "module trigger sum [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "ampl_sum_per_module",
+      "module precision ampl sum [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "trig_v_ampl_module",
+      "Module-sum full readout [MeV]",
+      100,0,2000,
+      "Module-sum trigger [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "trig_sum_per_layer",
+      "layer trigger sum [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "ampl_sum_per_layer",
+      "layer precision ampl sum [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "trig_v_ampl_layer",
+      "Layer trigger total [MeV]",
+      100,0,2500,
+      "Layer ampl total [MeV]",
+      100,0,2500
+  );
+  histograms_.create(
+      "trig_ampl_v_ampl",
+      "module precision ampl sum [MeV]",
+      100,0,1000,
+      "module trigger / module precision ampl",
+      100, 0.4, 1.2
+  );
+  histograms_.create(
+      "trig_ampl_v_ampl_binadjust",
+      "module precision trig sum [MeV]",
+      100,0,2000,
+      "module trigger / module precision ampl",
+      100, 0.4, 1.2
+  );
+  histograms_.create(
+      "trig_ampl_v_ampl_layer",
+      "layer precision ampl sum [MeV]",
+      100,0,1000,
+      "layer trigger / layer precision ampl",
+      100, 0.4, 1.2
+  );
+  histograms_.create(
+      "trig_ampl_v_ampl_total",
+      "total precision ampl sum [MeV]",
+      100,0,8000,
+      "total trigger / total precision ampl",
+      100, 0.9, 1.1
+  );
+  histograms_.create(
+      "trig_ampl_v_ampl_total_first20",
+      "Full readout sum [MeV]",
+      100,0,6000,
+      "Trigger / Full readout",
+      100, 0.95, 1.05
+  );
+  histograms_.create(
+      "trig_group",
+      "trigger group total precision hits [MeV]",
+      100,0,2000
+  );
+  histograms_.create(
+      "trig_group_trigger",
+      "trigger group trigger [MeV]",
+      100,0,8000
+  );
+  histograms_.create(
+      "trig_group_v_trig",
+      "trigger group total precision hits [MeV]",
+      100,0,2000,
+      "trigger group trigger [MeV]",
+      100,0,8000
+  );
+  histograms_.create(
+      "trig_group_ampl_v_ampl",
+      "Trigger group full readout [MeV]",
+      100,0,1000,
+      "Trigger group ratio / nominal",
+      200,0.6,1.4
+  );
+  histograms_.create(
+      "trig_group_ampl_v_ampl_varbin",
+      "Trigger group full readout [MeV]",
+      binsx,
+      "Trigger group ratio / nominal",
+      binsy
+  );
+  histograms_.create(
+      "trig_group_ampl_unweight",
+      "unweighted trigger group total precision hits [MeV]",
+      100,0,20,
+      "trigger group trigger / unweighted trigger group total prec hits / nominal",
+      200,0.6,1.4
+  );
+}
+
+/**
+ * structure holding data uniquely identifying a specific module in the ECal
+ */
+struct UniqueModule {
+  unsigned int layer_;
+  unsigned int module_;
+  UniqueModule(EcalTriggerID tid) {
+    layer_ = tid.getLayerID();
+    module_ = tid.getModuleID();
+  }
+  UniqueModule(EcalID eid) {
+    layer_ = eid.getLayerID();
+    module_ = eid.getModuleID();
+  }
+};
+
+// get the trigger primitive's estimate of the hit amplitude
+float get_estimate(const HgcrocTrigDigi& trig) {
+  uint32_t prim{trig.linearPrimitive()};
+  if (prim < 15) {
+    return (static_cast<float>(prim) + 0.5);
+  }
+  return static_cast<float>(prim);
+}
+
+const double total_trigger_mean = 876.28120;
+const double total_ampl_mean = 48.805244;
+// const double nominal = total_trigger_mean / total_ampl_mean;
+// nominal adjust for presentation
+const double nominal = 18.14;
+const double secondOrderEnergyCorrection = 4000./3940.5;
+const double mip_si_energy = 0.13;
+double layerWeights[34] = {2.312, 4.312, 6.522, 7.490, 8.595, 10.253, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 14.783, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 9.938};
+
+/**
+ * ordering operator required for UniqueModule to be used as a key in std::map
+ */
+bool operator<(const UniqueModule& lhs, const UniqueModule& rhs) {
+  if (lhs.layer_ < rhs.layer_) return true;
+  if (lhs.layer_ > rhs.layer_) return false;
+  // lhs.layer_ == rhs.layer_
+  return (lhs.module_ < rhs.module_);
+}
+
+void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
+  // called once on each event, get objects and fill histograms
+  const auto& trigs = event.getCollection<ldmx::HgcrocTrigDigi>(trig_collection_name_, trig_pass_name_);
+  // trigs are a std::vector<ldmx::HgcrocTrigDigi>
+  const auto& digis = event.getObject<ldmx::HgcrocDigiCollection>(digi_collection_name_, digi_pass_name_);
+  // digis are a ldmx::HgcrocDigiCollection
+  const auto& hits  = event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
+  // hits are a std::vector<ldmx::EcalHit>
+  const ::ecal::EcalTriggerGeometry& geom = getCondition<::ecal::EcalTriggerGeometry>(
+    ::ecal::EcalTriggerGeometry::CONDITIONS_OBJECT_NAME);
+
+  std::map<UniqueModule, std::pair<int, double>> module_sums;
+  int trig_prim_total{0};
+  int trig_prim_total_first20{0};
+  for (const auto& trig : trigs) {
+    EcalTriggerID tid{trig.getId()};
+    UniqueModule mod{tid};
+    if (module_sums.find(mod) == module_sums.end()) {
+      module_sums[mod] = {0, 0.0};
+    }
+    module_sums[mod].first += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
+    trig_prim_total +=(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
+    if (mod.layer_ <= 20) {
+      trig_prim_total_first20 += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection/nominal*get_estimate(trig);
+    }
+  }
+
+  double prec_ampl_total{0.};
+  double prec_ampl_total_first20{0.};
+  for (const auto& hit : hits) {
+    EcalID id{hit.getID()};
+    UniqueModule mod{id};
+    if (module_sums.find(mod) == module_sums.end()) {
+      module_sums[mod] = {0, 0.0};
+    }
+    module_sums[mod].second += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+    prec_ampl_total += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+    if (mod.layer_ <= 20) {
+      prec_ampl_total_first20 += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+    }
+  }
+
+  std::map<int, std::pair<int, double>> layer_sums;
+  for (const auto& [unique_module, sum_pair] : module_sums) {
+    if(layer_sums.find(unique_module.layer_) == layer_sums.end()) {
+      // layer is not found in layer_sums map so start the sum at 0
+      layer_sums[unique_module.layer_] = {0,0.0};
+    }
+    // add this module total to running total for the layer
+    layer_sums[unique_module.layer_].first += sum_pair.first;
+    layer_sums[unique_module.layer_].second += sum_pair.second;
+  }
+
+  for (const auto& trig: trigs){
+    EcalTriggerID tid{trig.getId()};
+    UniqueModule mod{tid};
+    double trig_group_prec_total{0};
+    double trig_group_prec_total_unweight{0};
+    for (auto& prec_id : geom.contentsOfTriggerCell(tid)) {
+      for (const auto& hit : hits){
+        if(prec_id == hit.getID()){
+          trig_group_prec_total += (1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*hit.getAmplitude();
+          trig_group_prec_total_unweight += hit.getAmplitude();
+	}
+      }
+    }
+
+    // have trig_group_total which is the sum of the precision hits
+    // in that trigger group and get_estimate(trig) is the sum
+    // as reported by the trigger itself
+    histograms_.fill("trig_group",trig_group_prec_total);
+    histograms_.fill("trig_group_trigger",(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig)); // get_estiamte instead of get_estimate(trig)
+    histograms_.fill("trig_group_v_trig",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig));
+    histograms_.fill("trig_group_ampl_v_ampl",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig) / trig_group_prec_total / nominal);
+    histograms_.fill("trig_group_ampl_v_ampl_varbin",trig_group_prec_total,(1.+layerWeights[mod.layer_]/mip_si_energy)*secondOrderEnergyCorrection*get_estimate(trig) / trig_group_prec_total / nominal);
+    histograms_.fill("trig_group_ampl_unweight",trig_group_prec_total_unweight, get_estimate(trig) / trig_group_prec_total_unweight / nominal);
+  }
+
+  int layer_id_tmp = {0};
+  int module_id_tmp = {0};
+  for (const auto& [mod_id,sum_pair] : module_sums){
+/*    std::cout << " layer id " << mod_id.layer_ << " mod id " << mod_id.module_ << std::endl; */
+    layer_id_tmp = mod_id.layer_;
+    module_id_tmp = mod_id.module_;
+    histograms_.fill("layer_id",layer_id_tmp);
+    histograms_.fill("module_id",module_id_tmp);
+    histograms_.fill("trig_sum_per_module", sum_pair.first);
+    histograms_.fill("ampl_sum_per_module", sum_pair.second);
+    histograms_.fill("trig_v_ampl_module", sum_pair.second, sum_pair.first);
+    histograms_.fill("trig_ampl_v_ampl", sum_pair.second, sum_pair.first / sum_pair.second);
+    histograms_.fill("trig_ampl_v_ampl_binadjust", sum_pair.second, sum_pair.first / sum_pair.second);
+  }
+
+  for (const auto& [layer, layer_sum_pair] : layer_sums) {
+    histograms_.fill("trig_sum_per_layer", layer_sum_pair.first);
+    histograms_.fill("ampl_sum_per_layer", layer_sum_pair.second);
+    histograms_.fill("trig_v_ampl_layer", layer_sum_pair.first, layer_sum_pair.second);
+    histograms_.fill("trig_ampl_v_ampl_layer",layer_sum_pair.second, layer_sum_pair.first / layer_sum_pair.second);
+  }
+
+  /*
+   * after picking some dummy bins, I printout the values I'm going to fill
+   * so I can see what an actual binning should be. For 10 events, the output was
+   * 978
+   * 949
+   * 1070
+   * 858
+   * 846
+   * 774
+   * 853
+   * 859
+   * 887
+   * 917
+   * so I changed the binning to 1k bins ranging from 0 to 10k
+  std::cout << trig_prim_total << std::endl;
+   */
+  histograms_.fill("total_trig_energy", trig_prim_total);
+  histograms_.fill("total_ampl_energy", prec_ampl_total);
+  histograms_.fill("total_trig_v_total_ampl", trig_prim_total, prec_ampl_total);
+  histograms_.fill("trig_ampl_nominal", trig_prim_total / prec_ampl_total);
+  histograms_.fill("trig_ampl_v_ampl_total",prec_ampl_total, trig_prim_total / prec_ampl_total);
+  histograms_.fill("trig_ampl_v_ampl_total_first20",prec_ampl_total_first20, trig_prim_total_first20 / prec_ampl_total_first20);
+
+/*  for (const auto& [ unique_module, sum_pair ] : module_sums) {
+    std::cout << unique_module.layer_ << " " << unique_module.module_
+      << " -> " << sum_pair.first << " " << sum_pair.second << std::endl;
+  }
+  */
+  
+  /*
+   * 2D fill example
+  histograms_.fill("name", xvalue, yvalue);
+  */
+}
+
+}
+
+DECLARE_ANALYZER_NS(ldmx::ecal, TrigPrimResolutionAnalyzer);

--- a/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -67,6 +67,9 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
       1.32, 1.328, 1.336, 1.344, 1.352, 1.36, 1.368, 1.376, 1.384, 1.392,
       1.4};
 
+  std::vector<double> binsx_fin = {0., 10., 20., 30., 40., 50., 60., 70.,
+	                           80., 90., 100., 150., 300., 575., 1000.};
+
   // initialize processing by making histograms and such
   // first, we get the directory for this processor in the histogram file
   getHistoDirectory();
@@ -119,7 +122,7 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
                      100, 0, 8000, "total trigger / total precision ampl", 100,
                      0.9, 1.1);
   histograms_.create("trig_ampl_v_ampl_total_first20", "Full readout sum [MeV]",
-                     100, 0, 6000, "Trigger / Full readout", 100, 0.95, 1.05);
+                     50, 0, 6000, "Trigger / Full readout", 100, 0.95, 1.05);
   histograms_.create("trig_group", "trigger group total precision hits [MeV]",
                      100, 0, 2000);
   histograms_.create("trig_group_trigger", "trigger group trigger [MeV]", 100,
@@ -139,6 +142,9 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
                      "trigger group trigger / unweighted trigger group total "
                      "prec hits / nominal",
                      200, 0.6, 1.4);
+  histograms_.create("trig_group_ampl_v_ampl_varbin_fin",
+                     "Trigger group full readout [MeV]", binsx_fin,
+                     "Trigger group ratio / nominal", binsy);
 }
 
 /**
@@ -289,6 +295,10 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
                          secondOrderEnergyCorrection * get_estimate(trig) /
                          trig_group_prec_total / nominal);
     histograms_.fill("trig_group_ampl_v_ampl_varbin", trig_group_prec_total,
+                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
+                         secondOrderEnergyCorrection * get_estimate(trig) /
+                         trig_group_prec_total / nominal);
+    histograms_.fill("trig_group_ampl_v_ampl_varbin_fin", trig_group_prec_total,
                      (1. + layerWeights[mod.layer_] / mip_si_energy) *
                          secondOrderEnergyCorrection * get_estimate(trig) /
                          trig_group_prec_total / nominal);

--- a/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -66,9 +66,8 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
       1.24, 1.248, 1.256, 1.264, 1.272, 1.28, 1.288, 1.296, 1.304, 1.312,
       1.32, 1.328, 1.336, 1.344, 1.352, 1.36, 1.368, 1.376, 1.384, 1.392,
       1.4};
-
-  std::vector<double> binsx_fin = {0., 10., 20., 30., 40., 50., 60., 70.,
-	                           80., 90., 100., 150., 300., 575., 1000.};
+  std::vector<double> binsx_fin = {0.,  10., 20.,  30.,  40.,  50.,  60.,  70.,
+                                   80., 90., 100., 150., 300., 575., 1000.};
 
   // initialize processing by making histograms and such
   // first, we get the directory for this processor in the histogram file
@@ -122,7 +121,7 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
                      100, 0, 8000, "total trigger / total precision ampl", 100,
                      0.9, 1.1);
   histograms_.create("trig_ampl_v_ampl_total_first20", "Full readout sum [MeV]",
-                     50, 0, 6000, "Trigger / Full readout", 100, 0.95, 1.05);
+                     100, 0, 6000, "Trigger / Full readout", 100, 0.95, 1.05);
   histograms_.create("trig_group", "trigger group total precision hits [MeV]",
                      100, 0, 2000);
   histograms_.create("trig_group_trigger", "trigger group trigger [MeV]", 100,

--- a/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
+++ b/Ecal/src/Ecal/TrigPrimResolutionAnalyzer.cxx
@@ -7,13 +7,28 @@
 #include "Recon/Event/HgcrocTrigDigi.h"
 
 namespace ldmx::ecal {
+/**
+ * Analyze the trigger primitives by comparing them to the precision hits
+ *
+ * This analyzer goes through and compares differents sums between the
+ * trigger primitive level (groups of 9 cells for the ECal) and the
+ * precision hit level (individual cells).
+ */
 class TrigPrimResolutionAnalyzer : public framework::Analyzer {
-  std::string digi_collection_name_ = "EcalDigis";
-  std::string digi_pass_name_ = "";
   std::string trig_collection_name_ = "ecalTrigDigis";
   std::string trig_pass_name_ = "";
   std::string hit_collection_name_ = "EcalRecHits";
   std::string hit_pass_name_ = "";
+  double total_trigger_mean_ = 876.28120;
+  double total_ampl_mean_ = 48.805244;
+  double nominal_{1.0};
+  double secondOrderEnergyCorrection_ = 4000. / 3940.5;
+  double mip_si_energy_ = 0.13;
+  std::vector<double> layerWeights_ = {
+      2.312,  4.312,  6.522,  7.490,  8.595,  10.253, 10.915, 10.915, 10.915,
+      10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915,
+      10.915, 10.915, 10.915, 10.915, 10.915, 14.783, 18.539, 18.539, 18.539,
+      18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 9.938};
 
  public:
   TrigPrimResolutionAnalyzer(const std::string& name,
@@ -23,30 +38,49 @@ class TrigPrimResolutionAnalyzer : public framework::Analyzer {
   void configure(framework::config::Parameters& parameters) final;
   void onProcessStart() final;
   void analyze(const framework::Event& event) final;
+
+  /**
+   * Calculate the energy deposited estimate from a hit's amplitude
+   *
+   * We scale the amplitude by the layer weight with a few other factors.
+   */
+  double calculate_energy(int layer, double amplitude) {
+    return (1 + layerWeights_[layer] / mip_si_energy_) * amplitude *
+           secondOrderEnergyCorrection_;
+  }
 };
+
+/**
+ * macro to help avoid repetition on optional configuraiton parameters
+ *
+ * the default for a parameter is defined when it is declared in the class
+ * declaration, here we provide its value to getParameter and so the user could
+ * override the default if the python value is provided.
+ *
+ * Assuming the parameters class instance is called parameters.
+ */
+#define optional_update(variable) \
+  variable##_ = parameters.getParameter(#variable, variable##_)
 
 void TrigPrimResolutionAnalyzer::configure(
     framework::config::Parameters& parameters) {
-  /*
-   * Since I defined these member variables to have sensible values in the
-   * declaration above, we DO NOT get their parameter values from the python
-   * config. Below, I have written out the lines that we could use to get their
-   * values from the python config if changing them is desirable (e.g. if you
-   * want to run a few different passes of digi and recon with different
-   * parameters and then want to analyze the different passes).
-   */
-  /*
-  digi_collection_name_ = parameters.getParameter("digi_collection_name");
-  digi_pass_name_ = parameters.getParameter("digi_pass_name");
-  trig_collection_name_ = parameters.getParameter("trig_collection_name");
-  trig_pass_name_ = parameters.getParameter("trig_pass_name");
-  hit_collection_name_ = parameters.getParameter("hit_collection_name");
-  hit_pass_name_ = parameters.getParameter("hit_pass_name");
-  */
-  //  digiCollName_ = parameters.getParameter<std::string>("digiCollName");
-  //  digiPassName = parameters.getParameter<std::string>("digiPassName");
-  //  condObjName_ =
-  //	  parameters.getParameter<std::string>("condObjName","EcalTrigPrimDigiConditions");
+  optional_update(trig_collection_name);
+  optional_update(trig_pass_name);
+  optional_update(hit_collection_name);
+  optional_update(hit_pass_name);
+  optional_update(total_trigger_mean);
+  optional_update(total_ampl_mean);
+  optional_update(secondOrderEnergyCorrection);
+  optional_update(mip_si_energy);
+  optional_update(layerWeights);
+
+  // nominal scale separation between trigger and precision would be
+  // determined experimentally by comparing their values
+  // nominal_ = total_trigger_mean_ / total_ampl_mean_;
+  // this has already been done so we just hardcode in the value
+  // determined by Steven Metallo in 2024, but it can be updated
+  // to use the ratio of the totals like above
+  nominal_ = 18.14;
 }
 
 void TrigPrimResolutionAnalyzer::onProcessStart() {
@@ -77,18 +111,9 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
       "total_trig_energy" /* name - as written in output ROOT file */,
       "Total of all Trig Digis [MeV]" /* xlabel - axis label of histogram */,
       100 /* number of bins */, 0 /* minimum value */, 8000 /* maximum value */
-  );  // WARNING: I don't think this binning is good!! I just picked a random
-      // number!!
+  );
   histograms_.create("total_ampl_energy",
                      "Total of Precision Hit Amplitudes [MeV]", 100, 0, 8000);
-  /*
-   * 2D Histograms are also possible
-  histograms_.create(
-      "name",
-      "xlabel", nbins, xstart, xend,
-      "ylabel", nbins, ystart, yend
-  );
-  */
   histograms_.create("total_trig_v_total_ampl", "Total of all Trig Digis [MeV]",
                      1000, 0, 8000, "Total of Precision Hit Amplitudes [MeV]",
                      100, 0, 8000);
@@ -148,6 +173,10 @@ void TrigPrimResolutionAnalyzer::onProcessStart() {
 
 /**
  * structure holding data uniquely identifying a specific module in the ECal
+ *
+ * This is helpful for doing module sums where we want to sum over all trigger
+ * or precision cells within a specific module. It acts like a key that can be
+ * constructed from either a trigger cell ID or a precision cell ID.
  */
 struct UniqueModule {
   unsigned int layer_;
@@ -162,28 +191,6 @@ struct UniqueModule {
   }
 };
 
-// get the trigger primitive's estimate of the hit amplitude
-float get_estimate(const HgcrocTrigDigi& trig) {
-  uint32_t prim{trig.linearPrimitive()};
-  if (prim < 15) {
-    return (static_cast<float>(prim) + 0.5);
-  }
-  return static_cast<float>(prim);
-}
-
-const double total_trigger_mean = 876.28120;
-const double total_ampl_mean = 48.805244;
-// const double nominal = total_trigger_mean / total_ampl_mean;
-// nominal adjust for presentation
-const double nominal = 18.14;
-const double secondOrderEnergyCorrection = 4000. / 3940.5;
-const double mip_si_energy = 0.13;
-double layerWeights[34] = {
-    2.312,  4.312,  6.522,  7.490,  8.595,  10.253, 10.915, 10.915, 10.915,
-    10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915,
-    10.915, 10.915, 10.915, 10.915, 10.915, 14.783, 18.539, 18.539, 18.539,
-    18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 9.938};
-
 /**
  * ordering operator required for UniqueModule to be used as a key in std::map
  */
@@ -194,14 +201,30 @@ bool operator<(const UniqueModule& lhs, const UniqueModule& rhs) {
   return (lhs.module_ < rhs.module_);
 }
 
+/**
+ * get the trigger primitive's estimate of the hit amplitude
+ *
+ * The trigger primitive digi class linearizes its packed estimate
+ * for us, but there is one more shift on the low end.
+ * Since the packing process drops the three lowest-order bits, we need
+ * to shift the estimate up by 0.5 if the value is below 15.
+ *
+ * This also re-casts the integer into a float which is more readily comparable
+ * to the float energy estimate stored within the reconstructed precision hits.
+ */
+float get_estimate(const HgcrocTrigDigi& trig) {
+  uint32_t prim{trig.linearPrimitive()};
+  if (prim < 15) {
+    return (static_cast<float>(prim) + 0.5);
+  }
+  return static_cast<float>(prim);
+}
+
 void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   // called once on each event, get objects and fill histograms
   const auto& trigs = event.getCollection<ldmx::HgcrocTrigDigi>(
       trig_collection_name_, trig_pass_name_);
   // trigs are a std::vector<ldmx::HgcrocTrigDigi>
-  const auto& digis = event.getObject<ldmx::HgcrocDigiCollection>(
-      digi_collection_name_, digi_pass_name_);
-  // digis are a ldmx::HgcrocDigiCollection
   const auto& hits =
       event.getCollection<ldmx::EcalHit>(hit_collection_name_, hit_pass_name_);
   // hits are a std::vector<ldmx::EcalHit>
@@ -215,38 +238,66 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
   for (const auto& trig : trigs) {
     EcalTriggerID tid{trig.getId()};
     UniqueModule mod{tid};
+    double trig_ampl = get_estimate(trig);
+    double trig_energy = calculate_energy(mod.layer_, trig_ampl) / nominal_;
+
+    /// add this trigger primitive to module sums
     if (module_sums.find(mod) == module_sums.end()) {
       module_sums[mod] = {0, 0.0};
     }
-    module_sums[mod].first += (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                              secondOrderEnergyCorrection / nominal *
-                              get_estimate(trig);
-    trig_prim_total += (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                       secondOrderEnergyCorrection / nominal *
-                       get_estimate(trig);
+
+    module_sums[mod].first += trig_energy;
+    trig_prim_total += trig_energy;
     if (mod.layer_ <= 20) {
-      trig_prim_total_first20 +=
-          (1. + layerWeights[mod.layer_] / mip_si_energy) *
-          secondOrderEnergyCorrection / nominal * get_estimate(trig);
+      trig_prim_total_first20 += trig_energy;
     }
+
+    // calculate the sum of precision hits for the 9 cells in this
+    // trigger grouping
+    double trig_group_prec_total{0};
+    double trig_group_prec_total_unweight{0};
+    for (auto& prec_id : geom.contentsOfTriggerCell(tid)) {
+      for (const auto& hit : hits) {
+        if (prec_id == hit.getID()) {
+          trig_group_prec_total +=
+              calculate_energy(mod.layer_, hit.getAmplitude());
+          trig_group_prec_total_unweight += hit.getAmplitude();
+        }
+      }
+    }
+
+    // have trig_group_prec_total which is the sum of the precision hits
+    // in that trigger group and trig_ampl is the sum
+    // as reported by the trigger itself
+    double ratio_energy = trig_energy / trig_group_prec_total,
+           ratio_ampl = trig_ampl / trig_group_prec_total_unweight / nominal_;
+    histograms_.fill("trig_group", trig_group_prec_total);
+    histograms_.fill("trig_group_trigger", trig_energy * nominal_);
+    histograms_.fill("trig_group_v_trig", trig_group_prec_total,
+                     trig_energy * nominal_);
+    histograms_.fill("trig_group_ampl_v_ampl", trig_group_prec_total,
+                     ratio_energy);
+    histograms_.fill("trig_group_ampl_v_ampl_varbin", trig_group_prec_total,
+                     ratio_energy);
+    histograms_.fill("trig_group_ampl_v_ampl_varbin_fin", trig_group_prec_total,
+                     ratio_energy);
+    histograms_.fill("trig_group_ampl_unweight", trig_group_prec_total_unweight,
+                     ratio_ampl);
   }
 
   double prec_ampl_total{0.};
   double prec_ampl_total_first20{0.};
   for (const auto& hit : hits) {
-    EcalID id{hit.getID()};
+    EcalID id{static_cast<unsigned int>(hit.getID())};
     UniqueModule mod{id};
     if (module_sums.find(mod) == module_sums.end()) {
       module_sums[mod] = {0, 0.0};
     }
-    module_sums[mod].second += (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                               secondOrderEnergyCorrection * hit.getAmplitude();
-    prec_ampl_total += (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                       secondOrderEnergyCorrection * hit.getAmplitude();
+    double prec_energy = calculate_energy(mod.layer_, hit.getAmplitude());
+    module_sums[mod].second += prec_energy;
+    prec_ampl_total += prec_energy;
     if (mod.layer_ <= 20) {
-      prec_ampl_total_first20 +=
-          (1. + layerWeights[mod.layer_] / mip_si_energy) *
-          secondOrderEnergyCorrection * hit.getAmplitude();
+      prec_ampl_total_first20 += prec_energy;
     }
   }
 
@@ -259,51 +310,6 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
     // add this module total to running total for the layer
     layer_sums[unique_module.layer_].first += sum_pair.first;
     layer_sums[unique_module.layer_].second += sum_pair.second;
-  }
-
-  for (const auto& trig : trigs) {
-    EcalTriggerID tid{trig.getId()};
-    UniqueModule mod{tid};
-    double trig_group_prec_total{0};
-    double trig_group_prec_total_unweight{0};
-    for (auto& prec_id : geom.contentsOfTriggerCell(tid)) {
-      for (const auto& hit : hits) {
-        if (prec_id == hit.getID()) {
-          trig_group_prec_total +=
-              (1. + layerWeights[mod.layer_] / mip_si_energy) *
-              secondOrderEnergyCorrection * hit.getAmplitude();
-          trig_group_prec_total_unweight += hit.getAmplitude();
-        }
-      }
-    }
-
-    // have trig_group_total which is the sum of the precision hits
-    // in that trigger group and get_estimate(trig) is the sum
-    // as reported by the trigger itself
-    histograms_.fill("trig_group", trig_group_prec_total);
-    histograms_.fill(
-        "trig_group_trigger",
-        (1. + layerWeights[mod.layer_] / mip_si_energy) *
-            secondOrderEnergyCorrection *
-            get_estimate(trig));  // get_estiamte instead of get_estimate(trig)
-    histograms_.fill("trig_group_v_trig", trig_group_prec_total,
-                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                         secondOrderEnergyCorrection * get_estimate(trig));
-    histograms_.fill("trig_group_ampl_v_ampl", trig_group_prec_total,
-                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                         secondOrderEnergyCorrection * get_estimate(trig) /
-                         trig_group_prec_total / nominal);
-    histograms_.fill("trig_group_ampl_v_ampl_varbin", trig_group_prec_total,
-                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                         secondOrderEnergyCorrection * get_estimate(trig) /
-                         trig_group_prec_total / nominal);
-    histograms_.fill("trig_group_ampl_v_ampl_varbin_fin", trig_group_prec_total,
-                     (1. + layerWeights[mod.layer_] / mip_si_energy) *
-                         secondOrderEnergyCorrection * get_estimate(trig) /
-                         trig_group_prec_total / nominal);
-    histograms_.fill(
-        "trig_group_ampl_unweight", trig_group_prec_total_unweight,
-        get_estimate(trig) / trig_group_prec_total_unweight / nominal);
   }
 
   int layer_id_tmp = {0};
@@ -333,23 +339,6 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
                      layer_sum_pair.first / layer_sum_pair.second);
   }
 
-  /*
-   * after picking some dummy bins, I printout the values I'm going to fill
-   * so I can see what an actual binning should be. For 10 events, the output
-  was
-   * 978
-   * 949
-   * 1070
-   * 858
-   * 846
-   * 774
-   * 853
-   * 859
-   * 887
-   * 917
-   * so I changed the binning to 1k bins ranging from 0 to 10k
-  std::cout << trig_prim_total << std::endl;
-   */
   histograms_.fill("total_trig_energy", trig_prim_total);
   histograms_.fill("total_ampl_energy", prec_ampl_total);
   histograms_.fill("total_trig_v_total_ampl", trig_prim_total, prec_ampl_total);
@@ -358,17 +347,6 @@ void TrigPrimResolutionAnalyzer::analyze(const framework::Event& event) {
                    trig_prim_total / prec_ampl_total);
   histograms_.fill("trig_ampl_v_ampl_total_first20", prec_ampl_total_first20,
                    trig_prim_total_first20 / prec_ampl_total_first20);
-
-  /*  for (const auto& [ unique_module, sum_pair ] : module_sums) {
-      std::cout << unique_module.layer_ << " " << unique_module.module_
-        << " -> " << sum_pair.first << " " << sum_pair.second << std::endl;
-    }
-    */
-
-  /*
-   * 2D fill example
-  histograms_.fill("name", xvalue, yvalue);
-  */
 }
 
 }  // namespace ldmx::ecal


### PR DESCRIPTION
This is an re-opening of a submodule PR (https://github.com/LDMX-Software/Ecal/pull/50) where I followed [the instructions](https://ldmx-software.github.io/transition-to-ldmx-sw-v4.html) to re-apply my changes in one commit onto the subdirectory.

---

I am updating _ldmx-sw_, here are the details.

I've copied this config around for awhile so it is time to put it into the repository.

This config is focused on firing electrons _directly_ into the ECal and then running the various processors that emulate electronics and reconstruct stuff within the ECal so users can then analyze the output.

## To Do
- [x] Compare module-level sum between trigger primitives and precision rec hits
- [x] Compare trigger primitives to trigger-group-sum of precision rec hits
- [ ] Write a processor that re-calculates the trigger primitives using the precision rec hits. This allows us to see how imprecise the trigger primitive "condensation" algorithm is.