### PR TITLE
Added multi-electron tagger truth tracking capability

### DIFF
--- a/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
+++ b/Tracking/include/Tracking/Reco/TruthSeedProcessor.h
@@ -249,6 +249,9 @@ class TruthSeedProcessor : public TrackingGeometryUser {
   // skip the recoil tracker
   bool skip_recoil_{false};
 
+  // Maximum track id for hit to be selected from target scoring plane
+  int max_track_id_{5};
+
   std::shared_ptr<LinPropagator> linpropagator_;
 
   // Track Extrapolator Tool :: TODO Use the real extrapolator!

--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -278,11 +278,11 @@ class TruthSeedProcessor(Producer):
     p_cut_ecal : double 
         Minimum seed track momentum(MeV) at the ECAL scoring plane 
     skip_tagger : bool 
-    max_track_id : double
-        Maximum track ID for a hit to be selected in the target scoring plane.
         Ignore the tagger tracker(makes empty collections). 
     skip_recoil : bool 
-        Ignore the recoil tracker(makes empty collections)
+        Ignore the recoil tracker(makes empty collections).
+    max_track_id : double
+        Maximum track ID for a hit to be selected in the target scoring plane.
     """
     def __init__(self, instance_name = "TruthSeedProcessor"):
         super().__init__(instance_name, 'tracking::reco::TruthSeedProcessor',

--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -278,6 +278,8 @@ class TruthSeedProcessor(Producer):
     p_cut_ecal : double 
         Minimum seed track momentum(MeV) at the ECAL scoring plane 
     skip_tagger : bool 
+    max_track_id : double
+        Maximum track ID for a hit to be selected in the target scoring plane.
         Ignore the tagger tracker(makes empty collections). 
     skip_recoil : bool 
         Ignore the recoil tracker(makes empty collections)
@@ -299,3 +301,4 @@ class TruthSeedProcessor(Producer):
         self.p_cut_ecal = -1. #MeV
         self.skip_tagger = False
         self.skip_recoil = False
+        self.max_track_id = 5

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -574,10 +574,10 @@ void TruthSeedProcessor::produce(framework::Event& event) {
     if (zhit < 0.) {
       // Tagger selection cuts
       // Negative scoring plane hit, with momentum > p_cut
-      if (p_vec(2) < 0. || p_vec.norm() < p_cut_)
-      {
-        continue;
-      }
+      if (p_vec(2) < 0. || p_vec.norm() < p_cut_) continue;
+      
+      // Check that the hit was left by a charged particle
+      if (abs(particleMap[hit.getTrackID()].getCharge()) < 1e-8) continue;
 
       if (p_vec.norm() > tagger_p_max) {
         tagger_sh_count_map[hit.getTrackID()].push_back(i_sh);

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -615,7 +615,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   }
 
   // Sort tagger hits.
-  for (auto& [ _track_id, hit_indices ] : tagger_sh_count_map) {
+  for (auto& [_track_id, hit_indices] : tagger_sh_count_map) {
     std::sort(
         hit_indices.begin(), hit_indices.end(),
         [&](const int idx1, int idx2) -> bool {
@@ -654,29 +654,27 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   auto beamOriginSurface{Acts::Surface::makeShared<Acts::PerigeeSurface>(
       Acts::Vector3(beamOrigin_[0], beamOrigin_[1], beamOrigin_[2]))};
 
-    if (!skip_tagger_) {
-  for (const auto& [track_id, hit_indices] : tagger_sh_count_map) {
-    const ldmx::SimTrackerHit& hit = scoring_hits.at(hit_indices.at(0));
-    const ldmx::SimParticle& phit = particleMap[hit.getTrackID()];
+  if (!skip_tagger_) {
+    for (const auto& [track_id, hit_indices] : tagger_sh_count_map) {
+      const ldmx::SimTrackerHit& hit = scoring_hits.at(hit_indices.at(0));
+      const ldmx::SimParticle& phit = particleMap[hit.getTrackID()];
 
-    if (hit_count_map_tagger[hit.getTrackID()].size() > n_min_hits_tagger_) {
+      if (hit_count_map_tagger[hit.getTrackID()].size() > n_min_hits_tagger_) {
+        ldmx::Track truth_tagger_track;
+        createTruthTrack(phit, hit, truth_tagger_track, targetSurface);
+        truth_tagger_track.setNhits(
+            hit_count_map_tagger[hit.getTrackID()].size());
+        tagger_truth_tracks.push_back(truth_tagger_track);
 
-      ldmx::Track truth_tagger_track;
-      createTruthTrack(phit, hit, truth_tagger_track, targetSurface);
-      truth_tagger_track.setNhits(
-          hit_count_map_tagger[hit.getTrackID()].size());
-      tagger_truth_tracks.push_back(truth_tagger_track);
-
-
-      if (hit.getPdgID() == 11 && hit.getTrackID() < max_track_id_) {
-        ldmx::Track beamETruthSeed = TaggerFullSeed(
-          particleMap[hit.getTrackID()], hit.getTrackID(), hit,
-          hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
-        beam_electrons.push_back(beamETruthSeed);
+        if (hit.getPdgID() == 11 && hit.getTrackID() < max_track_id_) {
+          ldmx::Track beamETruthSeed = TaggerFullSeed(
+              particleMap[hit.getTrackID()], hit.getTrackID(), hit,
+              hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
+          beam_electrons.push_back(beamETruthSeed);
+        }
       }
     }
   }
-    }
 
   // Recover the EcalScoring hits
   std::vector<ldmx::SimTrackerHit> ecal_spHits =

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -575,7 +575,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
       // Tagger selection cuts
       // Negative scoring plane hit, with momentum > p_cut
       if (p_vec(2) < 0. || p_vec.norm() < p_cut_) continue;
-      
+
       // Check that the hit was left by a charged particle
       if (abs(particleMap[hit.getTrackID()].getCharge()) < 1e-8) continue;
 
@@ -614,9 +614,8 @@ void TruthSeedProcessor::produce(framework::Event& event) {
         });
   }
 
-
   // Sort tagger hits. TO DO: simplify/merge with above
-    for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
+  for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
     std::sort(
         element.second.begin(), element.second.end(),
         [&](const int idx1, int idx2) -> bool {
@@ -655,16 +654,16 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   auto beamOriginSurface{Acts::Surface::makeShared<Acts::PerigeeSurface>(
       Acts::Vector3(beamOrigin_[0], beamOrigin_[1], beamOrigin_[2]))};
 
-    // For tagger scoring plane hits
+  // For tagger scoring plane hits
     if (!skip_tagger_) {
-    for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
+  for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
     const ldmx::SimTrackerHit& hit = scoring_hits.at(element.second.at(0));
     const ldmx::SimParticle& phit = particleMap[hit.getTrackID()];
 
     if (hit_count_map_tagger[hit.getTrackID()].size() > n_min_hits_tagger_) {
-      
-      ldmx::Track truth_tagger_track = TaggerFullSeed(particleMap[hit.getTrackID()], hit.getTrackID(),
-              hit, hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
+      ldmx::Track truth_tagger_track = TaggerFullSeed(
+          particleMap[hit.getTrackID()], hit.getTrackID(), hit,
+          hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
 
       truth_tagger_track.setNhits(
           hit_count_map_tagger[hit.getTrackID()].size());
@@ -674,9 +673,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
         beam_electrons.push_back(truth_tagger_track);
       }
     }
-
- 
-    }
+  }
     }
 
   // Recover the EcalScoring hits

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -614,7 +614,7 @@ void TruthSeedProcessor::produce(framework::Event& event) {
         });
   }
 
-  // Sort tagger hits. TO DO: simplify/merge with above
+  // Sort tagger hits.
   for (auto& [ _track_id, hit_indices ] : tagger_sh_count_map) {
     std::sort(
         hit_indices.begin(), hit_indices.end(),
@@ -660,16 +660,19 @@ void TruthSeedProcessor::produce(framework::Event& event) {
     const ldmx::SimParticle& phit = particleMap[hit.getTrackID()];
 
     if (hit_count_map_tagger[hit.getTrackID()].size() > n_min_hits_tagger_) {
-      ldmx::Track truth_tagger_track = TaggerFullSeed(
-          particleMap[hit.getTrackID()], hit.getTrackID(), hit,
-          hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
 
+      ldmx::Track truth_tagger_track;
+      createTruthTrack(phit, hit, truth_tagger_track, targetSurface);
       truth_tagger_track.setNhits(
           hit_count_map_tagger[hit.getTrackID()].size());
       tagger_truth_tracks.push_back(truth_tagger_track);
 
+
       if (hit.getPdgID() == 11 && hit.getTrackID() < max_track_id_) {
-        beam_electrons.push_back(truth_tagger_track);
+        ldmx::Track beamETruthSeed = TaggerFullSeed(
+          particleMap[hit.getTrackID()], hit.getTrackID(), hit,
+          hit_count_map_tagger, beamOriginSurface, targetUnboundSurface);
+        beam_electrons.push_back(beamETruthSeed);
       }
     }
   }

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -40,7 +40,7 @@ void TruthSeedProcessor::configure(framework::config::Parameters& parameters) {
   recoil_sp_ = parameters.getParameter<double>("recoil_sp", true);
   target_sp_ = parameters.getParameter<double>("tagger_sp", true);
   seedSmearing_ = parameters.getParameter<bool>("seedSmearing", false);
-  max_track_id_ = parameters.getParameter<int>("seedSmearing", 5);
+  max_track_id_ = parameters.getParameter<int>("max_track_id", 5);
 
   ldmx_log(info) << "Seed Smearing is set to " << seedSmearing_;
 
@@ -615,9 +615,9 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   }
 
   // Sort tagger hits. TO DO: simplify/merge with above
-  for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
+  for (auto& [ _track_id, hit_indices ] : tagger_sh_count_map) {
     std::sort(
-        element.second.begin(), element.second.end(),
+        hit_indices.begin(), hit_indices.end(),
         [&](const int idx1, int idx2) -> bool {
           const ldmx::SimTrackerHit& hit1 = scoring_hits.at(idx1);
           const ldmx::SimTrackerHit& hit2 = scoring_hits.at(idx2);
@@ -654,10 +654,9 @@ void TruthSeedProcessor::produce(framework::Event& event) {
   auto beamOriginSurface{Acts::Surface::makeShared<Acts::PerigeeSurface>(
       Acts::Vector3(beamOrigin_[0], beamOrigin_[1], beamOrigin_[2]))};
 
-  // For tagger scoring plane hits
     if (!skip_tagger_) {
-  for (std::pair<int, std::vector<int>> element : tagger_sh_count_map) {
-    const ldmx::SimTrackerHit& hit = scoring_hits.at(element.second.at(0));
+  for (const auto& [track_id, hit_indices] : tagger_sh_count_map) {
+    const ldmx::SimTrackerHit& hit = scoring_hits.at(hit_indices.at(0));
     const ldmx::SimParticle& phit = particleMap[hit.getTrackID()];
 
     if (hit_count_map_tagger[hit.getTrackID()].size() > n_min_hits_tagger_) {


### PR DESCRIPTION
I've modified TruthSeedProcessor so that truth seeding/tracking for the tagger is able to handle multi-electron events. This resolves #1373. Tagger truth tracking now operates the same way as recoil truth tracking, and was tested on simulated samples up to four electrons. Similar to recoil truth tracking, the tagger truth hits are selected according to a momentum cut in the appropriate target scoring plane. 

Tracks corresponding specifically to beam electron hits are stored in the `beamElectrons` collection. This selection is done according to a new parameter called `max_track_id`, which defines the maximum track ID corresponding to a primary electron, as well as a pdgID selection. 

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments
- [X] I ran my developments and the following shows that they are successful.

This plots shows the number of tracks identified in the TaggerTruthTracks collections, for a 2e- sample. We see that we are now able to recover 2e- events. 
<img width="1119" alt="taggerTruth_Ntracks" src="https://github.com/LDMX-Software/ldmx-sw/assets/66688168/e48dc2d7-5f29-44c4-b460-552d7f6a1600">



