### PR TITLE
Persist the actual simulated position of the ECAL hit rather than the cell center

### DIFF
--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -237,6 +237,15 @@ class EcalDigiVerify(ldmxcfg.Analyzer) :
         self.ecalRecHitColl = "EcalRecHits"
         self.ecalRecHitPass = "" #use whatever pass is available
 
+        self.build1DHistogram( "rec_sim_hit_residual_x" ,
+                "RecHit X - SimHit X [mm]" , 30 , -15.0 , 15.0 )
+        
+        self.build1DHistogram( "rec_sim_hit_residual_y" ,
+                "RecHit Y - SimHit Y [mm]" , 30 , -15.0 , 15.0 )
+
+        self.build1DHistogram( "rec_sim_hit_residual_z" ,
+                "RecHit Z - SimHit Z [mm]" , 40 , -20.0 , 20.0 )
+
         self.build1DHistogram( "num_sim_hits_per_cell" ,
                 "Number of SimHits per ECal Cell (excluding empty rec cells)" , 20 , -0.5 , 19.5 )
         

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -244,7 +244,7 @@ class EcalDigiVerify(ldmxcfg.Analyzer) :
                 "RecHit Y - SimHit Y [mm]" , 30 , -15.0 , 15.0 )
 
         self.build1DHistogram( "rec_sim_hit_residual_z" ,
-                "RecHit Z - SimHit Z [mm]" , 40 , -20.0 , 20.0 )
+                "RecHit Z - SimHit Z [mm]" , 200 , -5.0 , 5.0 )
 
         self.build1DHistogram( "num_sim_hits_per_cell" ,
                 "Number of SimHits per ECal Cell (excluding empty rec cells)" , 20 , -0.5 , 19.5 )

--- a/DQM/src/DQM/EcalDigiVerifier.cxx
+++ b/DQM/src/DQM/EcalDigiVerifier.cxx
@@ -57,6 +57,12 @@ void EcalDigiVerifier::analyze(const framework::Event &event) {
       if (rawID == simHit.getID()) {
         numSimHits += simHit.getNumberOfContribs();
         totalSimEDep += simHit.getEdep();
+        auto residualX = recHit.getXPos() - simHit.getPosition()[0];
+        auto residualY = recHit.getYPos() - simHit.getPosition()[1];
+        auto residualZ = recHit.getZPos() - simHit.getPosition()[2];
+        histograms_.fill("rec_sim_hit_residual_x", residualX);
+        histograms_.fill("rec_sim_hit_residual_y", residualY);
+        histograms_.fill("rec_sim_hit_residual_z", residualZ);
       } else if (rawID < simHit.getID()) {
         // later sim hits - all done
         break;

--- a/SimCore/src/SimCore/SDs/EcalSD.cxx
+++ b/SimCore/src/SimCore/SDs/EcalSD.cxx
@@ -79,7 +79,7 @@ G4bool EcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
   // fastest, but need to trust module number between GDML and EcalGeometry
   // match
   ldmx::EcalID id =
-      geometry.getID(position[0], position[1], layerNumber, module_position);
+      geometry.getID(position.x(), position.y(), layerNumber, module_position);
 
   // medium, only need to trust z-layer positions in GDML and EcalGeometry match
   //    helpful for debugging any issues where transverse position is not
@@ -96,17 +96,7 @@ G4bool EcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
     // hit in empty cell
     auto& hit = hits_[id];
     hit.setID(id.raw());
-    /**
-     * convert position to center of cell position
-     *
-     * This is the behavior that has been done in the past,
-     * although it is completely redundant with the ID information
-     * already deduced. It would probably help us more if we
-     * persisted the actual simulated position of the hit rather
-     * than the cell center; however, that is up for more discussion.
-     */
-    auto [x, y, z] = geometry.getPosition(id);
-    hit.setPosition(x, y, z);
+    hit.setPosition(position.x(), position.y(), position.z());
   }
 
   auto& hit = hits_[id];


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1484

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1482

But I'm only opening it as a draft first to see the effect using the CI tests

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
