### PR TITLE
Use recoil tracking's extrapolated position in EcalVeto

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -194,6 +194,10 @@ recoil_dqm.measurement_collection=digi_recoil.out_collection
 recoil_dqm.truth_hit_collection="RecoilSimHits"
 recoil_dqm.buildHistograms()
 
+# Load ecal veto and use tracking in it
+ecalVeto = ecal_vetos.EcalVetoProcessor()
+ecalVeto.recoil_from_tracking = True
+
 p.sequence.extend([
         digi_tagger,
         digi_recoil,
@@ -204,7 +208,7 @@ p.sequence.extend([
         tracking_recoil,
         ecal_digi.EcalDigiProducer(),
         ecal_digi.EcalRecProducer(), 
-        ecal_vetos.EcalVetoProcessor(),
+        ecalVeto,
         hcal_digi.HcalDigiProducer(),
         hcal_digi.HcalRecProducer(),
         *ts_digis,

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -20,16 +20,7 @@
 #include "TVector3.h"
 
 // For recoil tracking
-// #include "Tracking/Event/Track.h"
-#pragma once
-
-#include "Framework/Configure/Parameters.h"
-#include "Framework/Event.h"
-#include "Framework/EventProcessor.h"
-#include "SimCore/Event/SimTrackerHit.h"
-#include "Tracking/Event/Measurement.h"
 #include "Tracking/Event/Track.h"
-#include "Tracking/Event/TruthTrack.h"
 
 // C++
 #include <map>
@@ -121,9 +112,9 @@ class EcalVetoProcessor : public framework::Producer {
    * @param[in] ts_title The track state title, most likely "ecal"
    * @returns Vector of parameters for a propagated recoil track
    */
-  std::vector<float> trackProp(const ldmx::Tracks& tracks, 
-                             ldmx::TrackStateType ts_type,
-                             const std::string& ts_title);
+  std::vector<float> trackProp(const ldmx::Tracks& tracks,
+                               ldmx::TrackStateType ts_type,
+                               const std::string& ts_title);
 
  private:
   std::map<ldmx::EcalID, float> cellMap_;
@@ -183,7 +174,6 @@ class EcalVetoProcessor : public framework::Producer {
   std::string rec_coll_name_;
   bool recoil_from_tracking_;
   std::string track_collection_;
-  
 
   /** Name of the collection which will containt the results. */
   std::string collectionName_{"EcalVeto"};

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -19,6 +19,18 @@
 // ROOT (MIP tracking)
 #include "TVector3.h"
 
+// For recoil tracking
+// #include "Tracking/Event/Track.h"
+#pragma once
+
+#include "Framework/Configure/Parameters.h"
+#include "Framework/Event.h"
+#include "Framework/EventProcessor.h"
+#include "SimCore/Event/SimTrackerHit.h"
+#include "Tracking/Event/Measurement.h"
+#include "Tracking/Event/Track.h"
+#include "Tracking/Event/TruthTrack.h"
+
 // C++
 #include <map>
 #include <memory>
@@ -102,6 +114,17 @@ class EcalVetoProcessor : public framework::Producer {
    */
   float distPtToLine(TVector3 h1, TVector3 p1, TVector3 p2);
 
+  /**
+   * Return a vector of parameters for a propagated recoil track
+   * @param[in] tracks The track collection
+   * @param[in] ts_type The track state type, i.e. tracks state at the ECAL face
+   * @param[in] ts_title The track state title, most likely "ecal"
+   * @returns Vector of parameters for a propagated recoil track
+   */
+  std::vector<float> trackProp(const ldmx::Tracks& tracks, 
+                             ldmx::TrackStateType ts_type,
+                             const std::string& ts_title);
+
  private:
   std::map<ldmx::EcalID, float> cellMap_;
   std::map<ldmx::EcalID, float> cellMapTightIso_;
@@ -158,6 +181,9 @@ class EcalVetoProcessor : public framework::Producer {
 
   std::string rec_pass_name_;
   std::string rec_coll_name_;
+  bool recoil_from_tracking_;
+  std::string track_collection_;
+  
 
   /** Name of the collection which will containt the results. */
   std::string collectionName_{"EcalVeto"};

--- a/Ecal/python/vetos.py
+++ b/Ecal/python/vetos.py
@@ -25,6 +25,8 @@ class EcalVetoProcessor(ldmxcfg.Producer) :
         self.collection_name = "EcalVeto"
         self.rec_coll_name = 'EcalRecHits'
         self.rec_pass_name = ''
+        self.recoil_from_tracking = False # Will be True soon
+        self.track_collection = 'RecoilTracks'
 
 
 class DNNEcalVetoProcessor(ldmxcfg.Producer) :

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -245,18 +245,18 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   }
   // Get recoilPos using recoil tracking
   if (recoil_from_tracking_) {
-    std::vector<float> recoilTrackStates;
+    std::vector<float> recoil_track_states;
     if (verbose_) {
       ldmx_log(debug) << "   Propagate recoil tracks to ECAL face";
     }
     // Get the recoil track collection
     auto recoil_tracks{event.getCollection<ldmx::Track>(track_collection_)};
 
-    ldmx::TrackStateType tsType = ldmx::TrackStateType::AtECAL;
-    recoilTrackStates = trackProp(recoil_tracks, tsType, "ecal");
+    ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
+    recoil_track_states = trackProp(recoil_tracks, ts_type, "ecal");
     // Redefining recoilPos now to come from the track state
     // track_state_loc0 is recoilPos[0] and track_state_loc1 is recoilPos[1]
-    recoilPos = recoilTrackStates;
+    recoilPos = recoil_track_states;
   }
 
   if (verbose_) {
@@ -1283,10 +1283,10 @@ std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
                                                 ldmx::TrackStateType ts_type,
                                                 const std::string &ts_title) {
   // Vector to hold the new track state variables
-  std::vector<float> newTrackStates;
+  std::vector<float> new_track_states;
 
   // Return if no tracks
-  if (tracks.empty()) return newTrackStates;
+  if (tracks.empty()) return new_track_states;
 
   // Otherwise loop on the tracks
   for (auto &track : tracks) {
@@ -1294,19 +1294,19 @@ std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
     auto trk_ts = track.getTrackState(ts_type);
     // Continue if there's no value
     if (!trk_ts.has_value()) continue;
-    ldmx::Track::TrackState &TargetState = trk_ts.value();
+    ldmx::Track::TrackState &ecal_track_state = trk_ts.value();
 
     // Check that the track state is filled
-    if (TargetState.params.size() < 5) continue;
+    if (ecal_track_state.params.size() < 5) continue;
 
-    float track_state_loc0 = static_cast<float>(TargetState.params[0]);
-    float track_state_loc1 = static_cast<float>(TargetState.params[1]);
+    float track_state_loc0 = static_cast<float>(ecal_track_state.params[0]);
+    float track_state_loc1 = static_cast<float>(ecal_track_state.params[1]);
 
     // Store the new track state variables
-    newTrackStates.push_back(track_state_loc0);
-    newTrackStates.push_back(track_state_loc1);
+    new_track_states.push_back(track_state_loc0);
+    new_track_states.push_back(track_state_loc1);
     // z-position at the ECAL scoring plane
-    newTrackStates.push_back(239.999);
+    new_track_states.push_back(239.999);
 
     // Break after getting the first valid track state
     // TODO: interface this with CLUE to make sure the propageted track
@@ -1314,7 +1314,7 @@ std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
     break;
   }
 
-  return newTrackStates;
+  return new_track_states;
 }
 
 }  // namespace ecal

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -245,12 +245,18 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   }
   // Get recoilPos using recoil tracking
   if (recoil_from_tracking_) {
+    std::vector<float> recoilTrackStates;
+    if (verbose_) {
+      ldmx_log(debug) << "   Propagate recoil tracks to ECAL face";
+    }
+    // Get the recoil track collection
     auto recoil_tracks{event.getCollection<ldmx::Track>(track_collection_)};
-    std::vector<float> recoilTrackStates =
-        trackProp(recoil_tracks, ldmx::TrackStateType::AtECAL, "ecal");
-    // recoilPos defined earlier but redefining now to come from the track state
-    recoilPos[0] = recoilTrackStates[0];  // track_state_loc0
-    recoilPos[1] = recoilTrackStates[1];  // track_state_loc1
+
+    ldmx::TrackStateType tsType = ldmx::TrackStateType::AtECAL;
+    recoilTrackStates = trackProp(recoil_tracks, tsType, "ecal");
+    // Redefining recoilPos now to come from the track state
+    // track_state_loc0 is recoilPos[0] and track_state_loc1 is recoilPos[1]
+    recoilPos = recoilTrackStates;
   }
 
   if (verbose_) {
@@ -258,7 +264,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   }
   // Get projected trajectories for electron and photon
   std::vector<XYCoords> ele_trajectory, photon_trajectory;
-  if (recoilP.size() > 0) {
+  if (!recoilP.empty() && !recoilPos.empty()) {
     ele_trajectory = getTrajectory(recoilP, recoilPos);
     std::vector<double> pvec = recoilPAtTarget.size()
                                    ? recoilPAtTarget
@@ -667,7 +673,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   const float dz_from_face{7.932};
   float drifted_recoil_x{-9999.};
   float drifted_recoil_y{-9999.};
-  if (recoilP.size() > 0) {
+  if (!recoilP.empty()) {
     drifted_recoil_x =
         (dz_from_face * (recoilP[0] / recoilP[2])) + recoilPos[0];
     drifted_recoil_y =
@@ -707,7 +713,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   TVector3 e_traj_end;
   TVector3 p_traj_start;
   TVector3 p_traj_end;
-  if (ele_trajectory.size() > 0 && photon_trajectory.size() > 0) {
+  if (!ele_trajectory.empty() && !photon_trajectory.empty()) {
     // Create TVector3s marking the start and endpoints of each projected
     // trajectory
     e_traj_start.SetXYZ(ele_trajectory[0].first, ele_trajectory[0].second,
@@ -751,8 +757,8 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   // segmipBDT
   firstNearPhLayer_ = nEcalLayers_ - 1;
 
-  if (photon_trajectory.size() !=
-      0) {  // If no photon trajectory, leave this at the default (ECal back)
+  // If no photon trajectory, leave this at the default (ECal back)
+  if (!photon_trajectory.empty()) {
     for (std::vector<HitData>::iterator it = trackingHitList.begin();
          it != trackingHitList.end(); ++it) {
       float ehDist =
@@ -770,7 +776,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   // Territories limited to trackingHitList
   TVector3 gToe = (e_traj_start - p_traj_start).Unit();
   TVector3 origin = p_traj_start + 0.5 * 8.7 * gToe;
-  if (ele_trajectory.size() > 0) {
+  if (!ele_trajectory.empty()) {
     for (auto &hitData : trackingHitList) {
       TVector3 hitPos = hitData.pos;
       TVector3 hitPrime = hitPos - origin;
@@ -1116,6 +1122,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   buildBDTFeatureVector(result);
   ldmx::Ort::FloatArrays inputs({bdtFeatures_});
   float pred = rt_->run({featureListName_}, inputs, {"probabilities"})[0].at(1);
+  ldmx_log(debug) << "  BDT was ran, score is " << pred;
   // Other considerations were (nLinregTracks_ == 0)  && (firstNearPhLayer_ >=
   // 6)
   // && (epAng_ > 3.0 && epAng_ < 900 || epSep_ > 10.0 && epSep_ < 900)
@@ -1278,6 +1285,10 @@ std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
   // Vector to hold the new track state variables
   std::vector<float> newTrackStates;
 
+  // Return if no tracks
+  if (tracks.empty()) return newTrackStates;
+
+  // Otherwise loop on the tracks
   for (auto &track : tracks) {
     // Get track state for ts_type
     auto trk_ts = track.getTrackState(ts_type);
@@ -1294,6 +1305,8 @@ std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
     // Store the new track state variables
     newTrackStates.push_back(track_state_loc0);
     newTrackStates.push_back(track_state_loc1);
+    // z-position at the ECAL scoring plane
+    newTrackStates.push_back(239.999);
 
     // Break after getting the first valid track state
     // TODO: interface this with CLUE to make sure the propageted track

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -13,9 +13,6 @@
 /*~~~~~~~~~~~*/
 #include "Tools/AnalysisUtils.h"
 
-// For recoil tracking
-#include "Tracking/Event/Track.h"
-
 // C++
 #include <stdlib.h>
 
@@ -246,13 +243,14 @@ void EcalVetoProcessor::produce(framework::Event &event) {
       }
     }
   }
-// Get recoilPos using recoil tracking
+  // Get recoilPos using recoil tracking
   if (recoil_from_tracking_) {
     auto recoil_tracks{event.getCollection<ldmx::Track>(track_collection_)};
-    std::vector<float> recoilTrackStates = trackProp(recoil_tracks, ldmx::TrackStateType::AtECAL, "ecal");
+    std::vector<float> recoilTrackStates =
+        trackProp(recoil_tracks, ldmx::TrackStateType::AtECAL, "ecal");
     // recoilPos defined earlier but redefining now to come from the track state
-    recoilPos[0] = recoilTrackStates[0]; // track_state_loc0
-    recoilPos[1] = recoilTrackStates[1]; // track_state_loc1
+    recoilPos[0] = recoilTrackStates[0];  // track_state_loc0
+    recoilPos[1] = recoilTrackStates[1];  // track_state_loc1
   }
 
   if (verbose_) {
@@ -1274,18 +1272,18 @@ float EcalVetoProcessor::distPtToLine(TVector3 h1, TVector3 p1, TVector3 p2) {
   return ((h1 - p1).Cross(h1 - p2)).Mag() / (p1 - p2).Mag();
 }
 
-std::vector<float> trackProp(const ldmx::Tracks& tracks, 
-                             ldmx::TrackStateType ts_type,
-                             const std::string& ts_title) {
+std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
+                                                ldmx::TrackStateType ts_type,
+                                                const std::string &ts_title) {
   // Vector to hold the new track state variables
-  std::vector<float> newTrackStates; 
+  std::vector<float> newTrackStates;
 
-  for (auto& track : tracks) {
+  for (auto &track : tracks) {
     // Get track state for ts_type
     auto trk_ts = track.getTrackState(ts_type);
     // Continue if there's no value
-    if (!trk_ts.has_value()) continue; 
-    ldmx::Track::TrackState& TargetState = trk_ts.value();
+    if (!trk_ts.has_value()) continue;
+    ldmx::Track::TrackState &TargetState = trk_ts.value();
 
     // Check that the track state is filled
     if (TargetState.params.size() < 5) continue;
@@ -1299,13 +1297,12 @@ std::vector<float> trackProp(const ldmx::Tracks& tracks,
 
     // Break after getting the first valid track state
     // TODO: interface this with CLUE to make sure the propageted track
-    //       has an associated cluster in the ECAL 
+    //       has an associated cluster in the ECAL
     break;
   }
 
   return newTrackStates;
 }
-
 
 }  // namespace ecal
 

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -13,6 +13,9 @@
 /*~~~~~~~~~~~*/
 #include "Tools/AnalysisUtils.h"
 
+// For recoil tracking
+#include "Tracking/Event/Track.h"
+
 // C++
 #include <stdlib.h>
 
@@ -132,6 +135,8 @@ void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
   collectionName_ = parameters.getParameter<std::string>("collection_name");
   rec_pass_name_ = parameters.getParameter<std::string>("rec_pass_name");
   rec_coll_name_ = parameters.getParameter<std::string>("rec_coll_name");
+  recoil_from_tracking_ = parameters.getParameter<bool>("recoil_from_tracking");
+  track_collection_ = parameters.getParameter<std::string>("track_collection");
 }
 
 void EcalVetoProcessor::clearProcessor() {
@@ -240,6 +245,14 @@ void EcalVetoProcessor::produce(framework::Event &event) {
         }
       }
     }
+  }
+// Get recoilPos using recoil tracking
+  if (recoil_from_tracking_) {
+    auto recoil_tracks{event.getCollection<ldmx::Track>(track_collection_)};
+    std::vector<float> recoilTrackStates = trackProp(recoil_tracks, ldmx::TrackStateType::AtECAL, "ecal");
+    // recoilPos defined earlier but redefining now to come from the track state
+    recoilPos[0] = recoilTrackStates[0]; // track_state_loc0
+    recoilPos[1] = recoilTrackStates[1]; // track_state_loc1
   }
 
   if (verbose_) {
@@ -1260,6 +1273,39 @@ float EcalVetoProcessor::distTwoLines(TVector3 v1, TVector3 v2, TVector3 w1,
 float EcalVetoProcessor::distPtToLine(TVector3 h1, TVector3 p1, TVector3 p2) {
   return ((h1 - p1).Cross(h1 - p2)).Mag() / (p1 - p2).Mag();
 }
+
+std::vector<float> trackProp(const ldmx::Tracks& tracks, 
+                             ldmx::TrackStateType ts_type,
+                             const std::string& ts_title) {
+  // Vector to hold the new track state variables
+  std::vector<float> newTrackStates; 
+
+  for (auto& track : tracks) {
+    // Get track state for ts_type
+    auto trk_ts = track.getTrackState(ts_type);
+    // Continue if there's no value
+    if (!trk_ts.has_value()) continue; 
+    ldmx::Track::TrackState& TargetState = trk_ts.value();
+
+    // Check that the track state is filled
+    if (TargetState.params.size() < 5) continue;
+
+    float track_state_loc0 = static_cast<float>(TargetState.params[0]);
+    float track_state_loc1 = static_cast<float>(TargetState.params[1]);
+
+    // Store the new track state variables
+    newTrackStates.push_back(track_state_loc0);
+    newTrackStates.push_back(track_state_loc1);
+
+    // Break after getting the first valid track state
+    // TODO: interface this with CLUE to make sure the propageted track
+    //       has an associated cluster in the ECAL 
+    break;
+  }
+
+  return newTrackStates;
+}
+
 
 }  // namespace ecal
 

--- a/Ecal/src/Ecal/Event/EcalVetoResult.cxx
+++ b/Ecal/src/Ecal/Event/EcalVetoResult.cxx
@@ -170,6 +170,8 @@ void EcalVetoResult::setVariables(
     recoilPx_ = recoilP[0];
     recoilPy_ = recoilP[1];
     recoilPz_ = recoilP[2];
+  }
+  if (!recoilPos.empty()) {
     recoilX_ = recoilPos[0];
     recoilY_ = recoilPos[1];
   }


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1494

Introduced `recoil_from_tracking_` boolean, which if switched on will propagate the recoil track to the ECAL face and use that to make the projections.
For now I kept the default boolean False, and switched it on for the ecalPN sample, where we run the tracking anyway. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Unfortunately the ecalPN sample we have did not save the tracking simhits so I cannot rerun tracking on with.
I ran on the kaon samples tho which did keep the hits. I'll show the results at the SWAN meeting on Monday.


Much of this work was done by @JYoo001 who also made plots quantifying the distance between the projected and real positions in the ECAL (this we showed at a tracking meeting)