### PR TITLE
copy in positron-deduced positions and directions from the TS scoring planes

### DIFF
--- a/SimCore/exampleConfigs/backwards-positron.py
+++ b/SimCore/exampleConfigs/backwards-positron.py
@@ -1,0 +1,40 @@
+"""fire a positron with the input energy backwards from the target
+
+This is helpful for the situation where the beam spot needs to be
+determined. Instead of doing complicated math to figure out how much
+an electron of a given energy curves, let's just use a positron and Geant4
+to do the math for us!
+
+Note
+----
+This only functions well if the detector components upstream of the target
+are not included in the simulation. (If they are, then the positron interacts
+with them easily spoiling the measurement.) This can be done by commenting
+out their inclusion in the detector.gdml with `<!-- ... -->`.
+"""
+
+from LDMX.Framework import ldmxcfg
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--n-events', type=int, default=10, help='number of events to simulate')
+parser.add_argument('--beam', type=float, required=True, help='beam energy in GeV')
+
+args = parser.parse_args()
+
+p = ldmxcfg.Process("beam")
+p.maxEvents = args.n_events
+p.termLogLevel = 1
+p.run = 1
+p.outputFiles = [ f'backwards_positron_beam_{args.beam}.root' ]
+
+from LDMX.SimCore import generators
+from LDMX.SimCore import simulator
+import LDMX.Ecal.EcalGeometry
+import LDMX.Hcal.HcalGeometry
+
+mySim = simulator.simulator( "mySim" )
+mySim.setDetector( 'ldmx-det-v14' , True )
+mySim.generators = [ generators.single_backwards_positron(args.beam) ]
+mySim.description = 'Basic test Simulation'
+p.sequence = [ mySim ]

--- a/SimCore/python/generators.py
+++ b/SimCore/python/generators.py
@@ -246,8 +246,8 @@ def single_4gev_e_upstream_tagger() :
     upstream of the entire detector apparatus.
     """
     return _single_e_upstream_tagger(
-        [ -600.8976671223825, 0.0, -6000.0 ],
-        [ 434.54301089006407, 0.0, 3976.8404804302777],
+        [ -43.56748, 0.0, -883.0 ],
+        [ 388.5554, 0.0, 3981.5967 ],
         4.0
     )
 
@@ -286,8 +286,8 @@ def single_1pt2gev_e_upstream_tagger():
     upstream of the entire detector apparatus.
     """
     return _single_e_upstream_tagger(
-        [ -2083.3707473241993, 0.0, -6000.0 ],
-        [ 425.132266424426, 0.0, 1122.7149711218378],
+        [ -148.95303, 0.0, -883.0 ],
+        [ 388.57147, 0.0, 1135.8867 ],
         1.2
     )
 
@@ -305,8 +305,8 @@ def single_8gev_e_upstream_tagger():
     upstream of the entire detector apparatus.
     """
     return _single_e_upstream_tagger(
-        [ -299.2386690686212, 0.0, -6000.0 ],
-        [ 434.59663056485   , 0.0, 7988.698356992288],
+        [ -21.745876, 0.0, -883.0 ],
+        [ 388.55154, 0.0, 7991.0703],
         8.0
     )
 

--- a/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TruthSeedProcessor.cxx
@@ -61,11 +61,11 @@ void TruthSeedProcessor::configure(framework::config::Parameters& parameters) {
   // In tracking frame: where do these numbers come from?
   // These numbers come from approximating the path of the beam up
   // until it is about to enter the first detector volume (TriggerPad1).
-  // In detector coordinates, (x,y,z) = (-44,0,-880) is _roughly_
+  // In detector coordinates, (x,y,z) = (-21.7, -883) is
   // where the beam arrives (if no smearing is applied) and we simply
   // reorder these values so that they are in tracking coordinates.
   beamOrigin_ = parameters.getParameter<std::vector<double>>(
-      "beamOrigin", {-880.1, -44., 0.});
+      "beamOrigin", {-883.0, -21.745876, 0.0});
 
   // Skip the tagger or recoil trackers if wanted
   skip_tagger_ = parameters.getParameter<bool>("skip_tagger", false);


### PR DESCRIPTION
moving the z-position up to the upstream face of the furthest upstream trigger pad so that it is more feasibly understood by the Tracking algorithms


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1395 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
![position-and-momentum-trunk-1395-comp](https://github.com/user-attachments/assets/db6cba09-7568-4eaa-bac2-48181b947c03)

The tar-ball below has the configs I used and the python scripts I used to extract the beam positions and make the plot above.
[1395-testing.tar.gz](https://github.com/user-attachments/files/16676057/1395-testing.tar.gz)
