### PR TITLE
Persist ldmx-sw version and sha in run header

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -41,12 +41,33 @@ find_package(ROOT 6.16 CONFIG REQUIRED)
 # to generate the dictionary.
 include("${ROOT_DIR}/RootMacros.cmake")
 
-# Execute the command to extract the SHA1 hash of the current git tag. The
-# variable GIT_SHA1 will be set to contain the hash.
-execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE GIT_SHA1)
+# Execute the command to extract the SHA1 hash of the current git tag.
+# 'git' is removed from within the container to discourage opening a shell
+# in the container, so we need to go to some lengths in order to avoid using 'git'
+# The variable GIT_SHA1 will be set to contain the hash.
+set(git_dir "${PROJECT_SOURCE_DIR}/../.git")
+if (NOT IS_DIRECTORY "${git_dir}")
+  # we are a submodule of another project
+  file(READ "${git_dir}" git_dir)
+  string(REGEX REPLACE "^gitdir: " "" git_dir ${git_dir})
+  string(REGEX REPLACE "\n$" "" git_dir ${git_dir})
+endif()
+file(READ "${git_dir}/HEAD" current_ref)
+string(REGEX REPLACE "\n$" "" current_ref ${current_ref})
+if (current_ref MATCHES "^ref:.*$")
+  # on a branch
+  string(REGEX REPLACE "^ref: " "" current_ref "${current_ref}")
+  file(READ "${git_dir}/${current_ref}" GIT_SHA1)
+  string(REGEX REPLACE "\n$" "" GIT_SHA1 ${GIT_SHA1})
+else()
+  # in detached head state (probably on a tag)
+  set(GIT_SHA1 ${current_ref})
+endif()
+message(STATUS "Deduced git SHA: ${GIT_SHA1}")
 
-# Remove the newline character
-string(REGEX REPLACE "\n$" "" GIT_SHA1 "${GIT_SHA1}")
+# Include ldmx-sw version in the Run Header
+file(READ ${PROJECT_SOURCE_DIR}/../.github/actions/validate/gold_label LDMXSW_VERSION)
+string(STRIP "${LDMXSW_VERSION}" LDMXSW_VERSION)
 
 # Copies the file 'Version.h.in', substitutes the value of GIT_SHA1 and writes
 # it out to Version.h.

--- a/Framework/include/Framework/RunHeader.h
+++ b/Framework/include/Framework/RunHeader.h
@@ -50,6 +50,9 @@ namespace ldmx {
  * the user somehow gets into the situation of reading a v4 RunHeader with v3
  * software, the numTries_ member is quietly ignored, maintaining the format of
  * the v3 RunHeader in the resulting output file.
+ *
+ * ## v5
+ * Include a member to track the ldmx-sw version
  */
 class RunHeader {
  public:
@@ -84,6 +87,11 @@ class RunHeader {
    * to generate this file.
    */
   const std::string &getSoftwareTag() const { return softwareTag_; }
+
+  /**
+   * @return The ldmx-sw version used to generate this file
+   */
+  const std::string &getLdmxswVersion() const { return ldmxsw_version_; }
 
   /** @return A short description of the run. */
   const std::string &getDescription() const { return description_; }
@@ -281,6 +289,11 @@ class RunHeader {
    */
   std::string softwareTag_{GIT_SHA1};
 
+  /**
+   * ldmx-sw software version
+   */
+  std::string ldmxsw_version_{LDMXSW_VERSION};
+
   /** Map of int parameters. */
   std::map<std::string, int> intParameters_;
 
@@ -290,7 +303,7 @@ class RunHeader {
   /** Map of string parameters. */
   std::map<std::string, std::string> stringParameters_;
 
-  ClassDef(RunHeader, 4);
+  ClassDef(RunHeader, 5);
 
 };  // RunHeader
 

--- a/Framework/include/Framework/Version.h.in
+++ b/Framework/include/Framework/Version.h.in
@@ -4,6 +4,7 @@
  *        software related constants e.g. git SHA-1. 
  * @author Omar Moreno, SLAC National Accelerator Laboratory
  * @author Tom Eichlersmith, University of Minnesota
+ * @author Tamas Almos Vami (UCSB), added LDMXSW_VERSION
  */
 
 #ifndef _EVENT_VERSION_H_
@@ -20,6 +21,11 @@ namespace ldmx {
  * The git commit sha for this installation of ldmx-sw
  */
 #define GIT_SHA1 "${GIT_SHA1}"
+
+/**
+ * ldmx-sw version
+ */
+#define LDMXSW_VERSION "${LDMXSW_VERSION}"
 
 }
 

--- a/SimCore/src/SimCore/Simulator.cxx
+++ b/SimCore/src/SimCore/Simulator.cxx
@@ -113,6 +113,7 @@ void Simulator::beforeNewRun(ldmx::RunHeader& header) {
                       "G4 Version string.";
   }
 
+  header.setStringParameter("ldmx-sw version", LDMXSW_VERSION);
   header.setStringParameter("ldmx-sw revision", GIT_SHA1);
 }
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves https://github.com/LDMX-Software/ldmx-sw/issues/1538

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I ran
```
just setenv LDMX_NUM_EVENTS=1
just setenv LDMX_RUN_NUMBER=1
just fire  .github/validation_samples/inclusive/config.py
```
and then
```
just fire my_ana.py events.root 
```
and got
```
[tamasvami@sdfiana007 ldmx-sw]$ just fire my_ana.py events.root 
denv fire my_ana.py events.root
---- LDMXSW: Loading configuration --------
['events.root']
---- LDMXSW: Configuration load complete  --------
---- LDMXSW: Starting event processing --------
ldmx-sw version = v4.2.5
ldmx-sw sha = 0987a39511a7a1a70ec2d11c53521468ba805182
```


Where `my_ana.py` and `MyAna.cxx` are in the details below.

<details>

```
import os
import sys
fileIn = sys.argv[1:]
fileName =  " ".join(sys.argv[1:])

from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('myAna')

import LDMX.Ecal.ecal_hardcoded_conditions
from LDMX.Ecal import EcalGeometry
from LDMX.Hcal import hcal
from LDMX.Ecal import vetos

p.maxEvents = -1
p.run = 2

print(fileIn)
p.inputFiles  = fileIn
p.histogramFile = "myHistoOnEventFile.root"


myAna = ldmxcfg.Analyzer.from_file('MyAna.cxx')


p.sequence = [myAna]
```
and `MyAna.cxx` is
```
#include "Framework/EventProcessor.h"

#include <math.h>

class MyAna : public framework::Analyzer {
public:
  MyAna(const std::string& name, framework::Process& p)
  : framework::Analyzer(name, p) {}
  ~MyAna() = default;
  void onNewRun(const ldmx::RunHeader& rh);
  void analyze(const framework::Event& event) final;
};


void MyAna::onNewRun(const ldmx::RunHeader& runHeader) {
   std::cout << "ldmx-sw version = " << runHeader.getLdmxswVersion() << std::endl;
   std::cout << "ldmx-sw sha = " << runHeader.getSoftwareTag() << std::endl;
}

void MyAna::analyze(const framework::Event& event) {}

DECLARE_ANALYZER(MyAna);
```

</details>