### PR TITLE
Enable StatBox in DQM histograms

### DIFF
--- a/Framework/src/Framework/Histograms.cxx
+++ b/Framework/src/Framework/Histograms.cxx
@@ -17,7 +17,7 @@
 namespace framework {
 
 HistogramPool::HistogramPool() {
-  gStyle->SetOptStat(0);
+  gStyle->SetOptStat(1);
   gStyle->SetGridColor(17);
   gStyle->SetFrameBorderMode(0);
   gStyle->SetTitleOffset(1.2, "yx");


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1361

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Now there is a statbox in the DQM histograms. 
Please note, it's easy to switch the off (in Browser or code) while it didnt work the other way around.