### PR TITLE
Including ratio subplot within differ when comparing

### DIFF
--- a/Validation/src/Validation/_differ.py
+++ b/Validation/src/Validation/_differ.py
@@ -137,12 +137,13 @@ class Differ :
         denominator, bins, _denominator_art = raw_histograms[0]
         bin_centers = (bins[1:]+bins[:-1])/2
         for values, _bins, art in raw_histograms[1:]:
-            ratio_ax.plot(
+            ratio_ax.scatter(
                 bin_centers,
                 values/denominator,
                 color = art[0].get_edgecolor()
             )
-        
+
+        ratio_ax.set_ylabel('Ratio')
         ratio_ax.set_xlabel(xlabel)
         if tick_labels is not None:
             ratio_ax.set_xticks((bins[1:]+bins[:-1])/2)


### PR DESCRIPTION
The denominator for the ratio is whatever histogram is first in the list. This could lead to problems in two situations:
1. The first file in found in the directory (or given on the command line) does not have the histogram requested and so the denominator just becomes the next histogram that is found.
2. There are zero values in the denominator. This will lead to annoying divide-by-zero warnings which we can silence if there are a lot of them.

We try to inherit the color from the histogram in the ratio plot so that the legend applies. This may fail if I misunderstood the return type of the matplotlib `hist` function.

If we want to include error bars, we should probably switch to using [`hist` ](https://hist.readthedocs.io/en/latest/) directly since they have better error bar handling and have ironed out a lot of the common bugs. `uproot` can cast ROOT histograms into `hist.Hist` objects so the loading of already filled histograms is as seamless as it is now.

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1382 .

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
