### PR TITLE
Trailing ldmx command refs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
 get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
 if ("${srcdir}" STREQUAL "${bindir}")
   message(FATAL_ERROR "ldmx-sw does not support in-source builds.
-  Call 'ldmx cmake ..' from within a 'build/' subdirectory or
-  Tell cmake to use a different build directory with 'ldmx cmake -B build -S .'")
+  Call 'denv cmake ..' from within a 'build/' subdirectory or
+  Tell cmake to use a different build directory with 'denv cmake -B build -S .'
+  'just configure' and 'just build' will do the necessary directory movement for you as well.")
 endif()
 
 # Set the project name

--- a/DetDescr/README.md
+++ b/DetDescr/README.md
@@ -7,8 +7,11 @@
 ## Building DetDescr with DetectorID binding support 
 The DetDescr repository can optionally be built to enable Python bindings to most of the functionalities of the various DetectorID classes. This requires Boost.Python to be installed, which is part of the [the LDMX-software container distribution](https://github.com/LDMX-Software/docker) since [version 3.3](https://github.com/LDMX-Software/docker/releases/tag/v3.3). Since older versions of the container environment don't come with this library, the feature needs to be explicitly enabled as a CMake option. 
 
-``` sh
-ldmx cmake .. -DBUILD_DETECTORID_BINDINGS=ON
+```sh
+cd build
+denv cmake .. -DBUILD_DETECTORID_BINDINGS=ON
+# OR
+just configure -DBUILD_DETECTORID_BINDINGS=ON
 ```
 
 **Note:** Due to a bug, this option currently does not work if you built LDMX-sw with Sanitizer support (one of the `-DENABLE_SANITIZER_X=ON` settings). If your Python session crashes after trying to import the `libDetDescr`, try recompiling LDMX-sw with Sanitizer support disabled.

--- a/Detectors/data/README.md
+++ b/Detectors/data/README.md
@@ -40,5 +40,5 @@ Previously used geometries can be found under the `archived` directory. In case 
 ```
 cd ldmx-sw/Detectors/data
 tar -xzf archived/<detector>.tar.gz
-ldmx compile # even if you've already done this before!
+just configure build # even if you've already done this before!
 ```


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
No issues, I just noticed that there were some leftover references to the `ldmx` command in a few places.
I have not replaced every reference to `ldmx`, just ones I think are okay to be replaced.