### PR TITLE
Fix the precision of the tracking performance printouts

### DIFF
--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -633,19 +633,26 @@ void CKFProcessor::onProcessStart() {
 void CKFProcessor::onProcessEnd() {
   ldmx_log(info) << "found " << ntracks_ << " tracks  / " << nseeds_
                  << " nseeds";
-  ldmx_log(info) << "AVG Time/Event: " << processing_time_ / nevents_ << " ms";
+  ldmx_log(info) << "AVG Time/Event: " << std::fixed << std::setprecision(4)
+                 << processing_time_ / nevents_ << " ms";
   ldmx_log(info) << "Breakdown::";
-  ldmx_log(info) << "setup       Avg Time/Event = "
-                 << profiling_map_["setup"] / nevents_ << " ms";
-  ldmx_log(info) << "hits        Avg Time/Event = "
-                 << profiling_map_["hits"] / nevents_ << " ms";
-  ldmx_log(info) << "seeds       Avg Time/Event = "
-                 << profiling_map_["seeds"] / nevents_ << " ms";
-  ldmx_log(info) << "cf_setup    Avg Time/Event = "
+  ldmx_log(info) << "setup       Avg Time/Event = " << std::fixed
+                 << std::setprecision(4) << profiling_map_["setup"] / nevents_
+                 << " ms";
+  ldmx_log(info) << "hits        Avg Time/Event = " << std::fixed
+                 << std::setprecision(4) << profiling_map_["hits"] / nevents_
+                 << " ms";
+  ldmx_log(info) << "seeds       Avg Time/Event = " << std::fixed
+                 << std::setprecision(4) << profiling_map_["seeds"] / nevents_
+                 << " ms";
+  ldmx_log(info) << "cf_setup    Avg Time/Event = " << std::fixed
+                 << std::setprecision(4)
                  << profiling_map_["ckf_setup"] / nevents_ << " ms";
-  ldmx_log(info) << "ckf_run     Avg Time/Event = "
-                 << profiling_map_["ckf_run"] / nevents_ << " ms";
-  ldmx_log(info) << "result_loop Avg Time/Event = "
+  ldmx_log(info) << "ckf_run     Avg Time/Event = " << std::fixed
+                 << std::setprecision(4) << profiling_map_["ckf_run"] / nevents_
+                 << " ms";
+  ldmx_log(info) << "result_loop Avg Time/Event = " << std::fixed
+                 << std::setprecision(4)
                  << profiling_map_["result_loop"] / nevents_ << " ms";
 }
 

--- a/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -421,7 +421,8 @@ void SeedFinderProcessor::onProcessEnd() {
   // outputFile_->cd();
   // outputTree_->Write();
   // outputFile_->Close();
-  ldmx_log(info) << "AVG Time/Event: " << processing_time_ / nevents_ << " ms";
+  ldmx_log(info) << "AVG Time/Event: " << std::fixed << std::setprecision(4)
+                 << processing_time_ / nevents_ << " ms";
   ldmx_log(info) << "Total Seeds/Events: " << ntracks_ << "/" << nevents_;
   ldmx_log(info) << "Seeds discarded due to multiple hits on layers "
                  << ndoubles_;

--- a/Tracking/src/Tracking/Reco/VertexProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/VertexProcessor.cxx
@@ -190,7 +190,8 @@ void VertexProcessor::onProcessEnd() {
   outfile->Close();
   delete outfile;
 
-  ldmx_log(info) << "AVG Time/Event: " << processing_time_ / nevents_ << " ms";
+  ldmx_log(info) << "AVG Time/Event: " << std::fixed << std::setprecision(4)
+                 << processing_time_ / nevents_ << " ms";
 }
 
 }  // namespace reco


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1402
with the hope that now the logs will be showing no character count differences, 
given that this PR fixes the precision at 4

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.