### PR TITLE
update default LHE ID for A' to be 1023

### DIFF
--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -11,7 +11,7 @@ start_group Produce Dark Brem Library
 wget https://raw.githubusercontent.com/LDMX-Software/dark-brem-lib-gen/main/env.sh
 source env.sh
 # commented out lines are dbgen's defaults for reference
-dbgen use v4.6
+dbgen use v5.0
 #dbgen cache ${HOME} <- only matters for apptainer/singularity
 #dbgen work /tmp
 #dbgen dest $PWD

--- a/SimCore/src/SimCore/APrimePhysics.cxx
+++ b/SimCore/src/SimCore/APrimePhysics.cxx
@@ -108,7 +108,7 @@ void APrimePhysics::ConstructProcess() {
               model.getParameter<double>("epsilon"), scaling_method_it->second,
               g4db::G4DarkBreMModel::XsecMethod::Auto,
               model.getParameter<double>("max_R_for_full", 50.0),
-              model.getParameter<int>("aprime_lhe_id", 622),
+              model.getParameter<int>("aprime_lhe_id", 1023),
               true,  // always load the library
               model.getParameter<bool>("scale_APrime", false),
               model.getParameter<double>("dist_decay_min", 0.0),


### PR DESCRIPTION
This update then makes the default configuration of the dark brem model (from our point of view) align with the libraries that are produced by v5.0 of dark-brem-lib-gen.

Users can still use earlier versions of dark-brem-lib-gen, but then they will need to change their configuration script to look for the old LHE ID 622 rather than the new one.
```python
mySim.dark_brem.model.aprime_lhe_id = 622
```

This change *does not* alter the PDG ID of the dark photon within our simulation. It will still have the PDG ID of 622 according to Geant4 and the output SimParticle.


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1521 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

When opening this PR as a draft, the signal validation sample action will fail to run because it will be looking for ID 1023 in v4 dark brem libraries where the ID is 622. I'll then edit the CI to use v5 dark brem libraries and then they will succeed when I mark this PR as ready for review.
