### PR TITLE
Optionally save HCalDigis in every readout channel

### DIFF
--- a/Hcal/include/Hcal/HcalDigiProducer.h
+++ b/Hcal/include/Hcal/HcalDigiProducer.h
@@ -86,7 +86,7 @@ class HcalDigiProducer : public framework::Producer {
 
   /// If false, save digis from all channels, even pure noise in empty bars
   /// Helpful when comparing with test beam data
-  bool zeroSuppression_;
+  bool zeroSuppression_{true};
 
   /// Hgcroc Emulator to digitize analog voltage signals
   std::unique_ptr<ldmx::HgcrocEmulator> hgcroc_;

--- a/Hcal/include/Hcal/HcalDigiProducer.h
+++ b/Hcal/include/Hcal/HcalDigiProducer.h
@@ -84,6 +84,10 @@ class HcalDigiProducer : public framework::Producer {
   /// development
   bool noise_{true};
 
+  /// Save digis from all channels, even pure noise in empty bars
+  /// Helpful when comparing with test beam data
+  bool digitizeAllChannels_;
+
   /// Hgcroc Emulator to digitize analog voltage signals
   std::unique_ptr<ldmx::HgcrocEmulator> hgcroc_;
 

--- a/Hcal/include/Hcal/HcalDigiProducer.h
+++ b/Hcal/include/Hcal/HcalDigiProducer.h
@@ -84,9 +84,9 @@ class HcalDigiProducer : public framework::Producer {
   /// development
   bool noise_{true};
 
-  /// Save digis from all channels, even pure noise in empty bars
+  /// If false, save digis from all channels, even pure noise in empty bars
   /// Helpful when comparing with test beam data
-  bool digitizeAllChannels_;
+  bool zeroSuppression_;
 
   /// Hgcroc Emulator to digitize analog voltage signals
   std::unique_ptr<ldmx::HgcrocEmulator> hgcroc_;

--- a/Hcal/python/digi.py
+++ b/Hcal/python/digi.py
@@ -93,7 +93,11 @@ class HcalDigiProducer(Producer) :
         self.avgPedestal = 1. #noise config only
         # avg noise set to 0.02PE
         self.avgNoiseRMS = self.hgcroc.calculateVoltageHcal(0.02)/self.avgGain
-        
+
+        # digitize every channel, by not dropping any pulses
+        # to e.g. simulate a pedestal measurement
+        self.digitizeAllChannels = False
+
         # input and output collection name parameters
         self.inputCollName = 'HcalSimHits'
         self.inputPassName = ''

--- a/Hcal/python/digi.py
+++ b/Hcal/python/digi.py
@@ -94,9 +94,9 @@ class HcalDigiProducer(Producer) :
         # avg noise set to 0.02PE
         self.avgNoiseRMS = self.hgcroc.calculateVoltageHcal(0.02)/self.avgGain
 
-        # digitize every channel, by not dropping any pulses
+        # If false, digitize every channel, by not dropping any pulses
         # to e.g. simulate a pedestal measurement
-        self.digitizeAllChannels = False
+        self.zeroSuppression = True
 
         # input and output collection name parameters
         self.inputCollName = 'HcalSimHits'

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -37,7 +37,7 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
 
   // If true, ignore readout threshold
   // and generate pedestal noise digis in every empty channel
-  digitizeAllChannels_ = ps.getParameter<bool>("digitizeAllChannels");
+  zeroSuppression_ = ps.getParameter<bool>("zeroSuppression");
 
   // collection names
   inputCollName_ = ps.getParameter<std::string>("inputCollName");
@@ -258,13 +258,13 @@ void HcalDigiProducer::produce(framework::Event& event) {
       bool negEndActivity =
           hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend);
 
-      if (posEndActivity && negEndActivity && !digitizeAllChannels_) {
+      if (posEndActivity && negEndActivity && zeroSuppression_) {
         hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
         hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
-      }  // If not digitizeAllChannels == true, Back Hcal needs to digitize both
+      }  // If zeroSuppression == true, Back Hcal needs to digitize both
          // pulses or none
 
-      if (digitizeAllChannels_) {
+      if (!zeroSuppression_) {
         if (posEndActivity) {
           hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
         } else {
@@ -295,7 +295,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
         ldmx::HcalDigiID digiID(section, layer, strip, 0);
         if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
-        } else if (digitizeAllChannels_) {
+        } else if (!zeroSuppression_) {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
               hgcroc_->noiseDigi(digiID.raw(), 0.0);
           hcalDigis.addDigi(digiID.raw(), digi);
@@ -304,7 +304,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
         ldmx::HcalDigiID digiID(section, layer, strip, 1);
         if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
-        } else if (digitizeAllChannels_) {
+        } else if (!zeroSuppression_) {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
               hgcroc_->noiseDigi(digiID.raw(), 0.0);
           hcalDigis.addDigi(digiID.raw(), digi);
@@ -342,7 +342,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
       }
     }
 
-    if (!digitizeAllChannels_) {  // Fast noise sim
+    if (zeroSuppression_) {  // Fast noise sim
       int numEmptyChannels = numChannels - hcalDigis.getNumDigis();
       // noise generator gives us a list of noise amplitudes [mV] that randomly
       // populate the empty channels and are above the readout threshold
@@ -404,7 +404,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
           }
         }
       }       // loop over noise amplitudes
-    } else {  // If digitizeAllChannels_ == true, add noise digis for all bars
+    } else {  // If zeroSuppression_ == false, add noise digis for all bars
               // without simhits
       for (auto digiID : channelMap) {
         // Convert from digi ID to det ID (since simhits don't know about

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -293,15 +293,23 @@ void HcalDigiProducer::produce(framework::Event& event) {
       }
       if (is_posend) {
         ldmx::HcalDigiID digiID(section, layer, strip, 0);
-        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd) or
-            digitizeAllChannels_) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
+        }
+        else if(digitizeAllChannels_){
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
+              hgcroc_->noiseDigi(digiID.raw(), 0.0);
+          hcalDigis.addDigi(digiID.raw(), digi);
         }
       } else {
         ldmx::HcalDigiID digiID(section, layer, strip, 1);
-        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd) or
-            digitizeAllChannels_) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
+        }
+        else if(digitizeAllChannels_){
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
+              hgcroc_->noiseDigi(digiID.raw(), 0.0);
+          hcalDigis.addDigi(digiID.raw(), digi);
         }
       }
     }

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -295,8 +295,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
         ldmx::HcalDigiID digiID(section, layer, strip, 0);
         if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
-        }
-        else if(digitizeAllChannels_){
+        } else if (digitizeAllChannels_) {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
               hgcroc_->noiseDigi(digiID.raw(), 0.0);
           hcalDigis.addDigi(digiID.raw(), digi);
@@ -305,8 +304,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
         ldmx::HcalDigiID digiID(section, layer, strip, 1);
         if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd)) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
-        }
-        else if(digitizeAllChannels_){
+        } else if (digitizeAllChannels_) {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
               hgcroc_->noiseDigi(digiID.raw(), 0.0);
           hcalDigis.addDigi(digiID.raw(), digi);

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -35,6 +35,10 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
   iSOI_ = hgcrocParams.getParameter<int>("iSOI");
   noise_ = hgcrocParams.getParameter<bool>("noise");
 
+  //If true, ignore readout threshold
+  //and generate pedestal noise digis in every empty channel
+  digitizeAllChannels_ = ps.getParameter<bool>("digitizeAllChannels");
+
   // collection names
   inputCollName_ = ps.getParameter<std::string>("inputCollName");
   inputPassName_ = ps.getParameter<std::string>("inputPassName");
@@ -62,6 +66,7 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
 }
 
 void HcalDigiProducer::produce(framework::Event& event) {
+
   // Handle seeding on the first event
   if (!noiseGenerator_->hasSeed()) {
     const auto& rseed = getCondition<framework::RandomNumberSeedService>(
@@ -248,8 +253,8 @@ void HcalDigiProducer::produce(framework::Event& event) {
           digiToAddNegend;
       ldmx::HcalDigiID posendID(section, layer, strip, 0);
       ldmx::HcalDigiID negendID(section, layer, strip, 1);
-      if (hgcroc_->digitize(posendID.raw(), pulses_posend, digiToAddPosend) &&
-          hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend)) {
+      if ((hgcroc_->digitize(posendID.raw(), pulses_posend, digiToAddPosend) &&
+          hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend)) or digitizeAllChannels_) {
         hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
         hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
       }  // Back Hcal needs to digitize both pulses or none
@@ -265,12 +270,12 @@ void HcalDigiProducer::produce(framework::Event& event) {
       }
       if (is_posend) {
         ldmx::HcalDigiID digiID(section, layer, strip, 0);
-        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd)) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd) or digitizeAllChannels_) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
         }
       } else {
         ldmx::HcalDigiID digiID(section, layer, strip, 1);
-        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd)) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd) or digitizeAllChannels_) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
         }
       }
@@ -281,80 +286,103 @@ void HcalDigiProducer::produce(framework::Event& event) {
    * Noise Simulation on Empty Channels
    *****************************************************************************************/
   if (noise_) {
+
+    std::vector<ldmx::HcalDigiID> channelMap;
     int numChannels = 0;
     for (int section = 0; section < hcalGeometry.getNumSections(); section++) {
       int numChannelsInSection = 0;
-      for (int layer = 1; layer <= hcalGeometry.getNumLayers(section);
-           layer++) {
+      for (int layer = 1; layer <= hcalGeometry.getNumLayers(section); layer++) {
         numChannelsInSection += hcalGeometry.getNumStrips(section, layer);
+        for (int strip = 1; strip <= hcalGeometry.getNumStrips(section, layer); strip++){
+          if (section == ldmx::HcalID::HcalSection::BACK ) {
+            auto detIDend0 = ldmx::HcalDigiID(section, layer, strip, 0);
+            auto detIDend1 = ldmx::HcalDigiID(section, layer, strip, 1);
+            channelMap.push_back(detIDend0);
+            channelMap.push_back(detIDend1);
+            numChannels += 2;
+          }
+          else{
+            auto detID = ldmx::HcalDigiID(section, layer, strip, 0);
+            channelMap.push_back(detID);
+            numChannels++;
+          }
+        }
       }
-      // for back Hcal we have double readout, therefore we multiply the number
-      // of channels by 2.
-      if (section == ldmx::HcalID::HcalSection::BACK) {
-        numChannelsInSection *= 2;
-      }
-      numChannels += numChannelsInSection;
     }
-    int numEmptyChannels = numChannels - hcalDigis.getNumDigis();
-    // noise generator gives us a list of noise amplitudes [mV] that randomly
-    // populate the empty channels and are above the readout threshold
-    auto noiseHitAmplitudes{
-        noiseGenerator_->generateNoiseHits(numEmptyChannels)};
-    std::vector<std::pair<double, double>> fake_pulse(1, {0., 0.});
-    for (double noiseHit : noiseHitAmplitudes) {
-      // generate detector ID for noise hit
-      // making sure that it is in an empty channel
-      unsigned int noiseID;
-      int sectionID, layerID, stripID, endID;
-      do {
-        sectionID = noiseInjector_->Integer(hcalGeometry.getNumSections());
-        layerID = noiseInjector_->Integer(hcalGeometry.getNumLayers(sectionID));
-        // set layer to 1 if the generator says it is 0 (geometry map starts
-        // from 1)
-        if (layerID == 0) layerID = 1;
-        stripID = noiseInjector_->Integer(
-            hcalGeometry.getNumStrips(sectionID, layerID));
-        endID = noiseInjector_->Integer(2);
-        if ((sectionID == ldmx::HcalID::HcalSection::TOP) ||
-            (sectionID == ldmx::HcalID::HcalSection::LEFT)) {
-          endID = 0;
-        } else if ((sectionID == ldmx::HcalID::HcalSection::BOTTOM) ||
-                   (sectionID == ldmx::HcalID::HcalSection::RIGHT)) {
-          endID = 1;
+
+    if (!digitizeAllChannels_) { //Fast noise sim
+      int numEmptyChannels = numChannels - hcalDigis.getNumDigis();
+      // noise generator gives us a list of noise amplitudes [mV] that randomly
+      // populate the empty channels and are above the readout threshold
+      auto noiseHitAmplitudes{
+          noiseGenerator_->generateNoiseHits(numEmptyChannels)};
+      std::vector<std::pair<double, double>> fake_pulse(1, {0., 0.});
+      for (double noiseHit : noiseHitAmplitudes) {
+        // generate detector ID for noise hit
+        // making sure that it is in an empty channel
+        unsigned int noiseID;
+        int sectionID, layerID, stripID, endID;
+        do {
+          sectionID = noiseInjector_->Integer(hcalGeometry.getNumSections());
+          layerID = noiseInjector_->Integer(hcalGeometry.getNumLayers(sectionID));
+          // set layer to 1 if the generator says it is 0 (geometry map starts
+          // from 1)
+          if (layerID == 0) layerID = 1;
+          stripID = noiseInjector_->Integer(
+              hcalGeometry.getNumStrips(sectionID, layerID));
+          endID = noiseInjector_->Integer(2);
+          if ((sectionID == ldmx::HcalID::HcalSection::TOP) ||
+              (sectionID == ldmx::HcalID::HcalSection::LEFT)) {
+            endID = 0;
+          } else if ((sectionID == ldmx::HcalID::HcalSection::BOTTOM) ||
+                     (sectionID == ldmx::HcalID::HcalSection::RIGHT)) {
+            endID = 1;
+          }
+          auto detID = ldmx::HcalDigiID(sectionID, layerID, stripID, endID);
+          noiseID = detID.raw();
+        } while (hitsByID.find(noiseID) != hitsByID.end());
+        hitsByID[noiseID] =
+            std::vector<const ldmx::SimCalorimeterHit*>();  // mark this as used
+
+        // get a time for this noise hit
+        fake_pulse[0].second = noiseInjector_->Uniform(clockCycle_);
+
+        // noise generator gives the amplitude above the readout threshold
+        // we need to convert it to the amplitude above the pedestal
+        double gain = hgcroc_->gain(noiseID);
+        fake_pulse[0].first = noiseHit +
+                              gain * hgcroc_->readoutThreshold(noiseID) -
+                              gain * hgcroc_->pedestal(noiseID);
+
+        if (sectionID == ldmx::HcalID::HcalSection::BACK) {
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digiToAddPosend,
+              digiToAddNegend;
+          ldmx::HcalDigiID posendID(sectionID, layerID, stripID, 0);
+          ldmx::HcalDigiID negendID(sectionID, layerID, stripID, 1);
+          if (hgcroc_->digitize(posendID.raw(), fake_pulse, digiToAddPosend) &&
+              hgcroc_->digitize(negendID.raw(), fake_pulse, digiToAddNegend)) {
+            hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
+            hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
+          }
+        } else {
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digiToAdd;
+          if (hgcroc_->digitize(noiseID, fake_pulse, digiToAdd)) {
+            hcalDigis.addDigi(noiseID, digiToAdd);
+          }
         }
-        auto detID = ldmx::HcalDigiID(sectionID, layerID, stripID, endID);
-        noiseID = detID.raw();
-      } while (hitsByID.find(noiseID) != hitsByID.end());
-      hitsByID[noiseID] =
-          std::vector<const ldmx::SimCalorimeterHit*>();  // mark this as used
-
-      // get a time for this noise hit
-      fake_pulse[0].second = noiseInjector_->Uniform(clockCycle_);
-
-      // noise generator gives the amplitude above the readout threshold
-      // we need to convert it to the amplitude above the pedestal
-      double gain = hgcroc_->gain(noiseID);
-      fake_pulse[0].first = noiseHit +
-                            gain * hgcroc_->readoutThreshold(noiseID) -
-                            gain * hgcroc_->pedestal(noiseID);
-
-      if (sectionID == ldmx::HcalID::HcalSection::BACK) {
-        std::vector<ldmx::HgcrocDigiCollection::Sample> digiToAddPosend,
-            digiToAddNegend;
-        ldmx::HcalDigiID posendID(sectionID, layerID, stripID, 0);
-        ldmx::HcalDigiID negendID(sectionID, layerID, stripID, 1);
-        if (hgcroc_->digitize(posendID.raw(), fake_pulse, digiToAddPosend) &&
-            hgcroc_->digitize(negendID.raw(), fake_pulse, digiToAddNegend)) {
-          hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
-          hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
-        }
-      } else {
-        std::vector<ldmx::HgcrocDigiCollection::Sample> digiToAdd;
-        if (hgcroc_->digitize(noiseID, fake_pulse, digiToAdd)) {
-          hcalDigis.addDigi(noiseID, digiToAdd);
+      }    // loop over noise amplitudes
+    }
+    else{ //If digitizeAllChannels_ == true, add noise digis for all bars without simhits
+      for (auto digiID : channelMap){
+        //Convert from digi ID to det ID (since simhits don't know about different ends of the bar)
+        ldmx::HcalID detid(digiID.section(), digiID.layer(), digiID.strip());
+        unsigned int rawID = detid.raw();
+        if(hitsByID.find(rawID) == hitsByID.end()){
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi = hgcroc_->noiseDigi(rawID, 0.0);
+          hcalDigis.addDigi(rawID, digi);
         }
       }
-    }  // loop over noise amplitudes
+    }
   }    // if we should add noise
 
   event.add(digiCollName_, hcalDigis);

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -35,8 +35,8 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
   iSOI_ = hgcrocParams.getParameter<int>("iSOI");
   noise_ = hgcrocParams.getParameter<bool>("noise");
 
-  //If true, ignore readout threshold
-  //and generate pedestal noise digis in every empty channel
+  // If true, ignore readout threshold
+  // and generate pedestal noise digis in every empty channel
   digitizeAllChannels_ = ps.getParameter<bool>("digitizeAllChannels");
 
   // collection names
@@ -66,7 +66,6 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
 }
 
 void HcalDigiProducer::produce(framework::Event& event) {
-
   // Handle seeding on the first event
   if (!noiseGenerator_->hasSeed()) {
     const auto& rseed = getCondition<framework::RandomNumberSeedService>(
@@ -254,7 +253,8 @@ void HcalDigiProducer::produce(framework::Event& event) {
       ldmx::HcalDigiID posendID(section, layer, strip, 0);
       ldmx::HcalDigiID negendID(section, layer, strip, 1);
       if ((hgcroc_->digitize(posendID.raw(), pulses_posend, digiToAddPosend) &&
-          hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend)) or digitizeAllChannels_) {
+           hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend)) or
+          digitizeAllChannels_) {
         hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
         hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
       }  // Back Hcal needs to digitize both pulses or none
@@ -270,12 +270,14 @@ void HcalDigiProducer::produce(framework::Event& event) {
       }
       if (is_posend) {
         ldmx::HcalDigiID digiID(section, layer, strip, 0);
-        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd) or digitizeAllChannels_) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_posend, digiToAdd) or
+            digitizeAllChannels_) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
         }
       } else {
         ldmx::HcalDigiID digiID(section, layer, strip, 1);
-        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd) or digitizeAllChannels_) {
+        if (hgcroc_->digitize(digiID.raw(), pulses_negend, digiToAdd) or
+            digitizeAllChannels_) {
           hcalDigis.addDigi(digiID.raw(), digiToAdd);
         }
       }
@@ -286,22 +288,22 @@ void HcalDigiProducer::produce(framework::Event& event) {
    * Noise Simulation on Empty Channels
    *****************************************************************************************/
   if (noise_) {
-
     std::vector<ldmx::HcalDigiID> channelMap;
     int numChannels = 0;
     for (int section = 0; section < hcalGeometry.getNumSections(); section++) {
       int numChannelsInSection = 0;
-      for (int layer = 1; layer <= hcalGeometry.getNumLayers(section); layer++) {
+      for (int layer = 1; layer <= hcalGeometry.getNumLayers(section);
+           layer++) {
         numChannelsInSection += hcalGeometry.getNumStrips(section, layer);
-        for (int strip = 1; strip <= hcalGeometry.getNumStrips(section, layer); strip++){
-          if (section == ldmx::HcalID::HcalSection::BACK ) {
+        for (int strip = 1; strip <= hcalGeometry.getNumStrips(section, layer);
+             strip++) {
+          if (section == ldmx::HcalID::HcalSection::BACK) {
             auto detIDend0 = ldmx::HcalDigiID(section, layer, strip, 0);
             auto detIDend1 = ldmx::HcalDigiID(section, layer, strip, 1);
             channelMap.push_back(detIDend0);
             channelMap.push_back(detIDend1);
             numChannels += 2;
-          }
-          else{
+          } else {
             auto detID = ldmx::HcalDigiID(section, layer, strip, 0);
             channelMap.push_back(detID);
             numChannels++;
@@ -310,7 +312,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
       }
     }
 
-    if (!digitizeAllChannels_) { //Fast noise sim
+    if (!digitizeAllChannels_) {  // Fast noise sim
       int numEmptyChannels = numChannels - hcalDigis.getNumDigis();
       // noise generator gives us a list of noise amplitudes [mV] that randomly
       // populate the empty channels and are above the readout threshold
@@ -324,7 +326,8 @@ void HcalDigiProducer::produce(framework::Event& event) {
         int sectionID, layerID, stripID, endID;
         do {
           sectionID = noiseInjector_->Integer(hcalGeometry.getNumSections());
-          layerID = noiseInjector_->Integer(hcalGeometry.getNumLayers(sectionID));
+          layerID =
+              noiseInjector_->Integer(hcalGeometry.getNumLayers(sectionID));
           // set layer to 1 if the generator says it is 0 (geometry map starts
           // from 1)
           if (layerID == 0) layerID = 1;
@@ -370,20 +373,22 @@ void HcalDigiProducer::produce(framework::Event& event) {
             hcalDigis.addDigi(noiseID, digiToAdd);
           }
         }
-      }    // loop over noise amplitudes
-    }
-    else{ //If digitizeAllChannels_ == true, add noise digis for all bars without simhits
-      for (auto digiID : channelMap){
-        //Convert from digi ID to det ID (since simhits don't know about different ends of the bar)
+      }       // loop over noise amplitudes
+    } else {  // If digitizeAllChannels_ == true, add noise digis for all bars
+              // without simhits
+      for (auto digiID : channelMap) {
+        // Convert from digi ID to det ID (since simhits don't know about
+        // different ends of the bar)
         ldmx::HcalID detid(digiID.section(), digiID.layer(), digiID.strip());
         unsigned int rawID = detid.raw();
-        if(hitsByID.find(rawID) == hitsByID.end()){
-          std::vector<ldmx::HgcrocDigiCollection::Sample> digi = hgcroc_->noiseDigi(rawID, 0.0);
+        if (hitsByID.find(rawID) == hitsByID.end()) {
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
+              hgcroc_->noiseDigi(rawID, 0.0);
           hcalDigis.addDigi(rawID, digi);
         }
       }
     }
-  }    // if we should add noise
+  }  // if we should add noise
 
   event.add(digiCollName_, hcalDigis);
 

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -252,12 +252,35 @@ void HcalDigiProducer::produce(framework::Event& event) {
           digiToAddNegend;
       ldmx::HcalDigiID posendID(section, layer, strip, 0);
       ldmx::HcalDigiID negendID(section, layer, strip, 1);
-      if ((hgcroc_->digitize(posendID.raw(), pulses_posend, digiToAddPosend) &&
-           hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend)) or
-          digitizeAllChannels_) {
+
+      bool posEndActivity =
+          hgcroc_->digitize(posendID.raw(), pulses_posend, digiToAddPosend);
+      bool negEndActivity =
+          hgcroc_->digitize(negendID.raw(), pulses_negend, digiToAddNegend);
+
+      if (posEndActivity && negEndActivity && !digitizeAllChannels_) {
         hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
         hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
-      }  // Back Hcal needs to digitize both pulses or none
+      }  // If not digitizeAllChannels == true, Back Hcal needs to digitize both
+         // pulses or none
+
+      if (digitizeAllChannels_) {
+        if (posEndActivity) {
+          hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
+        } else {
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
+              hgcroc_->noiseDigi(posendID.raw(), 0.0);
+          hcalDigis.addDigi(posendID.raw(), digi);
+        }
+        if (negEndActivity) {
+          hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
+        } else {
+          std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
+              hgcroc_->noiseDigi(negendID.raw(), 0.0);
+          hcalDigis.addDigi(negendID.raw(), digi);
+        }
+      }
+
     } else {
       bool is_posend = false;
       std::vector<ldmx::HgcrocDigiCollection::Sample> digiToAdd;
@@ -295,17 +318,18 @@ void HcalDigiProducer::produce(framework::Event& event) {
       for (int layer = 1; layer <= hcalGeometry.getNumLayers(section);
            layer++) {
         numChannelsInSection += hcalGeometry.getNumStrips(section, layer);
-        for (int strip = 1; strip <= hcalGeometry.getNumStrips(section, layer);
+        // Note zero-indexed strip numbering...
+        for (int strip = 0; strip < hcalGeometry.getNumStrips(section, layer);
              strip++) {
           if (section == ldmx::HcalID::HcalSection::BACK) {
-            auto detIDend0 = ldmx::HcalDigiID(section, layer, strip, 0);
-            auto detIDend1 = ldmx::HcalDigiID(section, layer, strip, 1);
-            channelMap.push_back(detIDend0);
-            channelMap.push_back(detIDend1);
+            auto digiIDend0 = ldmx::HcalDigiID(section, layer, strip, 0);
+            auto digiIDend1 = ldmx::HcalDigiID(section, layer, strip, 1);
+            channelMap.push_back(digiIDend0);
+            channelMap.push_back(digiIDend1);
             numChannels += 2;
           } else {
-            auto detID = ldmx::HcalDigiID(section, layer, strip, 0);
-            channelMap.push_back(detID);
+            auto digiID = ldmx::HcalDigiID(section, layer, strip, 0);
+            channelMap.push_back(digiID);
             numChannels++;
           }
         }
@@ -380,11 +404,11 @@ void HcalDigiProducer::produce(framework::Event& event) {
         // Convert from digi ID to det ID (since simhits don't know about
         // different ends of the bar)
         ldmx::HcalID detid(digiID.section(), digiID.layer(), digiID.strip());
-        unsigned int rawID = detid.raw();
-        if (hitsByID.find(rawID) == hitsByID.end()) {
+        unsigned int rawdetID = detid.raw();
+        if (hitsByID.find(rawdetID) == hitsByID.end()) {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
-              hgcroc_->noiseDigi(rawID, 0.0);
-          hcalDigis.addDigi(rawID, digi);
+              hgcroc_->noiseDigi(digiID.raw(), 0.0);
+          hcalDigis.addDigi(digiID.raw(), digi);
         }
       }
     }


### PR DESCRIPTION
This PR adds a new argument to the HCalDigiProducer, digitizeAllChannels. If true, digis will be saved from every channel, not only in bars with large simhits in them. This mostly just adds a digi with some noise around the pedestal to a lot of channels. If false, as it is by default, then nothing changes from how it worked previously. 

With this change, we can more easily compare MC and data from the test beam. To e.g. find and fit pedestals in the simulated data, so we have the same calibration and analysis chain in both data and MC.  

In a simulation with the HCal prototype geometry, running only the digi producer and the rec hit producer, it becomes 3x slower and produces 13% larger file sizes when enabling this flag.  

Some details: 

- If the HgcrocEmulator produces a digi that doesn't pass above the readout threshold (i.e. when the HgcrocEmulator returns _false_), it is replaced by random noise instead (ignoring whatever small simhit there is in the bar).

- There is a new and optional noise simulation in HcalDigiProducer, that produces noise digis in every bar with no simhits. The ADC in the sample of interest is not treated specially, and may be below the readout threshold. 

- In the rare case where one end of the bar passes over the readout threshold, while the other end does not, the normal digi producer would not produce digis for either end. With this flag enabled, the bar that has some (probably very low) activity gets its digi saved properly, while the other end gets random noise.


## Check List
- [x ] I successfully compiled _ldmx-sw_ with my developments
- [ x] I ran my developments and the following shows that they are successful:

Simulating 1000 events with the prototype geometry yields exactly 384 channels * 1000 events = 384000 saved digis. So, it doesn't seem to be missing any channels or accidentally produce duplicate digis in the same one! 

Here's a plot of the reconstructed pulse amplitudes from MIPs. With digitizeAllChannels = false in red, and = true in blue: 
[NoiseSimulationComparison.pdf](https://github.com/user-attachments/files/18324773/NoiseSimulationComparison.pdf)
Here we see a lot of hits near the pedestal, which is exactly what I wanted :)   
