### PR TITLE
Part 3 of static analysis: clang-tidy

### DIFF
--- a/Biasing/src/Biasing/PhotoNuclearProductsFilter.cxx
+++ b/Biasing/src/Biasing/PhotoNuclearProductsFilter.cxx
@@ -72,7 +72,9 @@ void PhotoNuclearProductsFilter::stepping(const G4Step* step) {
 
   // Once the PN gamma has been procesed, untag it so its not reprocessed
   // again.
-  trackInfo->tagPNGamma(false);
+  if (trackInfo) {
+    trackInfo->tagPNGamma(false);
+  }
 }
 }  // namespace biasing
 

--- a/Biasing/src/Biasing/PhotoNuclearTopologyFilters.cxx
+++ b/Biasing/src/Biasing/PhotoNuclearTopologyFilters.cxx
@@ -70,7 +70,9 @@ void PhotoNuclearTopologyFilter::stepping(const G4Step* step) {
 
   // Once the PN gamma has been procesed, untag it so its not reprocessed
   // again.
-  trackInfo->tagPNGamma(false);
+  if (trackInfo) {
+    trackInfo->tagPNGamma(false);
+  }
 }
 
 }  // namespace biasing

--- a/Biasing/src/Biasing/TaggerHitFilter.cxx
+++ b/Biasing/src/Biasing/TaggerHitFilter.cxx
@@ -45,12 +45,25 @@ void TaggerHitFilter::stepping(const G4Step* step) {
     return;
 
   // The copy number is used to identify which layer energy was deposited into.
-  auto copy_number{step->GetPreStepPoint()
-                       ->GetTouchableHandle()
-                       ->GetHistory()
-                       ->GetVolume(2)
-                       ->GetCopyNo()};
-
+  int copy_number{0};
+  // Get the pre-step point
+  auto* preStepPoint = step->GetPreStepPoint();
+  if (preStepPoint) {
+    // Get the touchable handle
+    auto touchableHandle = preStepPoint->GetTouchableHandle();
+    if (touchableHandle) {
+      // Get the history
+      auto* history = touchableHandle->GetHistory();
+      if (history) {
+        // Get the volume
+        auto* volumeAtTwo = history->GetVolume(2);
+        if (volumeAtTwo) {
+          // Get the copy number
+          copy_number = volumeAtTwo->GetCopyNo();
+        }
+      }
+    }
+  }
   layer_count_.insert(copy_number);
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(LDMX_SW VERSION 3.1.1
                 LANGUAGES CXX    
 )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # Load additional macros used by this project. 
 list(APPEND CMAKE_MODULE_PATH ${LDMX_SW_SOURCE_DIR}/cmake/)
@@ -35,6 +35,9 @@ include(BuildMacros RESULT_VARIABLE build_macros_found)
 include_directories(SYSTEM /usr/local/include/root)
 include_directories(SYSTEM Tracking/acts/Core/include)
 include_directories(SYSTEM Trigger/HLS_arbitrary_Precision_Types/include)
+
+# FunctionalCoreTest.cxx doesnt comply with clang-tidy but that's ok
+set_source_files_properties(Framework/test/FunctionalCoreTest.cxx PROPERTIES COMPILE_OPTIONS "-Wno-null-dereference")
 
 # If an install location hasn't been set via CMAKE_INSTALL_PREFIX, set it to 
 # a reasonable default ($PWD/install).  

--- a/DQM/src/DQM/SampleValidation.cxx
+++ b/DQM/src/DQM/SampleValidation.cxx
@@ -20,7 +20,7 @@ void SampleValidation::analyze(const framework::Event& event) {
 
   std::vector<int> primary_daughters;
 
-  double hard_thresh;
+  double hard_thresh{9999.0};
 
   // Loop over all SimParticles
   for (auto const& it : particle_map) {

--- a/DetDescr/include/DetDescr/IDField.h
+++ b/DetDescr/include/DetDescr/IDField.h
@@ -81,27 +81,27 @@ class IDField {
   /**
    * The name of the field.
    */
-  std::string fieldName;
+  std::string fieldName_;
 
   /**
    * The index of the field.
    */
-  unsigned index;
+  unsigned index_;
 
   /**
    * The start bit of the field.
    */
-  unsigned startBit;
+  unsigned startBit_;
 
   /**
    * The end bit of the field.
    */
-  unsigned endBit;
+  unsigned endBit_;
 
   /**
    * The bit mask of the field.
    */
-  unsigned bitMask;
+  unsigned bitMask_;
 };
 }  // namespace ldmx
 

--- a/DetDescr/src/DetDescr/IDField.cxx
+++ b/DetDescr/src/DetDescr/IDField.cxx
@@ -4,20 +4,23 @@ namespace ldmx {
 
 IDField::IDField(std::string fieldName, unsigned index, unsigned startBit,
                  unsigned endBit)
-    : fieldName(fieldName), index(index), startBit(startBit), endBit(endBit) {
+    : fieldName_(fieldName),
+      index_(index),
+      startBit_(startBit),
+      endBit_(endBit) {
   // Create bit mask for the field.
-  bitMask = IDField::createBitMask(startBit, endBit);
+  bitMask_ = IDField::createBitMask(startBit, endBit);
 }
 
-const std::string& IDField::getFieldName() { return fieldName; }
+const std::string& IDField::getFieldName() { return fieldName_; }
 
-unsigned IDField::getIndex() { return index; }
+unsigned IDField::getIndex() { return index_; }
 
-unsigned IDField::getStartBit() { return startBit; }
+unsigned IDField::getStartBit() { return startBit_; }
 
-unsigned IDField::getEndBit() { return endBit; }
+unsigned IDField::getEndBit() { return endBit_; }
 
-unsigned IDField::getBitMask() { return bitMask; }
+unsigned IDField::getBitMask() { return bitMask_; }
 
 unsigned IDField::createBitMask(unsigned startBit, unsigned endBit) {
   unsigned mask = 0;

--- a/Ecal/src/Ecal/print_ecal_hex_readout.cxx
+++ b/Ecal/src/Ecal/print_ecal_hex_readout.cxx
@@ -76,7 +76,7 @@ int main() {
       std::make_pair(+1. * hexCornerRadius * cos(M_PI / 3),
                      -1. * hexCornerRadius * sin(M_PI / 3)),
       std::make_pair(+1. * hexCornerRadius, 0.)};
-  TLine moduleHexBorder;
+  TLine moduleHexBorder{0.,0.,0.,0.};
   moduleHexBorder.SetLineColorAlpha(kRed, 0.5);
   moduleHexBorder.SetLineWidth(2);
   for (int i = 1; i < hexCorners.size(); i++) {

--- a/Ecal/src/Ecal/print_ecal_hex_readout.cxx
+++ b/Ecal/src/Ecal/print_ecal_hex_readout.cxx
@@ -76,7 +76,7 @@ int main() {
       std::make_pair(+1. * hexCornerRadius * cos(M_PI / 3),
                      -1. * hexCornerRadius * sin(M_PI / 3)),
       std::make_pair(+1. * hexCornerRadius, 0.)};
-  TLine moduleHexBorder{0.,0.,0.,0.};
+  TLine moduleHexBorder{0., 0., 0., 0.};
   moduleHexBorder.SetLineColorAlpha(kRed, 0.5);
   moduleHexBorder.SetLineWidth(2);
   for (int i = 1; i < hexCorners.size(); i++) {

--- a/Framework/include/Framework/EventHeader.h
+++ b/Framework/include/Framework/EventHeader.h
@@ -75,7 +75,7 @@ class EventHeader {
    * Return the event number.
    * @return The event number.
    */
-  [[clang::no_sanitize("null")]] int getEventNumber() const {
+  int getEventNumber() const {
     return eventNumber_;
   }
 
@@ -249,7 +249,7 @@ class EventHeader {
   /**
    * ROOT class definition.
    */
-  ClassDef(EventHeader, 3);
+  ClassDef(EventHeader, 2);
 };
 
 }  // namespace ldmx

--- a/Framework/include/Framework/EventHeader.h
+++ b/Framework/include/Framework/EventHeader.h
@@ -75,9 +75,7 @@ class EventHeader {
    * Return the event number.
    * @return The event number.
    */
-  int getEventNumber() const {
-    return eventNumber_;
-  }
+  int getEventNumber() const { return eventNumber_; }
 
   /**
    * Return the run number.

--- a/Framework/include/Framework/EventHeader.h
+++ b/Framework/include/Framework/EventHeader.h
@@ -75,7 +75,9 @@ class EventHeader {
    * Return the event number.
    * @return The event number.
    */
-  int getEventNumber() const { return eventNumber_; }
+  [[clang::no_sanitize("null")]] int getEventNumber() const {
+    return eventNumber_;
+  }
 
   /**
    * Return the run number.
@@ -247,7 +249,7 @@ class EventHeader {
   /**
    * ROOT class definition.
    */
-  ClassDef(EventHeader, 2);
+  ClassDef(EventHeader, 3);
 };
 
 }  // namespace ldmx

--- a/Framework/include/Framework/Histograms.h
+++ b/Framework/include/Framework/Histograms.h
@@ -164,7 +164,10 @@ class HistogramHelper {
    * @param val value to fill
    */
   void fill(const std::string& name, const double& val) {
-    dynamic_cast<TH1F*>(this->get(name))->Fill(val, theWeight_);
+    auto hist = dynamic_cast<TH1F*>(this->get(name));
+    if (hist) {
+      hist->Fill(val, theWeight_);
+    }
   }
 
   /**
@@ -177,7 +180,10 @@ class HistogramHelper {
    * @param valy y value to fill
    */
   void fill(const std::string& name, const double& valx, const double& valy) {
-    dynamic_cast<TH2F*>(this->get(name))->Fill(valx, valy, theWeight_);
+    auto hist = dynamic_cast<TH2F*>(this->get(name));
+    if (hist) {
+      hist->Fill(valx, valy, theWeight_);
+    }
   }
 
   /**

--- a/Framework/include/Framework/RunHeader.h
+++ b/Framework/include/Framework/RunHeader.h
@@ -71,7 +71,8 @@ class RunHeader {
   virtual ~RunHeader() {}
 
   /** @return The run number. */
-  int getRunNumber() const { return runNumber_; }
+  int getRunNumber() const { 
+	  return runNumber_; }
 
   /** @return The name of the detector used to create the events. */
   const std::string &getDetectorName() const { return detectorName_; }

--- a/Framework/include/Framework/RunHeader.h
+++ b/Framework/include/Framework/RunHeader.h
@@ -71,8 +71,7 @@ class RunHeader {
   virtual ~RunHeader() {}
 
   /** @return The run number. */
-  int getRunNumber() const { 
-	  return runNumber_; }
+  int getRunNumber() const { return runNumber_; }
 
   /** @return The name of the detector used to create the events. */
   const std::string &getDetectorName() const { return detectorName_; }

--- a/Framework/src/Framework/Conditions.cxx
+++ b/Framework/src/Framework/Conditions.cxx
@@ -21,8 +21,7 @@ void Conditions::createConditionsObjectProvider(
     if (providerMap_.find(provides) != providerMap_.end()) {
       EXCEPTION_RAISE(
           "ConditionAmbiguityException",
-          std::string(
-              "Multiple ConditonsObjectProviders configured to provide ") +
+          "Multiple ConditonsObjectProviders configured to provide " +
               provides);
     }
     providerMap_[provides] = cop;
@@ -62,9 +61,8 @@ const ConditionsObject* Conditions::getConditionPtr(
     auto copptr = providerMap_.find(condition_name);
 
     if (copptr == providerMap_.end()) {
-      EXCEPTION_RAISE(
-          "ConditionUnavailable",
-          std::string("No provider is available for : " + condition_name));
+      EXCEPTION_RAISE("ConditionUnavailable",
+                      "No provider is available for : " + condition_name);
     }
 
     std::pair<const ConditionsObject*, ConditionsIOV> cond =
@@ -73,8 +71,7 @@ const ConditionsObject* Conditions::getConditionPtr(
     if (!cond.first) {
       EXCEPTION_RAISE(
           "ConditionUnavailable",
-          std::string("Null condition returned for requested item : " +
-                      condition_name));
+          "Null condition returned for requested item : " + condition_name);
     }
 
     // first request, create a cache entry

--- a/Framework/src/Framework/Event.cxx
+++ b/Framework/src/Framework/Event.cxx
@@ -122,7 +122,10 @@ void Event::setInputTree(TTree* tree) {
   // find the names of all the existing branches
   TObjArray* branches = inputTree_->GetListOfBranches();
   if (!branches) {
-    EXCEPTION_RAISE("RunHeaderError", "Branch doesnt exists");
+    EXCEPTION_RAISE(
+        "BadInputFile",
+        "Input tree doesn't have a list of branches but still made it to this "
+        "point. This is bad and has never been seen before!");
     return;
   }
   for (int i = 0; i < branches->GetEntriesFast(); i++) {

--- a/Framework/src/Framework/Event.cxx
+++ b/Framework/src/Framework/Event.cxx
@@ -121,8 +121,15 @@ void Event::setInputTree(TTree* tree) {
 
   // find the names of all the existing branches
   TObjArray* branches = inputTree_->GetListOfBranches();
+  if (!branches) {
+    EXCEPTION_RAISE("RunHeaderError", "Branch doesnt exists");
+    return;
+  }
   for (int i = 0; i < branches->GetEntriesFast(); i++) {
-    std::string brname = branches->At(i)->GetName();
+    std::string brname;
+    if (branches->At(i)) {
+      brname = branches->At(i)->GetName();
+    }
     if (brname != ldmx::EventHeader::BRANCH) {
       size_t j = brname.find("_");
       auto br = dynamic_cast<TBranchElement*>(branches->At(i));

--- a/Framework/src/Framework/EventFile.cxx
+++ b/Framework/src/Framework/EventFile.cxx
@@ -413,9 +413,13 @@ void EventFile::importRunHeaders() {
     TTreeReaderValue<ldmx::RunHeader> oldRunHeader(oldRunTree, "RunHeader");
     // TODO check that setup went correctly
     while (oldRunTree.Next()) {
-      // copy input run tree into run map
-      runMap_[oldRunHeader->getRunNumber()] =
-          std::make_pair(true, new ldmx::RunHeader(*oldRunHeader));
+      auto *oldRunHeaderPtr = oldRunHeader.Get();
+      if (oldRunHeaderPtr != nullptr) {
+        // copy input run tree into run map
+        // We should consider moving to a shared_ptr instead of 'new'
+        runMap_[oldRunHeaderPtr->getRunNumber()] =
+            std::make_pair(true, new ldmx::RunHeader(*oldRunHeader));
+      }
     }
   }
 

--- a/Framework/test/FunctionalCoreTest.cxx
+++ b/Framework/test/FunctionalCoreTest.cxx
@@ -47,7 +47,7 @@ class TestProducer : public Producer {
 
  public:
   TestProducer(const std::string& name, Process& p) : Producer(name, p) {}
-  virtual ~TestProducer() = default;
+  ~TestProducer() {}
 
   void configure(framework::config::Parameters& p) final override {
     createRunHeader_ = p.getParameter<bool>("createRunHeader");
@@ -58,6 +58,7 @@ class TestProducer : public Producer {
     header.setIntParameter("Should Be Run Number", header.getRunNumber());
     return;
   }
+
   void produce(framework::Event& event) final override {
     int i_event = event.getEventNumber();
 
@@ -71,7 +72,7 @@ class TestProducer : public Producer {
 
     REQUIRE_NOTHROW(event.add("TestCollection", caloHits));
 
-    ldmx::HcalHit maxPEHit{};
+    ldmx::HcalHit maxPEHit;
     maxPEHit.setID(i_event);
 
     ldmx::HcalVetoResult res;
@@ -106,14 +107,13 @@ class TestProducer : public Producer {
 class TestAnalyzer : public Analyzer {
  public:
   TestAnalyzer(const std::string& name, Process& p) : Analyzer(name, p) {}
-  virtual ~TestAnalyzer() = default;
+  ~TestAnalyzer() {}
 
   void onProcessStart() final override {
     REQUIRE_NOTHROW(getHistoDirectory());
     test_hist_ = new TH1F("test_hist_", "Test Histogram", 101, -50, 50);
     test_hist_->SetCanExtend(TH1::kAllAxes);
   }
-
 
   void analyze(const framework::Event& event) final override {
     int i_event = event.getEventNumber();
@@ -284,11 +284,6 @@ class isGoodEventFile : public Catch::Matchers::MatcherBase<std::string> {
 
     // Event tree should _always_ have the ldmx::EventHeader
     TTreeReaderValue<ldmx::EventHeader> header(events, "EventHeader");
-    if (!header.IsValid()) {
-      std::cerr << "Error: EventHeader branch does not exist in the TTree!"
-                << std::endl;
-      return false;
-    }
 
     if (existCollection_) {
       // make sure collection matches pattern

--- a/Framework/test/NtupleManagerTest.cxx
+++ b/Framework/test/NtupleManagerTest.cxx
@@ -1,5 +1,5 @@
 /**
- * @file FunctionalCoreTest.cxx
+ * @file NtupleManagerTest.cxx
  * @brief Test the operation of Framework processing
  *
  * @author Tom Eichlersmith, University of Minnesota

--- a/Hcal/include/Hcal/Event/HcalHit.h
+++ b/Hcal/include/Hcal/Event/HcalHit.h
@@ -199,34 +199,34 @@ class HcalHit : public ldmx::CalorimeterHit {
 
  private:
   /** The number of PE estimated for this hit. */
-  float pe_{0};
+  float pe_{0.0};
 
   /** The minimum number of PE estimated for this hit, different from pe_ when
    * you have two ended readout */
-  float minpe_{-99};
+  float minpe_{-99.0};
 
   /// section, layer, strip and end
-  int section_;
-  int layer_;
-  int strip_;
-  int end_;
+  int section_{-99};
+  int layer_{-99};
+  int strip_{-99};
+  int end_{-99};
 
   /// isADC
-  int isADC_;
+  int isADC_{-99};
 
-  double timeDiff_;
-  double position_;
-  double isX_;
+  double timeDiff_{-9999.};
+  double position_{-9999.};
+  double isX_{-9999.};
 
-  double toaPos_;
-  double toaNeg_;
-  double amplitudePos_;
-  double amplitudeNeg_;
+  double toaPos_{-9999.};
+  double toaNeg_{-9999.};
+  double amplitudePos_{-9999.};
+  double amplitudeNeg_{-9999.};
 
   /**
    * The ROOT class definition.
    */
-  ClassDef(HcalHit, 3);
+  ClassDef(HcalHit, 4);
 };
 }  // namespace ldmx
 

--- a/Hcal/include/Hcal/HcalWABVetoProcessor.h
+++ b/Hcal/include/Hcal/HcalWABVetoProcessor.h
@@ -30,7 +30,7 @@ class HcalWABVetoProcessor : public framework::Producer {
   HcalWABVetoProcessor(const std::string &name, framework::Process &process);
 
   /** Destructor */
-  virtual ~HcalWABVetoProcessor();
+  virtual ~HcalWABVetoProcessor() = default;
 
   /**
    * Configure the processor using the given user specified parameters.

--- a/Hcal/src/Hcal/HcalWABVetoProcessor.cxx
+++ b/Hcal/src/Hcal/HcalWABVetoProcessor.cxx
@@ -19,8 +19,6 @@ HcalWABVetoProcessor::HcalWABVetoProcessor(const std::string &name,
                                            framework::Process &process)
     : Producer(name, process) {}
 
-HcalWABVetoProcessor::~HcalWABVetoProcessor() {}
-
 void HcalWABVetoProcessor::configure(
     framework::config::Parameters &parameters) {
   maxtotalEnergyCompare_ =
@@ -58,7 +56,7 @@ void HcalWABVetoProcessor::produce(framework::Event &event) {
   float totalHCALEnergy{0};
   float totalECALEnergy{0};
   float maxPE{-1000};
-  const ldmx::HcalHit *maxPEHit;
+  const ldmx::HcalHit *maxPEHit = nullptr;
   for (const ldmx::HcalHit &hcalHit : hcalRecHits) {
     if (hcalHit.isNoise() == 0) {
       totalHCALEnergy += hcalHit.getPE();
@@ -67,7 +65,7 @@ void HcalWABVetoProcessor::produce(framework::Event &event) {
     // Find the maximum PE in the list
     if (maxPE < hcalHit.getPE()) {
       maxPE = hcalHit.getPE();
-      maxPEHit = &hcalHit;
+      maxPEHit = const_cast<ldmx::HcalHit *>(&hcalHit);
     }
   }
 

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -184,14 +184,14 @@ void OverlayProducer::produce(framework::Event &event) {
     // sample a poisson distribution, or use mu as fixed number of overlay
     // events
     int nEvsOverlay =
-        doPoissonOOT_ ? (int)rndm_->Poisson(poissonMu_) : (int)poissonMu_;
+        doPoissonOOT_ ? rndm_->Poisson(poissonMu_) : (int)poissonMu_;
 
     // special case: in-time pileup at bunch 0
     if (bunchOffset == 0) {
       if (!doPoissonIT_)
         nEvsOverlay = (int)poissonMu_;          // fix it to the average
       else if (doPoissonIT_ && !doPoissonOOT_)  // then we haven't set this yet
-        nEvsOverlay = (int)rndm_->Poisson(poissonMu_);
+        nEvsOverlay = rndm_->Poisson(poissonMu_);
 
       // paticularly useful in the poisson fluctuated case
       event.getEventHeader().setIntParameter("inTimePU", nEvsOverlay);

--- a/SimCore/src/SimCore/G4User/TrackingAction.cxx
+++ b/SimCore/src/SimCore/G4User/TrackingAction.cxx
@@ -35,7 +35,9 @@ void TrackingAction::PreUserTrackingAction(const G4Track* track) {
           track->GetDynamicParticle()
               ->GetPrimaryParticle()
               ->GetUserInformation());
-      curGenStatus = primaryInfo->getHepEvtStatus();
+      if (primaryInfo) {
+        curGenStatus = primaryInfo->getHepEvtStatus();
+      }
     }
 
     /**

--- a/SimCore/src/SimCore/SDs/EcalSD.cxx
+++ b/SimCore/src/SimCore/SDs/EcalSD.cxx
@@ -47,11 +47,21 @@ G4bool EcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
       0.5 * (prePoint->GetPosition() + postPoint->GetPosition());
 
   // Create the ID for the hit.
-  int cpynum = aStep->GetPreStepPoint()
-                   ->GetTouchableHandle()
-                   ->GetHistory()
-                   ->GetVolume(layer_depth)
-                   ->GetCopyNo();
+  int cpynum{0};  // Initialize cpynum to 0
+
+  auto preStepPoint = aStep->GetPreStepPoint();
+  if (preStepPoint) {
+    auto touchableHandle = preStepPoint->GetTouchableHandle();
+    if (touchableHandle) {
+      auto history = touchableHandle->GetHistory();
+      if (history) {
+        auto volume = history->GetVolume(layer_depth);
+        if (volume) {
+          cpynum = volume->GetCopyNo();
+        }
+      }
+    }
+  }
   int layerNumber;
   layerNumber = cpynum / 7;
   int module_position = cpynum % 7;

--- a/SimCore/src/SimCore/SDs/HcalSD.cxx
+++ b/SimCore/src/SimCore/SDs/HcalSD.cxx
@@ -122,22 +122,22 @@ G4bool HcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory* ROhist) {
   if (aStep) {
     const auto* preStepPoint = aStep->GetPreStepPoint();
     if (preStepPoint) {
-        const auto& touchableHandle = preStepPoint->GetTouchableHandle();
-	if (touchableHandle) {
+      const auto& touchableHandle = preStepPoint->GetTouchableHandle();
+      if (touchableHandle) {
         const auto* volume = touchableHandle->GetVolume();
 
         if (volume) {
-            const auto* logicalVolume = volume->GetLogicalVolume();
-            if (logicalVolume) {
-                auto* solid = logicalVolume->GetSolid();
-                if (solid) {
-                    scint = static_cast<G4Box*>(solid);
-                }
+          const auto* logicalVolume = volume->GetLogicalVolume();
+          if (logicalVolume) {
+            auto* solid = logicalVolume->GetSolid();
+            if (solid) {
+              scint = static_cast<G4Box*>(solid);
             }
+          }
         }
+      }
     }
-    }
-}
+  }
 
   // Set the step mid-point as the hit position.
   G4StepPoint* prePoint = aStep->GetPreStepPoint();

--- a/SimCore/src/SimCore/SDs/TrigScintSD.cxx
+++ b/SimCore/src/SimCore/SDs/TrigScintSD.cxx
@@ -37,6 +37,9 @@ G4bool TrigScintSD::ProcessHits(G4Step* step, G4TouchableHistory* history) {
 
   G4StepPoint* prePoint = step->GetPreStepPoint();
   G4StepPoint* postPoint = step->GetPostStepPoint();
+  if (prePoint == nullptr || postPoint == nullptr) {
+    return false;
+  }
 
   // A Geant4 "touchable" is a way to uniquely identify a particular volume,
   // short for touchable detector element. See the detector definition and
@@ -45,7 +48,9 @@ G4bool TrigScintSD::ProcessHits(G4Step* step, G4TouchableHistory* history) {
   // The TouchableHandle is just a reference counted pointer to a
   // G4TouchableHistory object, which is a concrete implementation of a
   // G4Touchable interface.
-  //
+  if (!prePoint->GetTouchableHandle()) {
+    return false;
+  }
   auto touchableHistory{prePoint->GetTouchableHandle()->GetHistory()};
   // Affine transform for converting between local and global coordinates
   auto topTransform{touchableHistory->GetTopTransform()};

--- a/Tracking/include/Tracking/Reco/TrackExtrapolatorTool.h
+++ b/Tracking/include/Tracking/Reco/TrackExtrapolatorTool.h
@@ -177,8 +177,7 @@ class TrackExtrapolatorTool {
   }
 
   /**
-
-  /** Create an ldmx::TrackState to the extrapolated position
+   ** Create an ldmx::TrackState to the extrapolated position
    @param Acts::Track
    @param extrapolation surface
    @param ldmx::Track::TrackState

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -327,6 +327,9 @@ void CKFProcessor::produce(framework::Event& event) {
   struct SourceLinkAccIt {
     using BaseIt = decltype(geoId_sl_map.begin());
     BaseIt it;
+    
+    #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 
     using difference_type = typename BaseIt::difference_type;
     using iterator_category = typename BaseIt::iterator_category;
@@ -334,6 +337,7 @@ void CKFProcessor::produce(framework::Event& event) {
     using value_type = Acts::SourceLink;
     using pointer = typename BaseIt::pointer;
     using reference = value_type&;
+#pragma GCC diagnostic pop
 
     SourceLinkAccIt& operator++() {
       ++it;

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -327,8 +327,8 @@ void CKFProcessor::produce(framework::Event& event) {
   struct SourceLinkAccIt {
     using BaseIt = decltype(geoId_sl_map.begin());
     BaseIt it;
-    
-    #pragma GCC diagnostic push
+
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 
     using difference_type = typename BaseIt::difference_type;

--- a/Tracking/src/Tracking/Reco/GSFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/GSFProcessor.cxx
@@ -81,8 +81,8 @@ void GSFProcessor::onNewRun(const ldmx::RunHeader& rh) {
   // Acts::MixtureReductionMethod finalReductionMethod;
   // const auto multi_stepper = Acts::MultiEigenStepperLoop{map};
 
-  Acts::ComponentMergeMethod reductionMethod =
-      Acts::ComponentMergeMethod::eMaxWeight;
+  // Acts::ComponentMergeMethod reductionMethod =
+  //    Acts::ComponentMergeMethod::eMaxWeight;
   //  Acts::MultiEigenStepperLoop multi_stepper(
   //      map, reductionMethod,
   //      Acts::getDefaultLogger("GSF_STEP", acts_loggingLevel));

--- a/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -299,7 +299,7 @@ ldmx::Track SeedFinderProcessor::SeedTracker(
   b3_.push_back(B(3));
   b4_.push_back(B(4));
 
-  Acts::ActsVector<5> hlx = Acts::ActsVector<5>::Zero();
+  // Acts::ActsVector<5> hlx = Acts::ActsVector<5>::Zero();
   Acts::ActsVector<3> ref{0., 0., 0.};
 
   double relativePerigeeX = perigee_location(0) - xOrigin;

--- a/Tracking/src/Tracking/geo/GeometryContext.cxx
+++ b/Tracking/src/Tracking/geo/GeometryContext.cxx
@@ -27,18 +27,18 @@ void GeometryContext::loadTransformations(const tgSurfMap& surf_map) {
             ->uncorrectedTransform();
   }
 }
+/*
+ Some testing functionality
+ deltaT = (tu, tv, tw)
+ deltaR = (ru, rv, rw)
 
-// Some testing functionality
+         /  1    -rw   rv  \
+deltaR = |  rw    1   -ru  |
+         \ -rv    ru   1   /
 
-// deltaT = (tu, tv, tw)
-// deltaR = (ru, rv, rw)
-
-//         /  1    -rw   rv  \
-  //deltaR = |  rw    1   -ru  |
-//         \ -rv    ru   1   /
-
-// "active"  means "rotate, then translate"
-// "passive" means "translate, then rotate"
+ "active"  means "rotate, then translate"
+ "passive" means "translate, then rotate"
+*/
 
 void GeometryContext::addAlignCorrection(unsigned int sensorId,
                                          const Acts::Vector3 deltaT,

--- a/TrigScint/src/TrigScint/EventReadoutProducer.cxx
+++ b/TrigScint/src/TrigScint/EventReadoutProducer.cxx
@@ -49,7 +49,7 @@ void EventReadoutProducer::produce(framework::Event &event) {
     outEvent.setElecID(digi.getElecID());
     outEvent.setTimeSinceSpill(digi.getTimeSinceSpill());
     // elecID increases monotonically with 8 channels per fiber
-    outEvent.setFiberNb((int)(digi.getElecID() / 8));
+    outEvent.setFiberNb(digi.getElecID() / 8);
     if (outEvent.getFiberNb() == fiberToShift_)
       outEvent.setTimeOffset(timeShift_);
 

--- a/TrigScint/src/TrigScint/QIEDecoder.cxx
+++ b/TrigScint/src/TrigScint/QIEDecoder.cxx
@@ -256,7 +256,7 @@ void QIEDecoder::produce(framework::Event &event) {
   }
 
   ldmx_log(debug) << "Done reading in header, ADC and TDC for event "
-                  << (unsigned)triggerID;
+                  << triggerID;
   for (std::map<int, std::vector<int>>::iterator itr = ADCmap.begin();
        itr != ADCmap.end(); ++itr) {
     TrigScintQIEDigis digi;

--- a/TrigScint/src/TrigScint/SimQIE.cxx
+++ b/TrigScint/src/TrigScint/SimQIE.cxx
@@ -43,8 +43,7 @@ int SimQIE::Q2ADC(float Charge) {
     } else
       b = (a + b) / 2;
   }
-  return 64 * (int)(a / 4) + nbins_[a % 4] +
-         floor((qq - edges_[a]) / sense_[a]);
+  return 64 * (a / 4) + nbins_[a % 4] + floor((qq - edges_[a]) / sense_[a]);
 }
 
 // Function to convert ADCs back to charge

--- a/TrigScint/src/TrigScint/TestBeamHitProducer.cxx
+++ b/TrigScint/src/TrigScint/TestBeamHitProducer.cxx
@@ -94,8 +94,6 @@ void TestBeamHitProducer::produce(framework::Event& event) {
       event.getCollection<trigscint::EventReadout>(inputCol_, inputPassName_)};
 
   int evNb = event.getEventNumber();
-  // it is unused, should it be? FIXME
-  // int nChan = channels.size();
   std::vector<trigscint::TestBeamHit> hits;
   for (auto chan : channels) {
     trigscint::TestBeamHit hit;

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -612,7 +612,8 @@ void TrigScintTrackProducer::matchXYTracks(
   for (auto yitr = yQuadMap.begin(); yitr != yQuadMap.end(); ++yitr) {
     int nYinQuad = yQuadMap.count((*yitr).first);
     int nXinQuad = xQuadMap.count((*yitr).first);
-    float y, sy, x, x1, x2, sx1, sx2, y1, y2, sy1, sy2;
+    float y{-9999.}, sy{-9999.}, x{-9999.}, x1{-9999.}, x2{-9999.}, sx1{-9999.},
+        sx2{-9999.}, y1{-9999.}, y2{-9999.}, sy1{-9999.}, sy2{-9999.};
     // quad midpoint:
     float y0 = (*yitr).first * 8 + sy0;
     float sx =

--- a/justfile
+++ b/justfile
@@ -58,14 +58,16 @@ install-denv:
     curl -s https://raw.githubusercontent.com/tomeichlersmith/denv/main/install | sh
 
 # configure how ldmx-sw will be built
+# added ADDITIONAL_WARNINGS and CLANG_TIDY to help improve code quality
 configure *CONFIG:
     denv cmake -B build -S .  -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  {{ CONFIG }}
 
-configure-force-error *CONFIG:
-    just  configure -DWARNINGS_AS_ERRORS=ON {{ CONFIG }}
+# This is the same as just configure but reports all (non-3rd-party) warnings as errors
+configure-force-error *CONFIG: (configure "-DWARNINGS_AS_ERRORS=ON" CONFIG)
 
-configure-clang-lto:
-    denv cmake -B build -S . -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  -DENABLE_LTO=ON  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang 
+# This is an alternative compiler (clang) together with enabling the LTO sanitizer
+# This is very helpful but for now it optimizes away our module linking, use for testing only
+configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
 # compile and install ldmx-sw
 build ncpu=num_cpus():

--- a/justfile
+++ b/justfile
@@ -59,7 +59,13 @@ install-denv:
 
 # configure how ldmx-sw will be built
 configure *CONFIG:
-    denv cmake -B build -S . {{ CONFIG }}
+    denv cmake -B build -S .  -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  {{ CONFIG }}
+
+configure-force-error  *CONFIG:
+    just configure -DWARNINGS_AS_ERRORS=ON  {{ CONFIG }}
+
+configure-clang-lto:
+    denv cmake -B build -S . -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  -DENABLE_LTO=ON  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang 
 
 # compile and install ldmx-sw
 build ncpu=num_cpus():
@@ -170,10 +176,12 @@ setenv +ENVVAR:
     denv config env copy {{ ENVVAR }}
 
 # configure and build ldmx-sw
-compile ncpu=num_cpus() *CONFIG='': (configure CONFIG) (build ncpu)
+compile ncpu=num_cpus() *CONFIG='':
+     (configure CONFIG) (build ncpu)
 
 # re-build ldmx-sw and then run a config
-recompFire config_py *ARGS: build (fire config_py ARGS)
+recompFire config_py *ARGS:
+     (compile) (fire config_py ARGS)
 
 # install the validation module
 # `python3 -m pip install Validation/` is the standard `pip` install method.

--- a/justfile
+++ b/justfile
@@ -61,8 +61,8 @@ install-denv:
 configure *CONFIG:
     denv cmake -B build -S .  -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  {{ CONFIG }}
 
-configure-force-error  *CONFIG:
-    just configure -DWARNINGS_AS_ERRORS=ON  {{ CONFIG }}
+configure-force-error *CONFIG:
+    just  configure -DWARNINGS_AS_ERRORS=ON {{ CONFIG }}
 
 configure-clang-lto:
     denv cmake -B build -S . -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  -DENABLE_LTO=ON  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang 
@@ -176,12 +176,10 @@ setenv +ENVVAR:
     denv config env copy {{ ENVVAR }}
 
 # configure and build ldmx-sw
-compile ncpu=num_cpus() *CONFIG='':
-     (configure CONFIG) (build ncpu)
+compile ncpu=num_cpus() *CONFIG='': (configure CONFIG) (build ncpu)
 
 # re-build ldmx-sw and then run a config
-recompFire config_py *ARGS:
-     (compile) (fire config_py ARGS)
+recompFire config_py *ARGS: compile (fire config_py ARGS)
 
 # install the validation module
 # `python3 -m pip install Validation/` is the standard `pip` install method.


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1176

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I killed all the warning. 
```
rm -rf build
just configure -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  -DENABLE_LTO=ON  -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
just build
// And switch back to a build with GCC
rm -rf build 
just configure -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  -DENABLE_LTO=ON 
just build
```
is now nice and clean.