### PR TITLE
trim dead code in simulator failing to add parameters to the runheader

### DIFF
--- a/SimCore/include/SimCore/Simulator.h
+++ b/SimCore/include/SimCore/Simulator.h
@@ -95,14 +95,6 @@ class Simulator : public SimulatorBase {
    */
   virtual void produce(framework::Event& event) final override;
 
-  /**
-   * Callback for the EventProcessor to take any necessary action
-   * when a file is closed.
-   *
-   * @param eventFile The intput/output file.
-   */
-  void onFileClose(framework::EventFile& eventFile) final override;
-
   /// Callback called once processing is complete.
   void onProcessEnd() final override;
 

--- a/SimCore/src/SimCore/Simulator.cxx
+++ b/SimCore/src/SimCore/Simulator.cxx
@@ -166,13 +166,6 @@ void Simulator::produce(framework::Event& event) {
   return;
 }
 
-void Simulator::onFileClose(framework::EventFile& file) {
-  // Pass the **real** number of events to the persistency manager
-  auto rh = file.getRunHeader(run_);
-  rh.setIntParameter("Event Count", numEventsCompleted_);
-  rh.setIntParameter("Events Began", numEventsBegan_);
-}
-
 void Simulator::onProcessEnd() {
   SimulatorBase::onProcessEnd();
   std::cout << "[ Simulator ] : "


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1324 by simply removing the dead code.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Not really sure how to show that this is successful besides running the PR validation suite to make sure other parts don't inadvertently rely on this code.