### PR TITLE
logging fix and the long-awaited setting log-level by processor

### DIFF
--- a/Framework/include/Framework/Logger.h
+++ b/Framework/include/Framework/Logger.h
@@ -22,6 +22,8 @@
 #include <boost/log/sources/record_ostream.hpp>
 #include <boost/log/utility/setup/file.hpp>
 
+#include "Framework/Configure/Parameters.h"
+
 namespace framework {
 
 namespace logging {
@@ -36,17 +38,6 @@ enum level {
   error,      ///> 3
   fatal       ///> 4
 };
-
-/**
- * Convert an integer to the severity level enum
- *
- * Any integer below zero will be set to 0 (debug),
- * and any integer above four will be set to 4 (fatal).
- *
- * @param[in] iLvl integer level to be converted
- * @return converted enum level
- */
-level convertLevel(int& iLvl);
 
 /**
  * Short names for boost namespaces
@@ -79,17 +70,12 @@ logger makeLogger(const std::string& name);
  * This function setups up the terminal and file sinks.
  * Sets their format and filtering level for this run.
  *
- * @note Will not setup printing log messages to file if fileName is empty
+ * @note Will not setup printing log messages to file if filePath is empty
  * string.
  *
- * @param termLevel minimum level to print to terminal (everything above it is
- * also printed)
- * @param fileLevel minimum level to print to file log (everything above it is
- * also printed)
- * @param fileName name of file to print log to
+ * @param p parameters to configure the logging with
  */
-void open(const level termLevel, const level fileLevel,
-          const std::string& fileName);
+void open(const framework::config::Parameters& p);
 
 /**
  * Close up the logging

--- a/Framework/include/Framework/Logger.h
+++ b/Framework/include/Framework/Logger.h
@@ -49,26 +49,6 @@ enum level {
 level convertLevel(int& iLvl);
 
 /**
- * Severity level to human readable name map
- *
- * Human readable names are the same width in characters
- *
- * We could also add terminal color here if we wanted.
- *
- * @note Not in use right now. boost's extract returns some
- * weird templated type that cannot be implicitly converted to level.
- *
- * We _can_ stream the output to a string stream and use
- * that as the key in our map, but that is lame.
- */
-const std::unordered_map<level, std::string> humanReadableLevel = {
-    {debug, "debug"},
-    {info, "info "},
-    {warn, "warn "},
-    {error, "error"},
-    {fatal, "fatal"}};
-
-/**
  * Short names for boost namespaces
  */
 namespace log = boost::log;
@@ -115,6 +95,40 @@ void open(const level termLevel, const level fileLevel,
  * Close up the logging
  */
 void close();
+
+/**
+ * Our logging formatter
+ *
+ * We use a singleton formatter so that it can hold the current event index
+ * as an attribute and include it within the logs. This is easier than
+ * attempting to update the event number in all of the different logging
+ * sources floating around ldmx-sw.
+ */
+class Formatter {
+  int event_number_{0};
+  Formatter() = default;
+ public:
+  /// delete the copy constructor
+  Formatter(Formatter const&) = delete;
+
+  /// delete the assignment operator
+  void operator=(Formatter const&) = delete;
+
+  /// get reference to the current single Formatter
+  static Formatter& get();
+
+  /// set the event number in the current Formatter
+  static void set(int n);
+
+  /**
+   * format the passed record view into the output stream
+   *
+   * The format is 
+   *
+   *  [ channel ] severity : message
+   */
+  void operator()(const log::record_view &view, log::formatting_ostream &os);
+};
 
 }  // namespace logging
 

--- a/Framework/include/Framework/Logger.h
+++ b/Framework/include/Framework/Logger.h
@@ -93,6 +93,7 @@ void close();
 class Formatter {
   int event_number_{0};
   Formatter() = default;
+
  public:
   /// delete the copy constructor
   Formatter(Formatter const&) = delete;
@@ -109,11 +110,11 @@ class Formatter {
   /**
    * format the passed record view into the output stream
    *
-   * The format is 
+   * The format is
    *
    *  [ channel ] severity : message
    */
-  void operator()(const log::record_view &view, log::formatting_ostream &os);
+  void operator()(const log::record_view& view, log::formatting_ostream& os);
 };
 
 }  // namespace logging

--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -136,14 +136,15 @@ class Process {
    * Process the input event through the sequence
    * of processors
    *
-   * The input counter for number of events processed is
+   * The input counters (for events and tries) are
    * only used to print the status.
    *
    * @param[in] n counter for number of events processed
+   * @param[in] n_tries counter for number of tries on current event
    * @param[in,out] event reference to event we are going to process
    * @returns true if event was full processed (false if aborted)
    */
-  bool process(int n, Event &event) const;
+  bool process(int n, int n_tries, Event &event) const;
 
   /**
    * Run through the processors and let them know

--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -181,15 +181,6 @@ class Process {
   /** The frequency with which event info is printed. */
   int logFrequency_;
 
-  /** Integer form of logging level to print to terminal */
-  int termLevelInt_;
-
-  /** Integer form of logging level to print to file */
-  int fileLevelInt_;
-
-  /** Name of file to print logging to */
-  std::string logFileName_;
-
   /** Maximum number of attempts to make before giving up on an event */
   int maxTries_;
 

--- a/Framework/python/ldmxcfg.py
+++ b/Framework/python/ldmxcfg.py
@@ -581,9 +581,6 @@ class Process:
         self.skimRules=[]
         self.logFrequency=-1
         self.logger = Logger()
-        self.termLogLevel=2 #warnings and above
-        self.fileLogLevel=0 #print all messages
-        self.logFileName='' #won't setup log file
         self.compressionSetting=9
         self.histogramFile=''
         self.conditionsGlobalTag='Default'
@@ -604,6 +601,15 @@ class Process:
         if key in logger_remap:
             setattr(self.logger, logger_remap[key], val)
             return
+        elif key == 'logFrequency' and val > 0:
+            # make sure the Process channel is lowered to info
+            # later log rules override earlier ones so we put this
+            # at the front of the list so the user could have overwritten
+            # this if need be
+            # 'Process' needs to match the name given in enableLogging
+            # in include/Framework/Process.h
+            self.logger.logRules.insert(0, _LogRule('Process', level=1))
+            # fall through to set the key=val
         
         super().__setattr__(key, val)
 

--- a/Framework/src/Framework/Logger.cxx
+++ b/Framework/src/Framework/Logger.cxx
@@ -154,21 +154,19 @@ void Formatter::operator()(const log::record_view& view,
   os << "[ " << log::extract<std::string>("Channel", view) << " ] "
      << event_number_ << " ";
   /**
-   * We _copy_ the value out of the log into our own type
+   * We de-reference the value out of the log into our own type
    * so that we can compare and convert it into a string.
-   * I expect this copying to be okay since its just a
-   * enum (int equivalent), but its good to be clear
    */
-  level msg_level = *log::extract<level>("Severity", view);
+  const level& msg_level = *log::extract<level>("Severity", view);
   switch (msg_level) {
     case level::debug:
       os << "debug";
       break;
     case level::info:
-      os << "info ";
+      os << " info";
       break;
     case level::warn:
-      os << "warn ";
+      os << " warn";
       break;
     case level::error:
       os << "error";
@@ -177,6 +175,12 @@ void Formatter::operator()(const log::record_view& view,
       os << "fatal";
       break;
     default:
+      // this should never happen since the loggers created
+      // with makeLogger use the level enum and thus check
+      // at compile time that the given level is an good option.
+      // That being said, we leave this in case someone creates
+      // their own logger circumventing makeLogger for whatever
+      // reason and changes the enum defining the severity.
       os << "?????";
       break;
   }

--- a/Framework/src/Framework/Logger.cxx
+++ b/Framework/src/Framework/Logger.cxx
@@ -13,7 +13,16 @@ namespace framework {
 
 namespace logging {
 
-level convertLevel(int &iLvl) {
+/**
+ * Convert an integer to the severity level enum
+ *
+ * Any integer below zero will be set to 0 (debug),
+ * and any integer above four will be set to 4 (fatal).
+ *
+ * @param[in] iLvl integer level to be converted
+ * @return converted enum level
+ */
+level convertLevel(int iLvl) {
   if (iLvl < 0)
     iLvl = 0;
   else if (iLvl > 4)
@@ -26,11 +35,14 @@ logger makeLogger(const std::string &name) {
   return boost::move(lg);
 }
 
-void open(const level termLevel, const level fileLevel,
-          const std::string &fileName) {
+void open(const framework::config::Parameters& p) {
   // some helpful types
   typedef sinks::text_ostream_backend ourSinkBack_t;
   typedef sinks::synchronous_sink<ourSinkBack_t> ourSinkFront_t;
+
+  level termLevel{convertLevel(p.getParameter<int>("termLevel", 4))};
+  level fileLevel{convertLevel(p.getParameter<int>("fileLevel", 0))};
+  std::string filePath{p.getParameter<std::string>("filePath", "")};
 
   // allow our logs to access common attributes, the ones availabe are
   //  "LineID"    : counter increments for each record being made (terminal or
@@ -43,11 +55,11 @@ void open(const level termLevel, const level fileLevel,
   boost::shared_ptr<log::core> core = log::core::get();
 
   // file sink is optional
-  //  don't even make it if no fileName is provided
-  if (not fileName.empty()) {
+  //  don't even make it if no filePath is provided
+  if (not filePath.empty()) {
     boost::shared_ptr<ourSinkBack_t> fileBack =
         boost::make_shared<ourSinkBack_t>();
-    fileBack->add_stream(boost::make_shared<std::ofstream>(fileName));
+    fileBack->add_stream(boost::make_shared<std::ofstream>(filePath));
 
     boost::shared_ptr<ourSinkFront_t> fileSink =
         boost::make_shared<ourSinkFront_t>(fileBack);

--- a/Framework/src/Framework/Logger.cxx
+++ b/Framework/src/Framework/Logger.cxx
@@ -30,11 +30,10 @@ level convertLevel(int iLvl) {
   return level(iLvl);
 }
 
-logger makeLogger(const std::string &name) {
+logger makeLogger(const std::string& name) {
   logger lg(log::keywords::channel = name);  // already has severity built in
   return boost::move(lg);
 }
-
 
 /**
  * Our filter implementation aligning with Boost.Log
@@ -47,9 +46,10 @@ logger makeLogger(const std::string &name) {
 class Filter {
   level fallback_level_;
   std::unordered_map<std::string, level> custom_levels_;
+
  public:
   Filter(level fallback, std::unordered_map<std::string, level> custom)
-    : fallback_level_{fallback}, custom_levels_{custom} {}
+      : fallback_level_{fallback}, custom_levels_{custom} {}
   Filter(level fallback) : Filter(fallback, {}) {}
   bool operator()(log::attribute_value_set const& attrs) {
     const std::string& channel{*log::extract<std::string>(attrs["Channel"])};
@@ -62,7 +62,6 @@ class Filter {
   }
 };
 
-
 void open(const framework::config::Parameters& p) {
   // some helpful types
   typedef sinks::text_ostream_backend ourSinkBack_t;
@@ -72,12 +71,13 @@ void open(const framework::config::Parameters& p) {
   std::string filePath{p.getParameter<std::string>("filePath", "")};
 
   level termLevel{convertLevel(p.getParameter<int>("termLevel", 4))};
-  const auto& logRules{p.getParameter<std::vector<framework::config::Parameters>>(
-      "logRules", {})};
+  const auto& logRules{
+      p.getParameter<std::vector<framework::config::Parameters>>("logRules",
+                                                                 {})};
   std::unordered_map<std::string, level> custom_levels;
   for (const auto& logRule : logRules) {
-    custom_levels[logRule.getParameter<std::string>("name")] = 
-      convertLevel(logRule.getParameter<int>("level"));
+    custom_levels[logRule.getParameter<std::string>("name")] =
+        convertLevel(logRule.getParameter<int>("level"));
   }
 
   // allow our logs to access common attributes, the ones availabe are
@@ -102,9 +102,10 @@ void open(const framework::config::Parameters& p) {
 
     // this is where the logging level is set
     fileSink->set_filter(Filter(fileLevel, custom_levels));
-    fileSink->set_formatter([](const log::record_view &view, log::formatting_ostream &os) {
-        Formatter::get()(view, os);
-    });
+    fileSink->set_formatter(
+        [](const log::record_view& view, log::formatting_ostream& os) {
+          Formatter::get()(view, os);
+        });
     core->add_sink(fileSink);
   }  // file set to pass something
 
@@ -124,9 +125,10 @@ void open(const framework::config::Parameters& p) {
   // translate integer level to enum
   termSink->set_filter(Filter(termLevel, custom_levels));
   // need to wrap formatter in lambda to enforce singleton formatter
-  termSink->set_formatter([](const log::record_view &view, log::formatting_ostream &os) {
-      Formatter::get()(view, os);
-  });
+  termSink->set_formatter(
+      [](const log::record_view& view, log::formatting_ostream& os) {
+        Formatter::get()(view, os);
+      });
   core->add_sink(termSink);
 
   return;
@@ -145,11 +147,10 @@ Formatter& Formatter::get() {
   return the_formatter;
 }
 
-void Formatter::set(int n) {
-  Formatter::get().event_number_ = n;
-}
+void Formatter::set(int n) { Formatter::get().event_number_ = n; }
 
-void Formatter::operator()(const log::record_view &view, log::formatting_ostream &os) {
+void Formatter::operator()(const log::record_view& view,
+                           log::formatting_ostream& os) {
   os << "[ " << log::extract<std::string>("Channel", view) << " ] "
      << event_number_ << " ";
   /**

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -225,6 +225,7 @@ void Process::run() {
 
       // reset the storage controller state
       storageController_.resetEventState();
+      logging::Formatter::set(theEvent.getEventNumber());
 
       bool completed = process(n_events_processed, theEvent);
 
@@ -339,6 +340,7 @@ void Process::run() {
              (eventLimit_ < 0 || (n_events_processed) < eventLimit_)) {
         // clean up for storage control calculation
         storageController_.resetEventState();
+        logging::Formatter::set(theEvent.getEventNumber());
 
         // notify for new run if necessary
         if (theEvent.getEventHeader().getRun() != wasRun) {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -26,7 +26,6 @@ Process::Process(const framework::config::Parameters &configuration)
 
   passname_ = configuration.getParameter<std::string>("passName", "");
   histoFilename_ = configuration.getParameter<std::string>("histogramFile", "");
-  logFileName_ = configuration.getParameter<std::string>("logFileName", "");
 
   maxTries_ = configuration.getParameter<int>("maxTriesPerEvent", 1);
   eventLimit_ = configuration.getParameter<int>("maxEvents", -1);
@@ -34,8 +33,6 @@ Process::Process(const framework::config::Parameters &configuration)
   logFrequency_ = configuration.getParameter<int>("logFrequency", -1);
   compressionSetting_ =
       configuration.getParameter<int>("compressionSetting", 9);
-  termLevelInt_ = configuration.getParameter<int>("termLogLevel", 2);
-  fileLevelInt_ = configuration.getParameter<int>("fileLogLevel", 0);
   skipCorruptedInputFiles_ =
       configuration.getParameter<bool>("skipCorruptedInputFiles", false);
 
@@ -49,10 +46,7 @@ Process::Process(const framework::config::Parameters &configuration)
   eventHeader_ = 0;
 
   // set up the logging for this run
-  logging::open(logging::convertLevel(termLevelInt_),
-                logging::convertLevel(fileLevelInt_),
-                logFileName_  // if this is empty string, no file is logged to
-  );
+  logging::open(configuration.getParameter<framework::config::Parameters>("logger", {}));
 
   auto run{configuration.getParameter<int>("run", -1)};
   if (run > 0) runForGeneration_ = run;

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -221,7 +221,7 @@ void Process::run() {
       storageController_.resetEventState();
       logging::Formatter::set(theEvent.getEventNumber());
 
-      bool completed = process(n_events_processed, theEvent);
+      bool completed = process(n_events_processed, numTries, theEvent);
 
       outFile.nextEvent(storageController_.keepEvent(completed));
 
@@ -352,7 +352,7 @@ void Process::run() {
           }
         }
 
-        event_completed = process(n_events_processed, theEvent);
+        event_completed = process(n_events_processed, 1, theEvent);
 
         if (event_completed) NtupleManager::getInstance().fill();
         NtupleManager::getInstance().clear();
@@ -480,8 +480,10 @@ void Process::newRun(ldmx::RunHeader &header) {
   if (performance_) performance_->stop(performance::Callback::onNewRun, 0);
 }
 
-bool Process::process(int n, Event &event) const {
-  if ((logFrequency_ != -1) && ((n + 1) % logFrequency_ == 0)) {
+bool Process::process(int n, int n_try, Event &event) const {
+  if ((logFrequency_ != -1) && ((n + 1) % logFrequency_ == 0) && (n_try < 2)) {
+    // only printout event counter if we've enabled log frequency, the event
+    // matches the frequency and we are on the first try
     TTimeStamp t;
     ldmx_log(info) << "Processing " << n + 1 << " Run "
                    << event.getEventHeader().getRun() << " Event "

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -46,7 +46,8 @@ Process::Process(const framework::config::Parameters &configuration)
   eventHeader_ = 0;
 
   // set up the logging for this run
-  logging::open(configuration.getParameter<framework::config::Parameters>("logger", {}));
+  logging::open(
+      configuration.getParameter<framework::config::Parameters>("logger", {}));
 
   auto run{configuration.getParameter<int>("run", -1)};
   if (run > 0) runForGeneration_ = run;


### PR DESCRIPTION
These developments do the following
- interpret the message's logging level into a human readable string for easier parsing
- add event number to logging messages via a custom Formatter which resolves #1301 
- allow logging levels to differ between different channels by implementing a custom Filter which resolves #922 
- update the configuration so that the logging has its own configuration class, keeping its parameters organized and separate from the Process (the current syntax is supported by overriding `__getattr__` so this doesn't require folks to update their configs).
- only printout an event status timestamp on the first try of every event which resolves #1455  

to lower the level for everyone
```python
p.logger.termLevel = 0
# OR, with legacy syntax
p.termLogLevel = 0
```
to debug a specific processor
```python
p.logger.debug(my_processor)
# OR
p.logger.debug("MyProcessorName")
```
to silence a specific processor
```python
p.logger.silence(my_processor)
# OR
p.logger.silence("MyProcessorName")
```
or something in between
```python
p.logger.custom(my_processor, level = 1)
```

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

These developments were tested with a simple standalong processor and config that I've copied here for completeness.

```python
from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('log')
p.sequence = [ldmxcfg.Producer.from_file('EgLog.cxx')]
p.outputFiles = [ '/dev/null' ]
p.maxEvents = 5
p.logFrequency = 1
p.termLogLevel = 0
p.logger.debug(p.sequence[0])
```

```cpp
#include "Framework/EventProcessor.h"

class EgLog : public framework::Producer {
 public:
  EgLog(const std::string& name, framework::Process& p)
    : framework::Producer(name, p) {}
  virtual ~EgLog() = default;
  void produce(framework::Event& event) override {
    ldmx_log(info) << "Info message";
    ldmx_log(error) << "Error message";
  }
};

DECLARE_PRODUCER(EgLog);
```