### PR TITLE
Bump up class versions for HcalHit, TestBeamHit, TrigScintHit

### DIFF
--- a/Hcal/include/Hcal/Event/HcalHit.h
+++ b/Hcal/include/Hcal/Event/HcalHit.h
@@ -226,7 +226,7 @@ class HcalHit : public ldmx::CalorimeterHit {
   /**
    * The ROOT class definition.
    */
-  ClassDef(HcalHit, 2);
+  ClassDef(HcalHit, 3);
 };
 }  // namespace ldmx
 

--- a/TrigScint/include/TrigScint/Event/TestBeamHit.h
+++ b/TrigScint/include/TrigScint/Event/TestBeamHit.h
@@ -200,7 +200,7 @@ class TestBeamHit : public ldmx::TrigScintHit {
   property
   */
 
-  ClassDef(TestBeamHit, 2);
+  ClassDef(TestBeamHit, 3);
 
 };  // TestBeamHit
 

--- a/TrigScint/include/TrigScint/Event/TrigScintHit.h
+++ b/TrigScint/include/TrigScint/Event/TrigScintHit.h
@@ -93,7 +93,7 @@ class TrigScintHit : public ldmx::HcalHit {
   float beamEfrac_{0};
 
   float pe_{0};
-  ClassDef(TrigScintHit, 2);
+  ClassDef(TrigScintHit, 3);
 
 };  // TrigScintHit
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1427

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I can now run
```
ldmx recompFire TrigScint/exampleConfigs/runQIEDecode.py /fs/ddn/sdf/group/ldmx/data/TS-data/test_stand_data/rootFiles/unpacked_ldmx_captan_out_09-04-2022_09-36-04__75_reformat_30timeSamplesFrom0_linearize_hits_clusters.root out.root raw 1 TrigScint/data/channelMap_LYSOback_plasticFront_12-to-16channels_rotated180.txt
```
w/o any issues
