### PR TITLE
drop ecal_pn validation config back down to debug

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -23,11 +23,7 @@ p.run = int(os.environ['LDMX_RUN_NUMBER'])
 
 p.histogramFile = f'hist.root'
 p.outputFiles = [f'events.root']
-
-# The Tracking modules produce a lot of helpful messages
-# but (at the debug level) is too much for commiting the gold log
-# into the git working tree on GitHub
-p.termLogLevel = 1
+p.termLogLevel = 0
 
 # Load the tracking module
 from LDMX.Tracking import tracking


### PR DESCRIPTION
With the patching of the Tracking truth seed location, it appears like Tracking is not producing as many messages so we can hopefully drop the log level back down to debug and the log will stay below file size limit imposed by GitHub.