### PR TITLE
Move some 'debug' to 'info' and change CI log level to 'info'

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -197,7 +197,7 @@ ecalVeto.recoil_from_tracking = True
 # The Tracking modules produce a lot of helpful messages
 # but (at the debug level) is too much for commiting the gold log
 # into the git working tree on GitHub
-p.logger.termLevel = 0
+p.logger.termLevel = 1
 p.logger.custom(truth_tracking, level = 2)
 p.logger.custom(digi_tagger, level = 2)
 p.logger.custom(digi_recoil, level = 2)

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -193,7 +193,7 @@ ecalVeto.recoil_from_tracking = False
 # The Tracking modules produce a lot of helpful messages
 # but (at the debug level) is too much for commiting the gold log
 # into the git working tree on GitHub
-p.logger.termLevel = 0
+p.logger.termLevel = 1 
 p.logger.custom(truth_tracking, level = 2)
 p.logger.custom(digi_tagger, level = 2)
 p.logger.custom(digi_recoil, level = 2)

--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -225,7 +225,7 @@ count.input_pass_name = ''
 # The Tracking modules produce a lot of helpful messages
 # but (at the debug level) is too much for commiting the gold log
 # into the git working tree on GitHub
-p.logger.termLevel = 0
+p.logger.termLevel = 1
 p.logger.custom(truth_tracking, level = 2)
 p.logger.custom(digi_tagger, level = 2)
 p.logger.custom(digi_recoil, level = 2)

--- a/.github/validation_samples/kaon_enhanced/config.py
+++ b/.github/validation_samples/kaon_enhanced/config.py
@@ -271,7 +271,7 @@ recoil_dqm.buildHistograms()
 # The Tracking modules produce a lot of helpful messages
 # but (at the debug level) is too much for commiting the gold log
 # into the git working tree on GitHub
-p.logger.termLevel = 0
+p.logger.termLevel = 1
 p.logger.custom(truth_tracking, level = 2)
 p.logger.custom(digi_tagger, level = 2)
 p.logger.custom(digi_recoil, level = 2)

--- a/.github/validation_samples/signal/config.py
+++ b/.github/validation_samples/signal/config.py
@@ -197,7 +197,7 @@ ecalVeto.recoil_from_tracking = False
 # The Tracking modules produce a lot of helpful messages
 # but (at the debug level) is too much for commiting the gold log
 # into the git working tree on GitHub
-p.logger.termLevel = 0
+p.logger.termLevel = 1 
 p.logger.custom(truth_tracking, level = 2)
 p.logger.custom(digi_tagger, level = 2)
 p.logger.custom(digi_recoil, level = 2)

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -166,7 +166,7 @@ void EcalProcessFilter::stepping(const G4Step* step) {
       return;
     }
 
-    ldmx_log(debug) << "[ EcalProcessFilter ]: "
+    ldmx_log(info) << "There were "
                     << G4EventManager::GetEventManager()
                            ->GetConstCurrentEvent()
                            ->GetEventID()

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -167,11 +167,11 @@ void EcalProcessFilter::stepping(const G4Step* step) {
     }
 
     ldmx_log(info) << "There were "
-                    << G4EventManager::GetEventManager()
-                           ->GetConstCurrentEvent()
-                           ->GetEventID()
-                    << " Brem photon produced " << secondaries->size()
-                    << " particle via " << processName << " process.";
+                   << G4EventManager::GetEventManager()
+                          ->GetConstCurrentEvent()
+                          ->GetEventID()
+                   << " Brem photon produced " << secondaries->size()
+                   << " particle via " << processName << " process.";
     trackInfo->tagBremCandidate(false);
     trackInfo->setSaveFlag(true);
     trackInfo->tagPNGamma();

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -976,8 +976,8 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   // ------------------------------------------------------
   // Linreg tracking:
   ldmx_log(info) << "Finding linreg tracks from a total of "
-                  << trackingHitList.size() << " hits using a radius of "
-                  << linreg_radius_ << " mm";
+                 << trackingHitList.size() << " hits using a radius of "
+                 << linreg_radius_ << " mm";
 
   for (int iHit = 0; iHit < trackingHitList.size(); iHit++) {
     // Hits being considered at a given time
@@ -1142,7 +1142,8 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   bool passesTrackingVeto = (nStraightTracks_ < 3);
   result.setVetoResult(pred > bdtCutVal_ && passesTrackingVeto);
   result.setDiscValue(pred);
-  ldmx_log(info) << " The pred > bdtCutVal = " << (pred > bdtCutVal_) << " and MIP tracking passed = " << passesTrackingVeto;
+  ldmx_log(info) << " The pred > bdtCutVal = " << (pred > bdtCutVal_)
+                 << " and MIP tracking passed = " << passesTrackingVeto;
 
   // Persist in the event if the recoil ele is fiducial
   result.setFiducial(inside);

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -975,7 +975,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
   // ------------------------------------------------------
   // Linreg tracking:
-  ldmx_log(debug) << "Finding linreg tracks from a total of "
+  ldmx_log(info) << "Finding linreg tracks from a total of "
                   << trackingHitList.size() << " hits using a radius of "
                   << linreg_radius_ << " mm";
 
@@ -1135,14 +1135,14 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   buildBDTFeatureVector(result);
   ldmx::Ort::FloatArrays inputs({bdtFeatures_});
   float pred = rt_->run({featureListName_}, inputs, {"probabilities"})[0].at(1);
-  ldmx_log(debug) << "  BDT was ran, score is " << pred;
+  ldmx_log(info) << " BDT was ran, score is " << pred;
   // Other considerations were (nLinregTracks_ == 0)  && (firstNearPhLayer_ >=
   // 6)
   // && (epAng_ > 3.0 && epAng_ < 900 || epSep_ > 10.0 && epSep_ < 900)
   bool passesTrackingVeto = (nStraightTracks_ < 3);
   result.setVetoResult(pred > bdtCutVal_ && passesTrackingVeto);
   result.setDiscValue(pred);
-  ldmx_log(debug) << " The pred > bdtCutVal = " << (pred > bdtCutVal_);
+  ldmx_log(info) << " The pred > bdtCutVal = " << (pred > bdtCutVal_) << " and MIP tracking passed = " << passesTrackingVeto;
 
   // Persist in the event if the recoil ele is fiducial
   result.setFiducial(inside);

--- a/Recon/src/Recon/ElectronCounter.cxx
+++ b/Recon/src/Recon/ElectronCounter.cxx
@@ -63,8 +63,8 @@ void ElectronCounter::produce(framework::Event& event) {
 
     nElectrons = tracks.size();
     ldmx_log(info) << "Found " << tracks.size()
-                    << " electrons (tracks) using input collection "
-                    << inputColl_ << "_" << inputPassName_;
+                   << " electrons (tracks) using input collection "
+                   << inputColl_ << "_" << inputPassName_;
   }
   // add number of electrons to event header. allow for it to be unset (-1)
   event.getEventHeader().setIntParameter("nElectrons", nElectrons);

--- a/Recon/src/Recon/ElectronCounter.cxx
+++ b/Recon/src/Recon/ElectronCounter.cxx
@@ -62,7 +62,7 @@ void ElectronCounter::produce(framework::Event& event) {
         event.getCollection<ldmx::TrigScintTrack>(inputColl_, inputPassName_);
 
     nElectrons = tracks.size();
-    ldmx_log(debug) << "Found " << tracks.size()
+    ldmx_log(info) << "Found " << tracks.size()
                     << " electrons (tracks) using input collection "
                     << inputColl_ << "_" << inputPassName_;
   }

--- a/Recon/src/Recon/TriggerProcessor.cxx
+++ b/Recon/src/Recon/TriggerProcessor.cxx
@@ -54,7 +54,7 @@ void TriggerProcessor::produce(framework::Event& event) {
     layerESumCut = layerESumCuts_.at(0) + (nElectrons - 1) * beamEnergy_;
 
   ldmx_log(info) << "Got trigger energy cut " << layerESumCut << " for "
-                  << nElectrons << " electrons counted in the event.";
+                 << nElectrons << " electrons counted in the event.";
 
   std::vector<double> layerDigiE(100, 0.0);  // big empty vector..
 
@@ -84,7 +84,7 @@ void TriggerProcessor::produce(framework::Event& event) {
 
   pass = (layerSum <= layerESumCut);
   ldmx_log(info) << "Got trigger energy sum " << layerSum
-                  << "; and decision is pass = " << pass;
+                 << "; and decision is pass = " << pass;
 
   ldmx::TriggerResult result;
   result.set(algoName_, pass, 4);

--- a/Recon/src/Recon/TriggerProcessor.cxx
+++ b/Recon/src/Recon/TriggerProcessor.cxx
@@ -53,7 +53,7 @@ void TriggerProcessor::produce(framework::Event& event) {
   else
     layerESumCut = layerESumCuts_.at(0) + (nElectrons - 1) * beamEnergy_;
 
-  ldmx_log(debug) << "Got trigger energy cut " << layerESumCut << " for "
+  ldmx_log(info) << "Got trigger energy cut " << layerESumCut << " for "
                   << nElectrons << " electrons counted in the event.";
 
   std::vector<double> layerDigiE(100, 0.0);  // big empty vector..
@@ -83,7 +83,7 @@ void TriggerProcessor::produce(framework::Event& event) {
   }
 
   pass = (layerSum <= layerESumCut);
-  ldmx_log(debug) << "Got trigger energy sum " << layerSum
+  ldmx_log(info) << "Got trigger energy sum " << layerSum
                   << "; and decision is pass = " << pass;
 
   ldmx::TriggerResult result;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

This is a further attempt to consolidate the logs in the CI. 
We also agreed that 
`info`: anything event level, e.g. number of tracks in the event, number of HCAL PE, max PE hits information --> i.e. anything that's adding 1 line of output per event into the logs
`debug`: lower than that, i.e. hit level, e.g. hit locations, each tracks momentum, covariance matrices, etc 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

The logs are significantly reduced