### PR TITLE
Make all truth tracking collections even with 0 SimHits

### DIFF
--- a/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
+++ b/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
@@ -243,12 +243,12 @@ class TruthSeedProcessor : public TrackingGeometryUser {
   // Use scoring plane for target truth tracks
   bool target_sp_{true};
 
-  //skip the tagger tracker
+  // skip the tagger tracker
   bool skip_tagger_{false};
 
-  //skip the recoil tracker
+  // skip the recoil tracker
   bool skip_recoil_{false};
-  
+
   std::shared_ptr<LinPropagator> linpropagator_;
 
   // Track Extrapolator Tool :: TODO Use the real extrapolator!

--- a/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
+++ b/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
@@ -243,6 +243,12 @@ class TruthSeedProcessor : public TrackingGeometryUser {
   // Use scoring plane for target truth tracks
   bool target_sp_{true};
 
+  //skip the tagger tracker
+  bool skip_tagger_{false};
+
+  //skip the recoil tracker
+  bool skip_recoil_{false};
+  
   std::shared_ptr<LinPropagator> linpropagator_;
 
   // Track Extrapolator Tool :: TODO Use the real extrapolator!

--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -270,30 +270,32 @@ class TruthSeedProcessor(Producer):
     track_id : int
         If positive, select only scoring hits with that particular track ID.
     pz_cut : double
-        Minimum cut on the momentum (MeV)
-of the seed along the beam axis.p_cut : double Minimum cut on the momentum(MeV)
-of the seed.p_cut_max
-    : double Maximum cut on the momentum of the seed.p_cut_ecal
-    : double Minimum seed track
-      momentum(MeV)
-at the ECAL scoring plane skip_tagger
-    : bool Ignore the tagger
-      tracker(makes empty collections) skip_recoil
-    : bool Ignore the recoil tracker(makes empty collections)
+        Minimum cut on the momentum (MeV)of the seed along the beam axis.
+    p_cut : double 
+        Minimum cut on the momentum(MeV) of the seed.
+    p_cut_max : double 
+        Maximum cut on the momentum of the seed.
+    p_cut_ecal : double 
+        Minimum seed track momentum(MeV) at the ECAL scoring plane 
+    skip_tagger : bool 
+        Ignore the tagger tracker(makes empty collections). 
+    skip_recoil : bool 
+        Ignore the recoil tracker(makes empty collections)
+    """
+    def __init__(self, instance_name = "TruthSeedProcessor"):
+        super().__init__(instance_name, 'tracking::reco::TruthSeedProcessor',
+                         'Tracking')
 
-          ""
-          "
-      def __init__(self, instance_name = "TruthSeedProcessor")
-    : super()
-          .__init__(instance_name, 'tracking::reco::TruthSeedProcessor',
-                    'Tracking')
-
-              self.pdg_ids = [11] self.scoring_hits_coll_name =
-    'TargetScoringPlaneHits' self.recoil_sim_hits_coll_name =
-        'RecoilSimHits' self.tagger_sim_hits_coll_name =
-            'TaggerSimHits' self.n_min_hits = 7 self.z_min =
-                -9999. #mm self.track_id = -9999 self.pz_cut =
-                    -9999. #MeV self.p_cut = 0. #MeV self.p_cut_max =
-                        100000. #MeV self.p_cut_ecal =
-                            -1. #MeV self.skip_tagger = False self.skip_recoil =
-                                False
+        self.pdg_ids = [11]
+        self.scoring_hits_coll_name = 'TargetScoringPlaneHits'
+        self.recoil_sim_hits_coll_name = 'RecoilSimHits'
+        self.tagger_sim_hits_coll_name = 'TaggerSimHits'
+        self.n_min_hits = 7
+        self.z_min = -9999. #mm
+        self.track_id = -9999
+        self.pz_cut = -9999. #MeV
+        self.p_cut = 0. #MeV
+        self.p_cut_max = 100000. #MeV
+        self.p_cut_ecal = -1. #MeV
+        self.skip_tagger = False
+        self.skip_recoil = False

--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -270,28 +270,30 @@ class TruthSeedProcessor(Producer):
     track_id : int
         If positive, select only scoring hits with that particular track ID.
     pz_cut : double
-        Minimum cut on the momentum (MeV) of the seed along the beam axis.
-    p_cut : double
-        Minimum cut on the momentum (MeV) of the seed.
-    p_cut_max : double
-        Maximum cut on the momentum of the seed.
-    p_cut_ecal : double
-        Minimum seed track momentum (MeV) at the ECAL scoring plane
-       
-    
-    """
-    def __init__(self, instance_name="TruthSeedProcessor"):
-        super().__init__(instance_name, 'tracking::reco::TruthSeedProcessor',
-                         'Tracking')
+        Minimum cut on the momentum (MeV)
+of the seed along the beam axis.p_cut : double Minimum cut on the momentum(MeV)
+of the seed.p_cut_max
+    : double Maximum cut on the momentum of the seed.p_cut_ecal
+    : double Minimum seed track
+      momentum(MeV)
+at the ECAL scoring plane skip_tagger
+    : bool Ignore the tagger
+      tracker(makes empty collections) skip_recoil
+    : bool Ignore the recoil tracker(makes empty collections)
 
-        self.pdg_ids = [11]
-        self.scoring_hits_coll_name = 'TargetScoringPlaneHits'
-        self.recoil_sim_hits_coll_name = 'RecoilSimHits'
-        self.tagger_sim_hits_coll_name = 'TaggerSimHits'
-        self.n_min_hits = 7
-        self.z_min = -9999.  # mm
-        self.track_id = -9999
-        self.pz_cut = -9999.  # MeV
-        self.p_cut = 0.  # MeV
-        self.p_cut_max = 100000.  # MeV
-        self.p_cut_ecal = -1.  # MeV
+          ""
+          "
+      def __init__(self, instance_name = "TruthSeedProcessor")
+    : super()
+          .__init__(instance_name, 'tracking::reco::TruthSeedProcessor',
+                    'Tracking')
+
+              self.pdg_ids = [11] self.scoring_hits_coll_name =
+    'TargetScoringPlaneHits' self.recoil_sim_hits_coll_name =
+        'RecoilSimHits' self.tagger_sim_hits_coll_name =
+            'TaggerSimHits' self.n_min_hits = 7 self.z_min =
+                -9999. #mm self.track_id = -9999 self.pz_cut =
+                    -9999. #MeV self.p_cut = 0. #MeV self.p_cut_max =
+                        100000. #MeV self.p_cut_ecal =
+                            -1. #MeV self.skip_tagger = False self.skip_recoil =
+                                False

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -60,9 +60,8 @@ void TruthSeedProcessor::configure(framework::config::Parameters& parameters) {
   // In tracking frame
   beamOrigin_ = parameters.getParameter<std::vector<double>>(
       "beamOrigin", {-880.1, -44., 0.});
-  skip_tagger_=parameters.getParameter<bool>("skip_tagger", false);
-  skip_recoil_=parameters.getParameter<bool>("skip_recoil", false);
-
+  skip_tagger_ = parameters.getParameter<bool>("skip_tagger", false);
+  skip_recoil_ = parameters.getParameter<bool>("skip_recoil", false);
 }
 
 void TruthSeedProcessor::createTruthTrack(
@@ -531,13 +530,13 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   // If sim hit collections are empty throw a warning
   if (tagger_sim_hits.size() == 0 && !skip_tagger_)
     ldmx_log(error) << "Tagger sim hits collection empty for event "
-		    << event.getEventNumber() << " in run "
-		    << event.getEventHeader().getRun() << std::endl;
+                    << event.getEventNumber() << " in run "
+                    << event.getEventHeader().getRun() << std::endl;
   if (recoil_sim_hits.size() == 0 && !skip_recoil_)
     ldmx_log(error) << "Recoil sim hits collection empty for event "
-		    << event.getEventNumber() << " in run "
-		    << event.getEventHeader().getRun() << std::endl;
-  
+                    << event.getEventNumber() << " in run "
+                    << event.getEventHeader().getRun() << std::endl;
+
   // The map stores which track leaves which sim hits
   std::map<int, std::vector<int>> hit_count_map_recoil;
   makeHitCountMap(recoil_sim_hits, hit_count_map_recoil);
@@ -654,7 +653,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   // Form the tagger full seed.
   // TODO This won't work for multiple electrons sample. Fix.
 
-  if (idx_taggerhit != -1  && !skip_tagger_ ) {
+  if (idx_taggerhit != -1 && !skip_tagger_) {
     ldmx::Track beamETruthSeed = TaggerFullSeed(
         particleMap[1], 1, scoring_hits.at(idx_taggerhit), hit_count_map_tagger,
         beamOriginSurface, targetUnboundSurface);
@@ -694,7 +693,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
 
     // Findable particle selection
     if (hit_count_map_recoil[hit.getTrackID()].size() > n_min_hits_recoil_ &&
-        foundEcalHit && ! skip_recoil_) {
+        foundEcalHit && !skip_recoil_) {
       ldmx::Track truth_recoil_track =
           RecoilFullSeed(particleMap[hit.getTrackID()], hit.getTrackID(), hit,
                          ecal_hit, hit_count_map_recoil, targetSurface,
@@ -735,8 +734,8 @@ void TruthSeedProcessor::produce(framework::Event& event) {
     recoil_truth_seeds.push_back(seed);
   }
 
-
-  //even if skip_tagger/recoil_ is true, still make the collections in the event
+  // even if skip_tagger/recoil_ is true, still make the collections in the
+  // event
   event.add("beamElectrons", beam_electrons);
   event.add("TaggerTruthTracks", tagger_truth_tracks);
   event.add("RecoilTruthTracks", recoil_truth_tracks);

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -57,9 +57,11 @@ void TruthSeedProcessor::configure(framework::config::Parameters& parameters) {
   inflate_factors_ = parameters.getParameter<std::vector<double>>(
       "inflate_factors", {10., 10., 10., 10., 10., 10.});
 
-  // In tracking frame
+  // In tracking frame:  MG where do these numbers come from?
   beamOrigin_ = parameters.getParameter<std::vector<double>>(
       "beamOrigin", {-880.1, -44., 0.});
+
+  // Skip the tagger or recoil trackers if wanted
   skip_tagger_ = parameters.getParameter<bool>("skip_tagger", false);
   skip_recoil_ = parameters.getParameter<bool>("skip_recoil", false);
 }
@@ -145,8 +147,9 @@ void TruthSeedProcessor::createTruthTrack(
 
   if (abs(tgt_surf_center(0) - gen_surf_center(0)) > tol)
     ldmx_log(error) << "Linear extrapolation to a far away surface in B field."
-                    << "This will cause inaccuracies in track parameters"
-                    << std::endl;
+                    << "  This will cause inaccuracies in track parameters"
+                    << "  Distance extrapolated = "
+                    << (tgt_surf_center(0) - gen_surf_center(0)) << std::endl;
 
   auto propBoundState = trk_extrap_->extrapolate(boundTrkPars, target_surface);
 
@@ -375,7 +378,7 @@ ldmx::Track TruthSeedProcessor::seedFromTruth(const ldmx::Track& tt,
     stddev[Acts::eBoundTime] =
         inflate_factors_[Acts::eBoundTime] * sigma_t * Acts::UnitConstants::ns;
 
-    ldmx_log(info) << stddev << std::endl;
+    ldmx_log(debug) << stddev << std::endl;
 
     std::vector<double> v_seed_params(
         (bound_params).data(),

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -57,7 +57,12 @@ void TruthSeedProcessor::configure(framework::config::Parameters& parameters) {
   inflate_factors_ = parameters.getParameter<std::vector<double>>(
       "inflate_factors", {10., 10., 10., 10., 10., 10.});
 
-  // In tracking frame:  MG where do these numbers come from?
+  // In tracking frame: where do these numbers come from?
+  // These numbers come from approximating the path of the beam up
+  // until it is about to enter the first detector volume (TriggerPad1).
+  // In detector coordinates, (x,y,z) = (-44,0,-880) is _roughly_
+  // where the beam arrives (if no smearing is applied) and we simply
+  // reorder these values so that they are in tracking coordinates.
   beamOrigin_ = parameters.getParameter<std::vector<double>>(
       "beamOrigin", {-880.1, -44., 0.});
 


### PR DESCRIPTION
I've modified TruthSeedProcessor so that it no longer skips MC events with 0 SimHits in either recoil or tracker collections (issue 1371).  This caused a crash downstream when one of the truth collections was (attempted) to be used.  

In the update, an error-level message will be printed when it encounters an empty SimHits collection but (empty) truth seed and track collections will be made.  

The error messages can be turned off (for instance if the tagger wasn't simulated) by setting the new config variable skip_XXXX to true, for example:   
`truth_tracking.skip_tagger       = True`
a 'skip_recoil' variable exists as well.  Note that these also turn off the relevant truth-track-making code as well.  These config variables are set to 'False' by default. 

I've also changed some log entries from 'info' to 'debug' level.  