### PR TITLE
Update Ecal 2nd correction for 8 GeV beam

### DIFF
--- a/Ecal/python/digi.py
+++ b/Ecal/python/digi.py
@@ -198,13 +198,14 @@ class EcalRecProducer(Producer) :
     def v14(self) :
         """Generated for the v14 geometry
 
-        The secondOrderEnergyCorrection is deteremined by generating 1M single 4GeV
+        The secondOrderEnergyCorrection is deteremined by generating 1M single 4GeV or 8GeV
         electron events shot directly into the front of the ECal from immediately upstream.
         The mean of the resulting total recon energy is found by fitting a two-sided normal
         distribution (one mean, a low and high deviation) to the histogram.
         """
 
-        self.secondOrderEnergyCorrection = 4000. / 3940.5;
+        #self.secondOrderEnergyCorrection = 4000. / 3940.5;
+        self.secondOrderEnergyCorrection = 8000. / 7998.3;
         self.layerWeights = [ 
                 2.312, 4.312, 6.522, 7.490, 8.595, 10.253, 10.915, 10.915, 10.915, 10.915, 10.915,
                 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915,
@@ -216,10 +217,10 @@ class EcalRecProducer(Producer) :
         """Generated for the reduced v2 geometry
 
         TODO: The secondOrderEnergyCorrection for this geometry has yet to be calculated,
-        so the v14 secondOrderEnergyCorrection is being used as a placeholder.
+        so unity is being used as a placeholder.
         """
 
-        self.secondOrderEnergyCorrection = 4000. / 3940.5;
+        self.secondOrderEnergyCorrection = 1.;
         self.layerWeights = [ 
                 2.312, 5.417, 9.837, 11.910, 11.910, 11.910
                 ]


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1419

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Ananda ran what's described in the text, 1M gun with 8 GeV, and then the double sides fit. He ran the fit with several sigma ranges, as displayed in the top of this plot
<img width="654" alt="Screenshot 2025-01-10 at 12 59 06" src="https://github.com/user-attachments/assets/e1a66d7c-abf4-45a6-b318-74549653d969" />

Then he printed out the corresponding parameters, left top is 0.5 sigma, and then right bottom is 4 sigma.
<img width="1313" alt="Screenshot 2025-01-10 at 13 02 56" src="https://github.com/user-attachments/assets/5eba5d3b-2739-4e92-9c7c-7fa43763950c" />


 I picked the 1sigma to be consistent with what Tom did in the past, this also has one of the best chi2/ndf values.

I also edited the reduced-ECAL to unity, just so it's going to be easier to measure it when we do it, and also the v14 8 GeV is pretty close to 1 anyway.