### PR TITLE
Add hcal veto to reduced ldmx CI

### DIFF
--- a/.github/validation_samples/reduced_ldmx/config.py
+++ b/.github/validation_samples/reduced_ldmx/config.py
@@ -62,6 +62,10 @@ from LDMX.Recon.simpleTrigger import TriggerProcessor
 count = ElectronCounter(1,'ElectronCounter')
 count.input_pass_name = ''
 
+# Load hcal veto
+import LDMX.Hcal.hcal as hcal
+hcal_veto = hcal.HcalVetoProcessor()
+
 from LDMX.DQM import dqm
 
 p.sequence.extend([
@@ -70,6 +74,7 @@ p.sequence.extend([
         ecalVeto,
         hcal_digi.HcalDigiProducer(),
         hcal_digi.HcalRecProducer(),
+        hcal_veto,
         *ts_digis,
         TrigScintClusterProducer.pad1(),
         TrigScintClusterProducer.pad2(),


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

After https://github.com/LDMX-Software/ldmx-sw/pull/1541 the CI fails (as it should)
but I didnt realize that will mean we cant build patch releases until one of the CIs is failing, see
https://github.com/LDMX-Software/ldmx-sw/actions/runs/13021076970

So this PR is going to fix that, then we can cut a patch release...

## Check List
- [ ] I successfully compiled _ldmx-sw_ with my developments
- [ ] I ran my developments and the following shows that they are successful.