### PR TITLE
add ability to link to additional libraries for `from_file` processors

### DIFF
--- a/Framework/python/ldmxcfg.py
+++ b/Framework/python/ldmxcfg.py
@@ -60,7 +60,12 @@ class EventProcessor:
 
         Note
         ----
-        
+        Developing processors in this way is incredible inefficient, especially since it
+        does not allow for code to be well organized and split across many files nor does it
+        allow for two processors to share common code.
+        If you find yourself defining more than one `class` within your new C++ processor,
+        it is highly recommended to transition your workflow to including your processor as a
+        part of ldmx-sw so that it can fully benefit from a build system.
 
         Parameters
         ----------


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
I very quickly noticed that this stand-alone processor function can be updated to link to additional pre-compiled ldmx-sw libraries which is helpful in many circumstances. Specifically, I am working with a new graduate student who wished to have her analyzer user the detector ID classes in the `DetDescr` library and updating the compilation command to include `-lDetDescr` was all that was necessary.

The developments here are focused on allowing for the user to add other libraries to link. Pretty much any library that is system-findable (or installed with ldmx-sw) should be linkable in this way, although I haven't tested this thoroughly.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
