### PR TITLE
Fix MIP tracking implementation issues

### DIFF
--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -1,7 +1,7 @@
 /**
  * @file EcalVetoProcessor.h
  * @brief Class that determines if event is vetoable using ECAL hit information
- * @author Owen Colegrove, UCSB
+ * @author Owen Colegrove, Danyi Zhang, Tamas Vami (UCSB)
  */
 
 #ifndef EVENTPROC_ECALVETOPROCESSOR_H_
@@ -157,6 +157,9 @@ class EcalVetoProcessor : public framework::Producer {
 
   /// handle to current geometry (to share with member functions)
   const ldmx::EcalGeometry* geometry_;
+  
+  /// Enable logging
+  enableLogging("EcalVetoProcessor")
 };
 
 }  // namespace ecal

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -157,9 +157,6 @@ class EcalVetoProcessor : public framework::Producer {
 
   /// handle to current geometry (to share with member functions)
   const ldmx::EcalGeometry* geometry_;
-  
-  /// Enable logging
-  enableLogging("EcalVetoProcessor")
 };
 
 }  // namespace ecal

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -603,7 +603,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
     for (int i = 0; i < trackingHitList.size(); i++) {
       std::cout << "[" << trackingHitList[i].pos.X() << ", "
       << trackingHitList[i].pos.Y() << ", "
-      << trackingHitList[i].layer << "] ";
+      << trackingHitList[i].layer << "], ";
     }
     std::cout << std::endl;
     ldmx_log(debug) << "====== END OF Tracking hit list ======";
@@ -626,8 +626,8 @@ void EcalVetoProcessor::produce(framework::Event &event) {
     while (jHit < trackingHitList.size()) {
       if ((trackingHitList[jHit].layer == trackingHitList[currenthit].layer - 1 ||
            trackingHitList[jHit].layer == trackingHitList[currenthit].layer - 2) &&
-          trackingHitList[jHit].pos.X() == trackingHitList[currenthit].pos.X() &&
-          trackingHitList[jHit].pos.Y() == trackingHitList[currenthit].pos.Y()) {
+          abs(trackingHitList[jHit].pos.X() - trackingHitList[currenthit].pos.X()) <= 0.5*cellWidth &&
+          abs(trackingHitList[jHit].pos.Y() - trackingHitList[currenthit].pos.Y()) <= 0.5*cellWidth  ) {
         track[trackLen] = jHit;
         trackLen++;
         currenthit = jHit;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

 * This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1355

 * An extra was to add the allowance to a half-cell offset in X/Y since that was introduced in v14 geometry (and so with that the MIP tracking of exactly behind in XY does not work anymore)

 * I also applied `clang-format`, sorry that kinda messes up the diffs

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Running the validation config file leads to the relevant printout of
```
 [ EcalVetoProcessor ] 0 : Straight tracks found (before merge): 5
 [ EcalVetoProcessor ] 0 : Begining track merging using 5 tracks
 [ EcalVetoProcessor ] 0 : Straight tracks found (after merge): 4
 [ EcalVetoProcessor ] 0 : Track 0:
 [ EcalVetoProcessor ] 0 :   Hit 0: [-16.8555, -12.512, 14]
 [ EcalVetoProcessor ] 0 :   Hit 1: [-16.8555, -12.512, 12]
 [ EcalVetoProcessor ] 0 :   Hit 2: [-16.8555, -12.512, 10]
 [ EcalVetoProcessor ] 0 :   Hit 3: [-16.8555, -12.512, 8]
 [ EcalVetoProcessor ] 0 : Track 1:
 [ EcalVetoProcessor ] 0 :   Hit 0: [-12.0397, -12.512, 11]
 [ EcalVetoProcessor ] 0 :   Hit 1: [-12.0397, -12.512, 9]
 [ EcalVetoProcessor ] 0 :   Hit 2: [-12.0397, -12.512, 7]
 [ EcalVetoProcessor ] 0 :   Hit 3: [-12.0397, -12.512, 5]
 [ EcalVetoProcessor ] 0 :   Hit 4: [-9.63173, -8.34132, 6]
 [ EcalVetoProcessor ] 0 :   Hit 5: [-9.63173, -8.34132, 4]
 [ EcalVetoProcessor ] 0 :   Hit 6: [-9.63173, -8.34132, 2]
 [ EcalVetoProcessor ] 0 :   Hit 7: [-9.63173, -8.34132, 0]
 [ EcalVetoProcessor ] 0 : Track 2:
 [ EcalVetoProcessor ] 0 :   Hit 0: [-2.40793, -12.512, 8]
 [ EcalVetoProcessor ] 0 :   Hit 1: [-2.40793, -12.512, 6]
 [ EcalVetoProcessor ] 0 : Track 3:
 [ EcalVetoProcessor ] 0 :   Hit 0: [-4.81586, -8.34132, 5]
 [ EcalVetoProcessor ] 0 :   Hit 1: [-4.81586, -8.34132, 3]
 [ EcalVetoProcessor ] 0 :   Hit 2: [-4.81586, -8.34132, 1]
 [ EcalVetoProcessor ] 0 : Finding linreg tracks from 60 hits
 [ EcalVetoProcessor ] 0 :   MIP tracking completed; found 4 straight tracks and 1 lin-reg tracks
 [ EcalVetoProcessor ] 0 :   The pred > bdtCutVal = false
```

We also had a look at the efficiencies:
```
original
  >> nStraightTrcaks <= 1:
    >> ecal_pn eff =  0.109
    >> signal_mA_0.01GeV eff =  0.791
    >> kaon eff =  0.313
  >> nStraightTrcaks <= 1 && nLinregTracks <= 1:
    >>>> ecal_pn eff =  0.076
    >>>> signal_mA_0.01GeV eff =  0.775
    >>>> kaon eff =  0.252
after the fix
  >> nStraightTrcaks <= 1:
    >> ecal_pn eff =  0.033
    >> signal_mA_0.01GeV eff =  0.763
    >> kaon eff =  0.092
  >> nStraightTrcaks <= 1 && nLinregTracks <= 1:
    >>>> ecal_pn eff =  0.032
    >>>> signal_mA_0.01GeV eff =  0.762
    >>>> kaon eff =  0.09
```
 --> you can see we loose 3% of signal but we kill 3.5 more kaons (!!!) (and generally pn bkgs too)