### PR TITLE
Add ASAN/UBSAN recipe to just, make a CI that runs it + adding GDB

### DIFF
--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run ecal_pn config
       continue-on-error: true
       run: |
-        just setenv LDMX_NUM_EVENTS=1500
+        just setenv LDMX_NUM_EVENTS=15
         just setenv LDMX_RUN_NUMBER=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 2> output.log
       shell: bash

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -35,7 +35,7 @@ jobs:
       #continue-on-error: true
       run: |
         just setenv LDMX_NUM_EVENTS=15
-        just setenv LDMX_RUN_NUMBER=1
+        just setenv LDMX_RUN_NUMBER=1500
         #just setenv ASAN_OPTIONS=log_path=output.log
         just setenv ASAN_OPTIONS=detect_leaks=0
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   LDMX_DOCKER_TAG: ldmx/dev:latest
-  LDMX_NUM_EVENTS: 7500
 
 jobs:
   build-with-asan-ubsan:
@@ -34,9 +33,9 @@ jobs:
 
     - name: Run ecal_pn config
       run: |
-        just setenv LDMX_NUM_EVENTS=7500
+        just setenv LDMX_NUM_EVENTS=1500
         just setenv LDMX_RUN_NUMBER=1
-        export LDMX_NUM_EVENTS=7500
+        export LDMX_NUM_EVENTS=1500
         export LDMX_RUN_NUMBER=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
       shell: bash

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -32,16 +32,18 @@ jobs:
       shell: bash
 
     - name: Run ecal_pn config
-      continue-on-error: true
+      #continue-on-error: true
       run: |
         just setenv LDMX_NUM_EVENTS=15
         just setenv LDMX_RUN_NUMBER=1
-        just setenv ASAN_OPTIONS=log_path=output.log
+        #just setenv ASAN_OPTIONS=log_path=output.log
+        just setenv ASAN_OPTIONS=detect_leaks=0
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
       shell: bash
 
-    - name: Upload log artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: ASAN_UBSAN_output
-        path: output.log*
+      # For the future, we could try to save the output of ASAN/UBSAN
+      #    - name: Upload log artifact
+      #      uses: actions/upload-artifact@v4
+      #      with:
+      #        name: ASAN_UBSAN_output
+      #        path: output.log*

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -32,6 +32,11 @@ jobs:
       run: |
         just install-denv init configure-asan-ubsan 
         just build
-        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 
+        just setenv LDMX_NUM_EVENTS=7500
+        just setenv LDMX_RUN_NUMBER=1
       shell: bash
+
+    - name: Run ecal_pn config
+      run: |
+        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
 

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -35,7 +35,7 @@ jobs:
       #continue-on-error: true
       run: |
         just setenv LDMX_NUM_EVENTS=15
-        just setenv LDMX_RUN_NUMBER=1500
+        just setenv LDMX_RUN_NUMBER=7500
         #just setenv ASAN_OPTIONS=log_path=output.log
         just setenv ASAN_OPTIONS=detect_leaks=0
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -36,6 +36,8 @@ jobs:
       run: |
         just setenv LDMX_NUM_EVENTS=7500
         just setenv LDMX_RUN_NUMBER=1
+        export LDMX_NUM_EVENTS=7500
+        export LDMX_RUN_NUMBER=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
       shell: bash
 

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -36,13 +36,12 @@ jobs:
       run: |
         just setenv LDMX_NUM_EVENTS=15
         just setenv LDMX_RUN_NUMBER=1
-        just setenv LSAN_OPTIONS=verbosity=1
-        just setenv LSAN_OPTIONS=log_threads=1
-        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 2> output.log
+        just setenv ASAN_OPTIONS=log_path=output.log
+        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
       shell: bash
 
     - name: Upload log artifact
       uses: actions/upload-artifact@v4
       with:
         name: ASAN_UBSAN_output
-        path: output.log
+        path: output.log*

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -37,11 +37,11 @@ jobs:
         just setenv LDMX_RUN_NUMBER=1
         export LDMX_NUM_EVENTS=15
         export LDMX_RUN_NUMBER=1
-        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py  2> output.log
+        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 2> output.log
       shell: bash
 
-   - name: Upload output artifact
-      uses: actions/upload-artifact@v3
+    - name: Upload log artifact
+      uses: actions/upload-artifact@v4
       with:
-        name: ASAN_UBSAN-output
+        name: ASAN_UBSAN_output
         path: output.log

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -1,0 +1,37 @@
+
+name: Build with ASAN/UBSAN
+
+on:
+  workflow_dispatch:
+  pull_request: 
+    branches: [trunk]
+    types: [opened, ready_for_review]
+
+env:
+  LDMX_DOCKER_TAG: ldmx/dev:latest
+  LDMX_NUM_EVENTS: 7500
+
+jobs:
+  build-with-asan-ubsan:
+    runs-on: ubuntu-latest
+    outputs:
+      job_matrix: ${{steps.gen-mat.outputs.job_matrix}}
+    steps:
+    - name: Checkout ldmx-sw
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+        fetch-depth: 0
+
+    - name: Install just
+      uses: extractions/setup-just@v2
+      with:
+          just-version: 1.26.0
+ 
+    - name: Compile and Install ldmx-sw
+      run: |
+        just install-denv init configure-asan-ubsan 
+        just build
+        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 
+      shell: bash
+

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -36,6 +36,8 @@ jobs:
       run: |
         just setenv LDMX_NUM_EVENTS=15
         just setenv LDMX_RUN_NUMBER=1
+        just setenv LSAN_OPTIONS=verbosity=1
+        just setenv LSAN_OPTIONS=log_threads=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 2> output.log
       shell: bash
 

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -32,11 +32,10 @@ jobs:
       shell: bash
 
     - name: Run ecal_pn config
+      continue-on-error: true
       run: |
         just setenv LDMX_NUM_EVENTS=1500
         just setenv LDMX_RUN_NUMBER=1
-        export LDMX_NUM_EVENTS=15
-        export LDMX_RUN_NUMBER=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py 2> output.log
       shell: bash
 

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -1,5 +1,5 @@
 
-name: Build with ASAN/UBSAN
+name: Build with ASAN and UBSAN
 
 on:
   workflow_dispatch:
@@ -35,8 +35,13 @@ jobs:
       run: |
         just setenv LDMX_NUM_EVENTS=1500
         just setenv LDMX_RUN_NUMBER=1
-        export LDMX_NUM_EVENTS=1500
+        export LDMX_NUM_EVENTS=15
         export LDMX_RUN_NUMBER=1
-        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
+        just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py  2> output.log
       shell: bash
 
+   - name: Upload output artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ASAN_UBSAN-output
+        path: output.log

--- a/.github/workflows/asan_ubsan_build.yml
+++ b/.github/workflows/asan_ubsan_build.yml
@@ -14,8 +14,6 @@ env:
 jobs:
   build-with-asan-ubsan:
     runs-on: ubuntu-latest
-    outputs:
-      job_matrix: ${{steps.gen-mat.outputs.job_matrix}}
     steps:
     - name: Checkout ldmx-sw
       uses: actions/checkout@v4
@@ -32,11 +30,12 @@ jobs:
       run: |
         just install-denv init configure-asan-ubsan 
         just build
-        just setenv LDMX_NUM_EVENTS=7500
-        just setenv LDMX_RUN_NUMBER=1
       shell: bash
 
     - name: Run ecal_pn config
       run: |
+        just setenv LDMX_NUM_EVENTS=7500
+        just setenv LDMX_RUN_NUMBER=1
         just fire  ${GITHUB_WORKSPACE}/.github/validation_samples/ecal_pn/config.py
+      shell: bash
 

--- a/justfile
+++ b/justfile
@@ -62,12 +62,21 @@ install-denv:
 configure *CONFIG:
     denv cmake -B build -S .  -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  {{ CONFIG }}
 
+# configure minimal option for faster compilation
+configure-quick *CONFIG: 
+    denv cmake -B build -S . {{ CONFIG }}
+
+# Configure with Address Sanitizer (ASAN) and  UndefinedBehaviorSanitizer (UBSan)
+configure-asan-ubsan: (configure-quick "-DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DENABLE_SANITIZER_ADDRESS=ON")
+
 # This is the same as just configure but reports all (non-3rd-party) warnings as errors
 configure-force-error *CONFIG: (configure "-DWARNINGS_AS_ERRORS=ON" CONFIG)
 
 # This is an alternative compiler (clang) together with enabling the LTO sanitizer
 # This is very helpful but for now it optimizes away our module linking, use for testing only
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
+
+configure-gdb: (configure-quick "-DCMAKE_BUILD_TYPE=Debug")
 
 # compile and install ldmx-sw
 build ncpu=num_cpus():
@@ -81,6 +90,11 @@ test *ARGS:
 [no-cd]
 fire config_py *ARGS:
     denv fire {{ config_py }} {{ ARGS }}
+
+# run gdb on a config file
+[no-cd]
+gdb-fire  config_py *ARGS:
+    denv gdb fire {{ config_py }} {{ ARGS }}
 
 # initialize a containerized development environment
 init:

--- a/justfile
+++ b/justfile
@@ -59,25 +59,28 @@ install-denv:
 
 # configure how ldmx-sw will be built
 # added ADDITIONAL_WARNINGS and CLANG_TIDY to help improve code quality
-configure *CONFIG:
-    denv cmake -B build -S .  -DADDITIONAL_WARNINGS=ON  -DENABLE_CLANG_TIDY=ON  {{ CONFIG }}
-
-# configure minimal option for faster compilation
-configure-quick *CONFIG: 
+# base configure command defining how cmake is called, private so only experts call it
+[private]
+configure-base *CONFIG:
     denv cmake -B build -S . {{ CONFIG }}
 
-# Configure with Address Sanitizer (ASAN) and  UndefinedBehaviorSanitizer (UBSan)
-configure-asan-ubsan: (configure-quick "-DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DENABLE_SANITIZER_ADDRESS=ON")
+# default configure of build when developing
+configure *CONFIG: (configure-base "-DADDITIONAL_WARNINGS=ON -DENABLE_CLANG_TIDY=ON" CONFIG)
+
+# configure minimal option for faster compilation
+configure-quick: (configure-base)
+
+# configure with Address Sanitizer (ASAN) and  UndefinedBehaviorSanitizer (UBSan)
+configure-asan-ubsan: (configure-base "-DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DENABLE_SANITIZER_ADDRESS=ON")
 
 # This is the same as just configure but reports all (non-3rd-party) warnings as errors
-configure-force-error *CONFIG: (configure "-DWARNINGS_AS_ERRORS=ON" CONFIG)
+configure-force-error: (configure "-DWARNINGS_AS_ERRORS=ON")
 
-# This is an alternative compiler (clang) together with enabling the LTO sanitizer
-# This is very helpful but for now it optimizes away our module linking, use for testing only
+# Use alternative compiler and enable LTO (test compiling only, won't run properly)
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
-configure-gdb: (configure-quick "-DCMAKE_BUILD_TYPE=Debug")
-
+# Keep debug symbols so running with gdb provides more helpful detail
+configure-gdb: (configure-base "-DCMAKE_BUILD_TYPE=Debug")
 # compile and install ldmx-sw
 build ncpu=num_cpus():
     denv cmake --build build --target install -- -j{{ ncpu }}

--- a/justfile
+++ b/justfile
@@ -96,7 +96,7 @@ fire config_py *ARGS:
 
 # run gdb on a config file
 [no-cd]
-gdb-fire  config_py *ARGS:
+debug config_py *ARGS:
     denv gdb fire {{ config_py }} {{ ARGS }}
 
 # initialize a containerized development environment


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1043 (the last bit of it)

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I did
```
just configure-asan-ubsan
just fire .github/validation_samples/kaon_enhanced/config.py 
```
give a lot of indirect memory leaks, which is fine, none of them are big. This is kinda expected since we fixed the ASAN / UBSAN problems in previous PRs. 

Added it to the CI with the option w/o the leak sanitizer, so currently there is no output from ASAN/UBSAN (given that we cleaned all the issues up already).

Then
```
just configure-gdb
denv gdb build/run_test 
```
this runs too, although I'm not sure how to actually make use of it for a real config file with `fire`.
I introduced
```
just debug
```
as well.