### PR TITLE
Fix deprecated functions in ONNX and boost + type conversion for ConfigurePythonTest

### DIFF
--- a/DetDescr/src/DetDescr/DetectorIDBindings.cxx
+++ b/DetDescr/src/DetDescr/DetectorIDBindings.cxx
@@ -1,4 +1,6 @@
 #if DETECTORID_BINDINGS_ENABLED
+// This we may be able to remove after boost update
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/python.hpp>
 
 #include "DetDescr/DetectorID.h"

--- a/Framework/include/Framework/ConfigurePython.h
+++ b/Framework/include/Framework/ConfigurePython.h
@@ -54,7 +54,7 @@ class ConfigurePython {
    *
    * Does nothing at the moment.
    */
-  ~ConfigurePython() {}
+  ~ConfigurePython() = default;
 
   /**
    * Create a process object based on the python file information

--- a/Framework/test/ConfigurePythonTest.cxx
+++ b/Framework/test/ConfigurePythonTest.cxx
@@ -163,7 +163,7 @@ TEST_CASE("Configure Python Test", "[Framework][functionality]") {
   // was set correctly.
   auto correct_log_freq{9000};
   SECTION("Single argument to python script") {
-    args[0] = "9000";
+    args[0] = (char *)"9000";
     framework::ConfigurePython cfg(config_file_name_arg, args, 1);
     p = cfg.makeProcess();
 

--- a/Tools/src/Tools/ONNXRuntime.cxx
+++ b/Tools/src/Tools/ONNXRuntime.cxx
@@ -72,7 +72,9 @@ ONNXRuntime::ONNXRuntime(const std::string& model_path,
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     size_t num_dims = tensor_info.GetDimensionsCount();
     input_node_dims_[input_name].resize(num_dims);
-    tensor_info.GetDimensions(input_node_dims_[input_name].data(), num_dims);
+    const auto input_shape = tensor_info.GetShape();
+    std::copy(input_shape.begin(), input_shape.end(),
+              input_node_dims_[input_name].begin());
 
     // set the batch size to 1 by default
     input_node_dims_[input_name].at(0) = 1;
@@ -94,7 +96,9 @@ ONNXRuntime::ONNXRuntime(const std::string& model_path,
     auto tensor_info = type_info.GetTensorTypeAndShapeInfo();
     size_t num_dims = tensor_info.GetDimensionsCount();
     output_node_dims_[output_name].resize(num_dims);
-    tensor_info.GetDimensions(output_node_dims_[output_name].data(), num_dims);
+    const auto output_shape = tensor_info.GetShape();
+    std::copy(output_shape.begin(), output_shape.end(),
+              output_node_dims_[output_name].begin());
 
     // the 0th dim depends on the batch size
     output_node_dims_[output_name].at(0) = -1;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1208


## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
