### PR TITLE
dont recurse into submodules when checking the state

### DIFF
--- a/scripts/state
+++ b/scripts/state
@@ -10,8 +10,8 @@
 set -o errexit
 set -o nounset
 
-git submodule foreach --recursive git fetch --tags
-git submodule status --recursive | awk '{
+git submodule foreach git fetch --tags
+git submodule status | awk '{
 # git submodule status returns lines of the form
 #  <commit> <submodule> (<version>)
 # where <version> is either the tag, branch name, or something else


### PR DESCRIPTION
all of the ldmx-sw submodules are now being treated as separate projects
and so we only care about hte specific version of the submodule and not
the specific versions of any of the submodule's submodules.
