### PR TITLE
include VERSION in ldmx-sw package for PR validation

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -39,7 +39,7 @@ jobs:
       shell: bash
 
     - name: Package ldmx-sw Into Artifact
-      run: tar cf ldmx-sw-package.tar install/ .github/
+      run: tar cf ldmx-sw-package.tar install/ .github/ VERSION
 
     - name: Upload ldmx-sw Package
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
the VERSION file is shipped with the gold that it originates from so that we can deduce a label for the reference histograms in the plots.


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1552 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
