### PR TITLE
Change default trigger thresholds

### DIFF
--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -41,7 +41,7 @@ class TriggerProcessor(ldmxcfg.Producer) :
           
         self.beamEnergy = beamEnergy
         if (self.beamEnergy == 4000.): 
-            self.thresholds = [ 3000., 10000., 17000., 24200. ]
+            self.thresholds = [ 1500., 5000., 8500., 12100. ]
         else:
             self.thresholds = [ 3000., 10790., 18540., 26250. ]
         self.mode = 0

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -41,7 +41,7 @@ class TriggerProcessor(ldmxcfg.Producer) :
           
         self.beamEnergy = beamEnergy
         if (self.beamEnergy == 4000.): 
-            self.thresholds = [ 3000, 10000, 17000, 24200 ]
+            self.thresholds = [ 3000., 10000., 17000., 24200. ]
         else:
             self.thresholds = [ 3000., 10790., 18540., 26250. ]
         self.mode = 0

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -41,7 +41,7 @@ class TriggerProcessor(ldmxcfg.Producer) :
           
         self.beamEnergy = beamEnergy
         if (self.beamEnergy == 4000.): 
-            self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]
+            self.thresholds = [ 3000, 10000, 17000, 24200 ]
         else:
             self.thresholds = [ 3000., 10790., 18540., 26250. ]
         self.mode = 0

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -40,7 +40,10 @@ class TriggerProcessor(ldmxcfg.Producer) :
         super().__init__(name,'recon::TriggerProcessor','Recon')
           
         self.beamEnergy = beamEnergy
-        self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]
+        if (self.beamEnergy == 4000.): 
+            self.thresholds = [ self.beamEnergy/4000.*1500.0, self.beamEnergy/4000.*1000. + self.beamEnergy, self.beamEnergy/4000.*500. + 2*self.beamEnergy, self.beamEnergy/4000.*100. + 3*self.beamEnergy ]
+        else:
+            self.thresholds = [ 3000., 10790., 18540., 26250. ]
         self.mode = 0
         self.start_layer = 0
         self.end_layer = 20

--- a/Recon/python/simpleTrigger.py
+++ b/Recon/python/simpleTrigger.py
@@ -41,7 +41,7 @@ class TriggerProcessor(ldmxcfg.Producer) :
           
         self.beamEnergy = beamEnergy
         if (self.beamEnergy == 4000.): 
-            self.thresholds = [ 1500., 5000., 8500., 12100. ]
+            self.thresholds = [ 1500., 5000., 8200., 11800. ]
         else:
             self.thresholds = [ 3000., 10790., 18540., 26250. ]
         self.mode = 0


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1468. I've updated the 8 GeV default thresholds to reflect the optimized values calculated for a mu=1 Poisson beam profile, and 20 ECal layers. The 1e threshold was kept at 3 GeV, which also happens to be consistent with the optimized value (3.01 GeV).

Thresholds for 4 GeV were also updated to reflect thresholds calculated by Megan, as reported here: https://indico.fnal.gov/event/51366/contributions/225984/attachments/148282/190432/MeganLoh_multielectronTriggering.pdf

The 1e- threshold at 4 GeV was kept at 1.5 GeV.



## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [ ] I ran my developments and the following shows that they are successful.