### PR TITLE
use denv v1.1.0's quiet no-overwrite init flags

### DIFF
--- a/justfile
+++ b/justfile
@@ -102,18 +102,28 @@ debug config_py *ARGS:
 # initialize a containerized development environment
 init:
     #!/usr/bin/env sh
-    # while setting the denv_workspace is helpful for other
-    # commands that can assume the denv is already initialized,
-    # we need to unset this environment variable to make sure
-    # the test is done appropriately.
-    # just makes sure this recipe runs from the directory of
-    # the justfile so we know we are in the correct location.
-    unset denv_workspace
-    if denv check --workspace --quiet; then
-      echo "\033[32mWorkspace already initialized.\033[0m"
-      denv config print
+    denv_major=$(denv version | sed 's/denv v//' | cut -f 1 -d.)
+    denv_minor=$(denv version | set 's/denv v//' | cut -f 2 -d.)
+    if [ "${denv_major}" -lt 1 ] || [ "${denv_minor}" -lt "1" ]; then
+      # denv v1.0.X or earlier, manually check for workspace
+      # which may print a confusing error from denv when no workspace is found
+      unset denv_workspace
+      # while setting the denv_workspace is helpful for other
+      # commands that can assume the denv is already initialized,
+      # we need to unset this environment variable to make sure
+      # the test is done appropriately.
+      # just makes sure this recipe runs from the directory of
+      # the justfile so we know we are in the correct location.
+      if denv check --workspace --quiet; then
+        echo "\033[32mWorkspace already initialized.\033[0m"
+        denv config print
+      else
+        denv init --clean-env --name ldmx ldmx/dev:latest ${LDMX_BASE}
+      fi
     else
-      denv init --clean-env --name ldmx ldmx/dev:latest ${LDMX_BASE}
+      # denv v1.1.0 and later has updated denv init to allow us
+      # to avoid overwriting quietly
+      denv init --clean-env --no-over --no-mkdir --name ldmx ldmx/dev:latest ${LDMX_BASE}
     fi
 
 # check that the necessary programs for running ldmx-sw are present

--- a/justfile
+++ b/justfile
@@ -103,8 +103,8 @@ debug config_py *ARGS:
 init:
     #!/usr/bin/env sh
     denv_major=$(denv version | sed 's/denv v//' | cut -f 1 -d.)
-    denv_minor=$(denv version | set 's/denv v//' | cut -f 2 -d.)
-    if [ "${denv_major}" -lt 1 ] || [ "${denv_minor}" -lt "1" ]; then
+    denv_minor=$(denv version | sed 's/denv v//' | cut -f 2 -d.)
+    if [ "${denv_major}" -lt "1" ] || [ "${denv_minor}" -lt "1" ]; then
       # denv v1.0.X or earlier, manually check for workspace
       # which may print a confusing error from denv when no workspace is found
       unset denv_workspace
@@ -116,15 +116,15 @@ init:
       # the justfile so we know we are in the correct location.
       if denv check --workspace --quiet; then
         echo "\033[32mWorkspace already initialized.\033[0m"
-        denv config print
       else
-        denv init --clean-env --name ldmx ldmx/dev:latest ${LDMX_BASE}
+        denv init --clean-env --name ldmx ldmx/dev:latest "${LDMX_BASE}"
       fi
     else
       # denv v1.1.0 and later has updated denv init to allow us
       # to avoid overwriting quietly
-      denv init --clean-env --no-over --no-mkdir --name ldmx ldmx/dev:latest ${LDMX_BASE}
+      denv init --clean-env --no-over --no-mkdir --name ldmx ldmx/dev:latest "${LDMX_BASE}"
     fi
+    denv config print
 
 # check that the necessary programs for running ldmx-sw are present
 check:

--- a/justfile
+++ b/justfile
@@ -174,8 +174,10 @@ shellcheck:
     #!/usr/bin/env sh
     set -x
     format_list=$(mktemp)
-    git ls-tree -r HEAD | awk '{ if ($1 == 100755 || $4 ~ /\.sh/) print $4 }' > ${format_list}
-    shellcheck --severity style --shell sh $(cat ${format_list})
+    git ls-tree -r HEAD | awk '{ if ($1 == 100755 || $4 ~ /\.sh/) print $4 }' \
+      > "${format_list}"
+    xargs --arg-file="${format_list}" \
+      shellcheck --severity style --shell sh
     rm "${format_list}"
 
 # check a script recipe also using shellcheck

--- a/justfile
+++ b/justfile
@@ -102,6 +102,7 @@ debug config_py *ARGS:
 # initialize a containerized development environment
 init:
     #!/usr/bin/env sh
+    set -eu
     denv_major=$(denv version | sed 's/denv v//' | cut -f 1 -d.)
     denv_minor=$(denv version | sed 's/denv v//' | cut -f 2 -d.)
     if [ "${denv_major}" -lt "1" ] || [ "${denv_minor}" -lt "1" ]; then

--- a/justfile
+++ b/justfile
@@ -172,10 +172,19 @@ format-just:
 # check the scripts for common errors and bugs
 shellcheck:
     #!/usr/bin/env sh
-    set -exu
+    set -x
     format_list=$(mktemp)
     git ls-tree -r HEAD | awk '{ if ($1 == 100755 || $4 ~ /\.sh/) print $4 }' > ${format_list}
     shellcheck --severity style --shell sh $(cat ${format_list})
+    rm "${format_list}"
+
+# check a script recipe also using shellcheck
+shellcheck-recipe RECIPE:
+    #!/usr/bin/env sh
+    source=$(mktemp)
+    just -n {{ RECIPE }} 2> "${source}"
+    shellcheck --severity style --shell sh "${source}"
+    rm "${source}"
 
 # below are the mimics of ldmx <cmd>
 # we could think about removing them if folks are happy with committing to the


### PR DESCRIPTION
This simplifies `just init` for newer `denv` users and avoids a confusing error message that is ignored because we immediately follow up a missing workspace with creating the workspace.