### PR TITLE
Add condition for not being on trunk when pushing in format CI

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -37,7 +37,7 @@ jobs:
       id: commit
 
     - name: Push changes
-      if: steps.commit.outcome == 'success'
+      if: github.ref != 'refs/heads/trunk' 
       run: |
         git push origin HEAD:${GITHUB_HEAD_REF}
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Format check fails on trunk
https://github.com/LDMX-Software/ldmx-sw/actions/runs/10923712245/job/30321004467
because there is nothing to commit (which I tested already, and works) BUT now we are also not on a PR branch but on `trunk` (this I couldn't test until the prev PR was merged).

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Post-merge comment: indeed push was skipped on trunk https://github.com/LDMX-Software/ldmx-sw/actions/runs/10924826800/job/30324837501

