### PR TITLE
forgot to call `items()` when looping over a dict

### DIFF
--- a/Framework/python/ldmxcfg.py
+++ b/Framework/python/ldmxcfg.py
@@ -149,7 +149,7 @@ class EventProcessor:
                 print(f'done compiling {src}')
 
         instance = cls(instance_name, class_name, str(lib))
-        for cfg_name, cfg_val in config_kwargs:
+        for cfg_name, cfg_val in config_kwargs.items():
             setattr(instance, cfg_name, cfg_val)
         return instance
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Currently, on trunk, you will see the following error when attempting to define config parameters for your standalone processor in-line.
```python
ldmxcfg.Analyzer.from_file('Skimmer.cxx', output_file = str(args.out_file))
```
produces
```
---- LDMXSW: Loading configuration --------
Processor source file /export/scratch/users/eichl008/ldmx/eat/v14/event-display/Skimmer.cxx is newer than its compiled library /export/scratch/users/eichl008/ldmx/eat/v14/event-display/libSkimmer.so (or library does not exist), recompilin
g...
done compiling /export/scratch/users/eichl008/ldmx/eat/v14/event-display/Skimmer.cxx
Traceback (most recent call last):
  File "event-display-skim.py", line 15, in <module>
    ldmxcfg.Analyzer.from_file('Skimmer.cxx', output_file = str(args.out_file))
  File "/usr/local/python/LDMX/Framework/ldmxcfg.py", line 125, in from_file
    for cfg_name, cfg_val in config_kwargs:
ValueError: too many values to unpack (expected 2)
```
We can get around this by simply avoiding this piece of buggy code.
```python
skim = ldmxcfg.Analyzer.from_file('Skimmer.cxx')
skim.output_file = str(args.out_file)
```
works as desired.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

```
# on trunk
---- LDMXSW: Loading configuration --------
Processor source file /home/tom/code/ldmx/1368-standalone-config/Example.cxx is newer than its compiled library /home/tom/code/ldmx/1368-standalone-config/libExample.so (or library does not exist), recompiling...
done compiling /home/tom/code/ldmx/1368-standalone-config/Example.cxx
Traceback (most recent call last):
  File "config.py", line 3, in <module>
    p.sequence = [ ldmxcfg.Analyzer.from_file('Example.cxx', factor = 2) ]
  File "/home/tom/code/ldmx/ldmx-sw/install/python/LDMX/Framework/ldmxcfg.py", line 152, in from_file
    for cfg_name, cfg_val in config_kwargs:
ValueError: too many values to unpack (expected 2)
Configuration Error [ConfigureError] : Problem running python script.
  at /home/tom/code/ldmx/ldmx-sw/Framework/src/Framework/ConfigurePython.cxx:319 in ConfigurePython
# on this branch (didn't need to recompile!)
---- LDMXSW: Loading configuration --------
---- LDMXSW: Configuration load complete  --------
---- LDMXSW: Starting event processing --------
2
4
6
8
10
12
14
16
18
20
---- LDMXSW: Event processing complete  --------
```

<details>
  <summary>Files and Image</summary>

I was using ldmx/dev:4.2.0 and the following two files.

Running `ldmx fire config.py` on either branch.

### Example.cxx
```cpp
// filename: Example.cxx
#include "Framework/EventProcessor.h"

#include "Ecal/Event/EcalHit.h"

class Example : public framework::Analyzer {
  int factor_;
 public:
  Example(const std::string& name, framework::Process& p)
    : framework::Analyzer(name, p) {}
  ~Example() = default;
  void configure(framework::config::Parameters& p) final {
    factor_ = p.getParameter<int>("factor");
  }
  void analyze(const framework::Event& event) final {
    std::cout << event.getEventNumber()*factor_ << std::endl;
  }
};

DECLARE_ANALYZER(Example);
```

### config.py
```python
from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('ana')
p.sequence = [ ldmxcfg.Analyzer.from_file('Example.cxx', factor = 2) ]
p.maxEvents = 10
p.outputFiles = [ '/dev/null' ]
p.run = 1
```

</details>

I also added a check to make sure these keyword-arguments are not overwriting anything else.
For example, if someone tried to pass `instanceName` as a kwarg, they would see
```
---- LDMXSW: Loading configuration --------
Traceback (most recent call last):
  File "config.py", line 3, in <module>
    p.sequence = [ ldmxcfg.Analyzer.from_file('Example.cxx', factor = 2, instanceName='bad') ]
  File "/home/tom/code/ldmx/ldmx-sw/install/python/LDMX/Framework/ldmxcfg.py", line 161, in from_file
    raise KeyError(f'The parameter {cfg_name} is already set for {cls.__name__}({instance.instanceName}, {instance.className}).')
KeyError: 'The parameter instanceName is already set for Analyzer(Example, Example).'
Configuration Error [ConfigureError] : Problem running python script.
  at /home/tom/code/ldmx/ldmx-sw/Framework/src/Framework/ConfigurePython.cxx:319 in ConfigurePython
```