### PR TITLE
Move logger open into Process constructor

### DIFF
--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -46,6 +46,12 @@ Process::Process(const framework::config::Parameters &configuration)
 
   eventHeader_ = 0;
 
+  // set up the logging for this run
+  logging::open(logging::convertLevel(termLevelInt_),
+                logging::convertLevel(fileLevelInt_),
+                logFileName_  // if this is empty string, no file is logged to
+  );
+
   auto run{configuration.getParameter<int>("run", -1)};
   if (run > 0) runForGeneration_ = run;
 
@@ -136,11 +142,6 @@ Process::~Process() {
 
 void Process::run() {
   if (performance_) performance_->absolute_start();
-  // set up the logging for this run
-  logging::open(logging::convertLevel(termLevelInt_),
-                logging::convertLevel(fileLevelInt_),
-                logFileName_  // if this is empty string, no file is logged to
-  );
 
   // Counter to keep track of the number of events that have been
   // procesed


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Part of https://github.com/LDMX-Software/ldmx-sw/issues/922
Specifically https://github.com/LDMX-Software/ldmx-sw/issues/922#issuecomment-2318946560


## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

This will get rid of the char difference issue are seeing in the logs.
```
[2024-09-06 12:12:33.350429] [0x00007fe2c6ce6bc0] [info]    In TrigScintDQM::configure, got parameters TriggerPad1SimHits and pad1
[2024-09-06 12:12:33.350453] [0x00007fe2c6ce6bc0] [info]    In TrigScintDQM::configure, got parameters TriggerPad2SimHits and pad2
[2024-09-06 12:12:33.350463] [0x00007fe2c6ce6bc0] [info]    In TrigScintDQM::configure, got parameters TriggerPad3SimHits and pad3
[2024-09-06 12:12:33.350474] [0x00007fe2c6ce6bc0] [info]    In TrigScintHitDQM::configure, got parameters trigScintDigisPad1 and pad1
[2024-09-06 12:12:33.350483] [0x00007fe2c6ce6bc0] [info]    In TrigScintHitDQM::configure, got parameters trigScintDigisPad2 and pad2
[2024-09-06 12:12:33.350492] [0x00007fe2c6ce6bc0] [info]    In TrigScintHitDQM::configure, got parameters trigScintDigisPad3 and pad3
[2024-09-06 12:12:33.350504] [0x00007fe2c6ce6bc0] [info]    In TrigScintClusterDQM::configure, got parameters TriggerPad1Clusters, pad = pad1, pass = 
[2024-09-06 12:12:33.350514] [0x00007fe2c6ce6bc0] [info]    In TrigScintClusterDQM::configure, got parameters TriggerPad2Clusters, pad = pad2, pass = 
[2024-09-06 12:12:33.350523] [0x00007fe2c6ce6bc0] [info]    In TrigScintClusterDQM::configure, got parameters TriggerPad3Clusters, pad = pad3, pass = 
[2024-09-06 12:12:33.350534] [0x00007fe2c6ce6bc0] [info]    In TrigScintTrackDQM::configure, got parameters TriggerPadTracks and 
```
is now
```
 [ TrigScintClusterPad1 ] 1 : In TrigScintClusterDQM::configure, got parameters TriggerPad1Clusters, pad = pad1, pass = 
 [ TrigScintClusterPad2 ] 1 : In TrigScintClusterDQM::configure, got parameters TriggerPad2Clusters, pad = pad2, pass = 
 [ TrigScintClusterPad3 ] 1 : In TrigScintClusterDQM::configure, got parameters TriggerPad3Clusters, pad = pad3, pass = 
 [ TrigScintTracks ] 1 : In TrigScintTrackDQM::configure, got parameters TriggerPadTracks and 
```
and also if I set the log level to 10 it's gone now (as it should)