### PR TITLE
Introduce EcalPreselectionSkimmer

### DIFF
--- a/Recon/include/Recon/Skims/EcalPreselectionSkimmer.h
+++ b/Recon/include/Recon/Skims/EcalPreselectionSkimmer.h
@@ -12,27 +12,26 @@
 //----------//
 #include "Ecal/Event/EcalVetoResult.h"
 #include "Framework/EventProcessor.h"
-#include "Tools/AnalysisUtils.h"
 
 namespace recon {
 
 class EcalPreselectionSkimmer : public framework::Producer {
  public:
-  // @param parameters Set of parameters used to configure this processor.
-  virtual void configure(framework::config::Parameters &);
-
   /** Constructor */
   EcalPreselectionSkimmer(const std::string &name, framework::Process &process);
 
   /** Destructor */
   ~EcalPreselectionSkimmer() = default;
 
+  // Configure this processor with a set of parameters passed
+  virtual void configure(framework::config::Parameters &) final;
+
   /**
    * Run the processor and select events that pass pre-selection in ECAL
    *
    * @param event The event to process.
    */
-  void produce(framework::Event &event);
+  virtual void produce(framework::Event &event) final;
 
  private:
   /// Collection Name for veto object

--- a/Recon/include/Recon/Skims/EcalPreselectionSkimmer.h
+++ b/Recon/include/Recon/Skims/EcalPreselectionSkimmer.h
@@ -1,0 +1,66 @@
+/**
+ * @file EcalPreselectionSkimmer.h
+ * @brief Processor used to pre-select events for the ECAL studies
+ * @author Tamas Almos Vami (UCSB)
+ */
+
+#ifndef RECON_SKIMS_EcalPreselectionSkimmer_H_
+#define RECON_SKIMS_EcalPreselectionSkimmer_H_
+
+//----------//
+//   LDMX   //
+//----------//
+#include "Ecal/Event/EcalVetoResult.h"
+#include "Framework/EventProcessor.h"
+#include "Tools/AnalysisUtils.h"
+
+namespace recon {
+
+class EcalPreselectionSkimmer : public framework::Producer {
+ public:
+  // @param parameters Set of parameters used to configure this processor.
+  virtual void configure(framework::config::Parameters &);
+
+  /** Constructor */
+  EcalPreselectionSkimmer(const std::string &name, framework::Process &process);
+
+  /** Destructor */
+  ~EcalPreselectionSkimmer() = default;
+
+  /**
+   * Run the processor and select events that pass pre-selection in ECAL
+   *
+   * @param event The event to process.
+   */
+  void produce(framework::Event &event);
+
+ private:
+  /// Collection Name for veto object
+  std::string ecal_veto_name_;
+  /// Pass Name for veto object
+  std::string ecal_veto_pass_;
+  /// Max value for summed det
+  double summed_det_max_;
+  /// Max value for summed tigh iso
+  double summed_tight_iso_max_;
+  /// Max value for ecal back energy
+  double ecal_back_energy_max_;
+  /// Max value for num readout hits
+  int n_readout_hits_max_;
+  /// Max value for shower rms
+  int shower_rms_max_;
+  /// Max value for shower rms in Y
+  int shower_y_std_max_;
+  /// Max value for shower rms in X
+  int shower_x_std_max_;
+  /// Max value for maximal cell deposition
+  double max_cell_dep_max_;
+  /// Max value for std layer hits
+  int std_layer_hit_max_;
+  /// Max value for num straight tracks
+  int n_straight_tracks_max_;
+
+};  // EcalPreselectionSkimmer
+}  // namespace recon
+
+#endif  // RECON_SKIMS_EcalPreselectionSkimmer_H_

--- a/Recon/python/ecalPreselectionSkimmer.py
+++ b/Recon/python/ecalPreselectionSkimmer.py
@@ -1,0 +1,63 @@
+"""Configuration for PreselectionProcessor
+
+Sets all the default parameters that high so it leads to no preselection.
+
+Attributes:
+------------- 
+
+ecal_veto_name: string
+    Collection Name for veto object
+ecal_veto_pass: string
+    Pass Name for veto object
+summed_det_max: double
+    Max value for summed det
+summed_tight_iso_max: double
+   Max value for summed tigh iso
+ecal_back_energy_max: double
+    Max value for ecal back energy
+ n_readout_hits_max: int
+    Max value for num readout hits
+ shower_rms_max: int
+    Max value for shower rms
+ shower_y_std_max: int
+   Max value for shower rms in Y
+shower_x_std_max: int
+    Max value for shower rms in X
+max_cell_dep_max: double
+    Max value for maximal cell deposition
+std_layer_hit_max: int
+    Max value for std layer hits
+n_straight_tracks_max: int
+    Max value for num straight tracks
+
+
+Examples
+--------
+    from LDMX.Recon.ecalPreselectionSkimmer import ecalPreselectionSkimmer
+    p.sequence.append( ecalPreselectionSkimmer )
+"""
+
+from LDMX.Framework import ldmxcfg
+
+class EcalPreselectionSkimmer(ldmxcfg.Producer) :
+    """Configuration for an ECAL-based pre-selection skimmer"""
+
+    def __init__(self, name) :
+        super().__init__(name,'recon::EcalPreselectionSkimmer','Recon')
+
+        self.ecal_veto_name = "EcalVeto"
+        self.ecal_veto_pass = ""
+        self.summed_det_max = 9999.
+        self.summed_tight_iso_max = 9999.
+        self.ecal_back_energy_max = 9999.
+        self.n_readout_hits_max = 9999
+        self.shower_rms_max = 9999
+        self.shower_y_std_max = 9999
+        self.shower_x_std_max = 9999
+        self.max_cell_dep_max = 9999.
+        self.std_layer_hit_max = 9999
+        self.n_straight_tracks_max = 9999
+
+
+ecalPreselectionSkimmer = EcalPreselectionSkimmer("ecalPreselectionSkimmer")
+

--- a/Recon/python/ecalPreselectionSkimmer.py
+++ b/Recon/python/ecalPreselectionSkimmer.py
@@ -33,8 +33,9 @@ n_straight_tracks_max: int
 
 Examples
 --------
-    from LDMX.Recon.ecalPreselectionSkimmer import ecalPreselectionSkimmer
-    p.sequence.append( ecalPreselectionSkimmer )
+    from LDMX.Recon.ecalPreselectionSkimmer import EcalPreselectionSkimmer
+    ecal_pres_skimmer = EcalPreselectionSkimmer()
+    p.sequence.append( ecal_pres_skimmer )
 """
 
 from LDMX.Framework import ldmxcfg
@@ -42,7 +43,7 @@ from LDMX.Framework import ldmxcfg
 class EcalPreselectionSkimmer(ldmxcfg.Producer) :
     """Configuration for an ECAL-based pre-selection skimmer"""
 
-    def __init__(self, name) :
+    def __init__(self, name = "ecalPreselectionSkimmer") :
         super().__init__(name,'recon::EcalPreselectionSkimmer','Recon')
 
         self.ecal_veto_name = "EcalVeto"
@@ -57,7 +58,3 @@ class EcalPreselectionSkimmer(ldmxcfg.Producer) :
         self.max_cell_dep_max = 9999.
         self.std_layer_hit_max = 9999
         self.n_straight_tracks_max = 9999
-
-
-ecalPreselectionSkimmer = EcalPreselectionSkimmer("ecalPreselectionSkimmer")
-

--- a/Recon/src/Recon/Skims/EcalPreselectionSkimmer.cxx
+++ b/Recon/src/Recon/Skims/EcalPreselectionSkimmer.cxx
@@ -1,0 +1,62 @@
+/**
+ * @file EcalPreselectionSkimmer.cxx
+ * @brief Processor used to pre-select events for the ECAL studies
+ * @author Tamas Almos Vami (UCSB)
+ */
+
+#include "Recon/Skims/EcalPreselectionSkimmer.h"
+
+namespace recon {
+
+EcalPreselectionSkimmer::EcalPreselectionSkimmer(const std::string &name,
+                                                 framework::Process &process)
+    : framework::Producer(name, process) {}
+
+void EcalPreselectionSkimmer::configure(framework::config::Parameters &ps) {
+  ecal_veto_name_ = ps.getParameter<std::string>("ecal_veto_name");
+  ecal_veto_pass_ = ps.getParameter<std::string>("ecal_veto_pass");
+  summed_det_max_ = ps.getParameter<double>("summed_det_max");  // MeV
+  summed_tight_iso_max_ =
+      ps.getParameter<double>("summed_tight_iso_max");  // MeV
+  ecal_back_energy_max_ =
+      ps.getParameter<double>("ecal_back_energy_max");  // MeV
+  n_readout_hits_max_ = ps.getParameter<int>("n_readout_hits_max");
+  shower_rms_max_ = ps.getParameter<int>("shower_rms_max");
+  shower_y_std_max_ = ps.getParameter<int>("shower_y_std_max");
+  shower_x_std_max_ = ps.getParameter<int>("shower_x_std_max");
+  max_cell_dep_max_ = ps.getParameter<double>("max_cell_dep_max");  // MeV
+  std_layer_hit_max_ = ps.getParameter<int>("std_layer_hit_max");
+  n_straight_tracks_max_ = ps.getParameter<int>("n_straight_tracks_max");
+
+  return;
+}
+
+void EcalPreselectionSkimmer::produce(framework::Event &event) {
+  bool passedPreselection{false};
+  auto ecalVeto{
+      event.getObject<ldmx::EcalVetoResult>(ecal_veto_name_, ecal_veto_pass_)};
+
+  // Boolean to check if we pass preselection
+  passedPreselection = (ecalVeto.getSummedDet() < summed_det_max_) &&
+                       (ecalVeto.getSummedTightIso() < summed_tight_iso_max_) &&
+                       (ecalVeto.getEcalBackEnergy() < ecal_back_energy_max_) &&
+                       (ecalVeto.getNReadoutHits() < n_readout_hits_max_) &&
+                       (ecalVeto.getShowerRMS() < shower_rms_max_) &&
+                       (ecalVeto.getYStd() < shower_y_std_max_) &&
+                       (ecalVeto.getXStd() < shower_x_std_max_) &&
+                       (ecalVeto.getMaxCellDep() < max_cell_dep_max_) &&
+                       (ecalVeto.getStdLayerHit() < std_layer_hit_max_) &&
+                       (ecalVeto.getNStraightTracks() < n_straight_tracks_max_);
+
+  // Tell the skimmer to keep or drop the event based on whether preselection
+  // passed
+  if (passedPreselection) {
+    ldmx_log(debug) << "This event passed preselection!";
+    setStorageHint(framework::hint_shouldKeep);
+  } else {
+    setStorageHint(framework::hint_shouldDrop);
+  }
+}
+}  // namespace recon
+
+DECLARE_PRODUCER_NS(recon, EcalPreselectionSkimmer);

--- a/Recon/src/Recon/Skims/EcalPreselectionSkimmer.cxx
+++ b/Recon/src/Recon/Skims/EcalPreselectionSkimmer.cxx
@@ -33,7 +33,7 @@ void EcalPreselectionSkimmer::configure(framework::config::Parameters &ps) {
 
 void EcalPreselectionSkimmer::produce(framework::Event &event) {
   bool passedPreselection{false};
-  auto ecalVeto{
+  const auto &ecalVeto{
       event.getObject<ldmx::EcalVetoResult>(ecal_veto_name_, ecal_veto_pass_)};
 
   // Boolean to check if we pass preselection
@@ -56,6 +56,8 @@ void EcalPreselectionSkimmer::produce(framework::Event &event) {
   } else {
     setStorageHint(framework::hint_shouldDrop);
   }
+  // Add the boolean to the event
+  event.add("EcalPreselectionDecision", passedPreselection);
 }
 }  // namespace recon
 

--- a/Recon/test/ecal_preselection_skim.py
+++ b/Recon/test/ecal_preselection_skim.py
@@ -1,17 +1,34 @@
-import os import sys
+import os 
+import sys
 
-    thisPassName = "presel" inputName = sys.argv[1]
+thisPassName = "presel" 
+inputName = sys.argv[1]
 
-                                                 from LDMX.Framework import ldmxcfg p = ldmxcfg.Process(thisPassName)
+from LDMX.Framework import ldmxcfg 
+p = ldmxcfg.Process(thisPassName)
 
-                                                                                                            p.termLogLevel = 0
+p.termLogLevel = 0
+p.inputFiles =[inputName] 
+p.outputFiles =["eventsPreskimmed.root"]
 
-                                                                                                        p.inputFiles =[inputName] p.histogramFile = "histosPreskimmed.root" p.outputFiles =["eventsPreskimmed.root"]
-
-                                                                                                                                                                                            from LDMX.Recon.ecalPreselectionSkimmer import ecalPreselectionSkimmer ecalPreselectionSkimmer.summed_tight_iso_max = 1100. ecalPreselectionSkimmer.n_readout_hits_max = 90
-''' ## #Reminder for the possible things to cut on
-
-                                                                                                                                                                                            ecalPreselectionSkimmer.summed_det_max = 9999. ecalPreselectionSkimmer.summed_tight_iso_max = 9999. ecalPreselectionSkimmer.ecal_back_energy_max = 9999. ecalPreselectionSkimmer.n_readout_hits_max = 9999 ecalPreselectionSkimmer.shower_rms_max = 9999 ecalPreselectionSkimmer.shower_y_std_max = 9999 ecalPreselectionSkimmer.shower_x_std_max = 9999 ecalPreselectionSkimmer.max_cell_dep_max = 9999. ecalPreselectionSkimmer.std_layer_hit_max = 9999 ecalPreselectionSkimmer.n_straight_tracks_max = 9999
+from LDMX.Recon.ecalPreselectionSkimmer import EcalPreselectionSkimmer
+ecal_pres_skimmer = EcalPreselectionSkimmer()
+ecal_pres_skimmer.summed_tight_iso_max = 1100. 
+ecal_pres_skimmer.n_readout_hits_max = 90
+''' 
+## Reminder for the possible things to cut on
+ecal_pres_skimmer.summed_det_max = 9999. 
+ecal_pres_skimmer.summed_tight_iso_max = 9999. 
+ecal_pres_skimmer.ecal_back_energy_max = 9999. 
+ecal_pres_skimmer.n_readout_hits_max = 9999
+ecal_pres_skimmer.shower_rms_max = 9999 
+ecal_pres_skimmer.shower_y_std_max = 9999 
+ecal_pres_skimmer.shower_x_std_max = 9999 
+ecal_pres_skimmer.max_cell_dep_max = 9999. 
+ecal_pres_skimmer.std_layer_hit_max = 9999 
+ecal_pres_skimmer.n_straight_tracks_max = 9999
 '''
 
-                                                                                                                                                                                            p.sequence =[ecalPreselectionSkimmer] p.skimDefaultIsDrop() p.skimConsider(p.sequence[0].instanceName)
+p.sequence =[ecal_pres_skimmer] 
+p.skimDefaultIsDrop() 
+p.skimConsider(p.sequence[0].instanceName)

--- a/Recon/test/ecal_preselection_skim.py
+++ b/Recon/test/ecal_preselection_skim.py
@@ -1,0 +1,17 @@
+import os import sys
+
+    thisPassName = "presel" inputName = sys.argv[1]
+
+                                                 from LDMX.Framework import ldmxcfg p = ldmxcfg.Process(thisPassName)
+
+                                                                                                            p.termLogLevel = 0
+
+                                                                                                        p.inputFiles =[inputName] p.histogramFile = "histosPreskimmed.root" p.outputFiles =["eventsPreskimmed.root"]
+
+                                                                                                                                                                                            from LDMX.Recon.ecalPreselectionSkimmer import ecalPreselectionSkimmer ecalPreselectionSkimmer.summed_tight_iso_max = 1100. ecalPreselectionSkimmer.n_readout_hits_max = 90
+''' ## #Reminder for the possible things to cut on
+
+                                                                                                                                                                                            ecalPreselectionSkimmer.summed_det_max = 9999. ecalPreselectionSkimmer.summed_tight_iso_max = 9999. ecalPreselectionSkimmer.ecal_back_energy_max = 9999. ecalPreselectionSkimmer.n_readout_hits_max = 9999 ecalPreselectionSkimmer.shower_rms_max = 9999 ecalPreselectionSkimmer.shower_y_std_max = 9999 ecalPreselectionSkimmer.shower_x_std_max = 9999 ecalPreselectionSkimmer.max_cell_dep_max = 9999. ecalPreselectionSkimmer.std_layer_hit_max = 9999 ecalPreselectionSkimmer.n_straight_tracks_max = 9999
+'''
+
+                                                                                                                                                                                            p.sequence =[ecalPreselectionSkimmer] p.skimDefaultIsDrop() p.skimConsider(p.sequence[0].instanceName)


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1387

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I used the validation ecal pn config to produce 10k events. Then I run  `Recon/test/ecal_preselection_skim.py` on it. The current settings lead that 10k to 53 events, and looking at the distributions indeed they are cut off at the values set in the config. I made everything configurable and kept the defaults so high that it doesnt do anything in default. 