### PR TITLE
Missing argument in just debug

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ fire config_py *ARGS:
 # run gdb on a config file
 [no-cd]
 debug config_py *ARGS:
-    denv gdb fire {{ config_py }} {{ ARGS }}
+    denv gdb --args fire {{ config_py }} {{ ARGS }}
 
 # initialize a containerized development environment
 init:


### PR DESCRIPTION
### What are the issues that this addresses?
"just debug" passes cmd line arguments, such as the config file name, into gdb instead of into fire. This is shown by the following two examples:
```
>>>just debug config.py
[...]
Reading symbols from fire...
"/home/ewallin/Programming/justbug/ldmx-sw/build/config.py" is not a core dump: file format not recognized
```

```
>>>just debug config.py --nevents 5
denv gdb fire config.py --nevents 5
gdb: unrecognized option '--nevents'
Use `gdb --help' for a complete list of options.
error: Recipe `debug` failed on line 100 with exit code 1
```

## Check List
- [X ] I successfully compiled _ldmx-sw_ with my developments
- [ X] I ran my developments and the following shows that they are successful.

 Now
```
>>>just debug config.py
>>>just debug config.py --nevents 5
```
both make it to the gdb prompt without complaint, and can run fire with the intended passed arguments :) 