### PR TITLE
Introduce variable for total events with no tries limit

### DIFF
--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -172,6 +172,11 @@ class Process {
 
   /** Limit on events to process. */
   int eventLimit_;
+  
+  /** Number of events we'd like to produce
+   independetly of the number of tries it would take.
+   Be warned about infinite loops!*/
+  int totalEvents_;
 
   /** The frequency with which event info is printed. */
   int logFrequency_;

--- a/Framework/python/ldmxcfg.py.in
+++ b/Framework/python/ldmxcfg.py.in
@@ -328,10 +328,15 @@ class Process:
     lastProcess : Process
         Class-wide reference to the last Process object to be constructed
     maxEvents : int
-        Maximum number events to process
+        Maximum number events to process.
+        If totalEvents is set, this will be ignored.
     maxTriesPerEvent : int
         Maximum number of attempts to make in a row before giving up on an event
         Only used in Production Mode (no input files)
+        If totalEvents is set, this will be ignored.
+    totalEvents : int
+        Number of events we'd like to produce independetly of the number of tries it would take.
+        Both maxEvents and maxTriesPerEvent will be ignored. Be warned about infinite loops!
     run : int
         Run number for this process
     inputFiles : list of strings

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -30,6 +30,7 @@ Process::Process(const framework::config::Parameters &configuration)
 
   maxTries_ = configuration.getParameter<int>("maxTriesPerEvent", 1);
   eventLimit_ = configuration.getParameter<int>("maxEvents", -1);
+  totalEvents_ = configuration.getParameter<int>("totalEvents", -1);
   logFrequency_ = configuration.getParameter<int>("logFrequency", -1);
   compressionSetting_ =
       configuration.getParameter<int>("compressionSetting", 9);
@@ -202,7 +203,13 @@ void Process::run() {
 
     int totalTries = 0;  // total number of tries for entire run
     int numTries = 0;    // number of tries for the current event number
-    while (n_events_processed < eventLimit_) {
+    int event_limit = eventLimit_;
+    if (totalEvents_ > 0) {
+      // Have a warning at the first event
+      if (numTries == 0) ldmx_log(warn) << "The totalEvents was set, so maxEvents and maxTriesPerEvent will be ignored!";
+      event_limit = totalEvents_;
+    }
+    while (n_events_processed < event_limit) {
       totalTries++;
       numTries++;
 
@@ -223,7 +230,8 @@ void Process::run() {
 
       // we use modulo here insetad of >= because we want to carry
       // the number of tries across the number of events processed boundary
-      if (completed or numTries % maxTries_ == 0) {
+      // totalEvents_ is set let's not exit until that's reached
+      if (completed or (totalEvents_ < 0 and numTries % maxTries_ == 0)) {
         n_events_processed++;                 // increment events made
         NtupleManager::getInstance().fill();  // fill ntuples
       }
@@ -237,6 +245,12 @@ void Process::run() {
     runHeader.setNumTries(totalTries);
     ldmx_log(info) << runHeader;
     outFile.writeRunTree();
+    
+    // Give a warning that this filter has very low efficiency
+    if (n_events_processed < totalTries / 10000) { // integer division is okay
+      ldmx_log(warn) << "Less than 1 event out of every 10k events tried was accepted!";
+      ldmx_log(warn) << "This could be an issue with your filtering and biasing procedure since this is incredibly inefficient.";
+    }
 
   } else {
     // there are input files


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1299

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I ran the pn code and set 
```
p.run = 2
p.maxEvents = 1
```
 * In default I get
```
Started 23 events to produce 1 events.
```

 * then
```
p.maxEvents = 1
p.maxTriesPerEvent = 10
```
leads to
```
Started 10 events to produce 1 events.
```

 * then
```
p.maxEvents = 1
p.maxTriesPerEvent = 10
p.totalEvents = 1
```
leads again to 
```
[ Process ] 2 : The totalEvents was set, so maxEvents and maxTriesPerEvent will be ignored!
Started 23 events to produce 1 events.
```
as expected