### PR TITLE
Inverse skimming in vetos

### DIFF
--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -175,6 +175,7 @@ class EcalVetoProcessor : public framework::Producer {
   std::string rec_coll_name_;
   bool recoil_from_tracking_;
   std::string track_collection_;
+  bool inverse_skim_{false};
 
   /** Name of the collection which will containt the results. */
   std::string collectionName_{"EcalVeto"};

--- a/Ecal/python/vetos.py
+++ b/Ecal/python/vetos.py
@@ -28,6 +28,7 @@ class EcalVetoProcessor(ldmxcfg.Producer) :
         self.rec_pass_name = ''
         self.recoil_from_tracking = False # Will be True soon
         self.track_collection = 'RecoilTracks'
+        self.inverse_skim = False
 
 
 class DNNEcalVetoProcessor(ldmxcfg.Producer) :

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -135,6 +135,7 @@ void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
   rec_coll_name_ = parameters.getParameter<std::string>("rec_coll_name");
   recoil_from_tracking_ = parameters.getParameter<bool>("recoil_from_tracking");
   track_collection_ = parameters.getParameter<std::string>("track_collection");
+  inverse_skim_ = parameters.getParameter<bool>("inverse_skim");
 }
 
 void EcalVetoProcessor::clearProcessor() {
@@ -1150,10 +1151,17 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
   // If the event passes the veto, keep it. Otherwise,
   // drop the event.
-  if (result.passesVeto()) {
+  if (result.passesVeto() && !inverse_skim_) {
     setStorageHint(framework::hint_shouldKeep);
   } else {
     setStorageHint(framework::hint_shouldDrop);
+  }
+
+  // Invert the skimming logic
+  if (result.passesVeto() && inverse_skim_) {
+    setStorageHint(framework::hint_shouldDrop);
+  } else {
+    setStorageHint(framework::hint_shouldKeep);
   }
 
   event.add(collectionName_, result);

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -1151,17 +1151,19 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
   // If the event passes the veto, keep it. Otherwise,
   // drop the event.
-  if (result.passesVeto() && !inverse_skim_) {
-    setStorageHint(framework::hint_shouldKeep);
+  if (!inverse_skim_) {
+    if (result.passesVeto()) {
+      setStorageHint(framework::hint_shouldKeep);
+    } else {
+      setStorageHint(framework::hint_shouldDrop);
+    }
   } else {
-    setStorageHint(framework::hint_shouldDrop);
-  }
-
-  // Invert the skimming logic
-  if (result.passesVeto() && inverse_skim_) {
-    setStorageHint(framework::hint_shouldDrop);
-  } else {
-    setStorageHint(framework::hint_shouldKeep);
+    // Invert the skimming logic
+    if (result.passesVeto()) {
+      setStorageHint(framework::hint_shouldDrop);
+    } else {
+      setStorageHint(framework::hint_shouldKeep);
+    }
   }
 
   event.add(collectionName_, result);

--- a/Hcal/include/Hcal/HcalVetoProcessor.h
+++ b/Hcal/include/Hcal/HcalVetoProcessor.h
@@ -93,6 +93,7 @@ class HcalVetoProcessor : public framework::Producer {
   bool exclude_recoil_ele_;
   std::string track_collection_;
   float dr_from_recoil_max_;
+  bool inverse_skim_{false};
 };  // HcalVetoProcessor
 }  // namespace hcal
 

--- a/Hcal/python/hcal.py
+++ b/Hcal/python/hcal.py
@@ -22,6 +22,7 @@ class HcalVetoProcessor(ldmxcfg.Producer) :
         self.input_hit_coll_name= "HcalRecHits";
         self.input_hit_pass_name = ''
         self.output_coll_name= "HcalVeto";
+        self.inverse_skim = False;
 
 class HcalWABVetoProcessor(ldmxcfg.Producer) :
     """Configuration for WAB veto in HCal

--- a/Hcal/src/Hcal/HcalVetoProcessor.cxx
+++ b/Hcal/src/Hcal/HcalVetoProcessor.cxx
@@ -55,6 +55,7 @@ void HcalVetoProcessor::configure(framework::config::Parameters &parameters) {
       parameters.getParameter<std::string>("track_collection", "RecoilTracks");
   dr_from_recoil_max_ =
       parameters.getParameter<double>("dr_from_recoil_max", 100);
+  inverse_skim_ = parameters.getParameter<bool>("inverse_skim");
 }
 
 void HcalVetoProcessor::produce(framework::Event &event) {
@@ -176,10 +177,18 @@ void HcalVetoProcessor::produce(framework::Event &event) {
   result.setTotalPE(total_PE);
   result.setNumValidHits(num_valid_hits);
 
-  if (passes_veto) {
+  // Skimming rules
+  if (passes_veto && !inverse_skim_) {
     setStorageHint(framework::hint_shouldKeep);
   } else {
     setStorageHint(framework::hint_shouldDrop);
+  }
+
+  // Inverse skimming rules
+  if (passes_veto && inverse_skim_) {
+    setStorageHint(framework::hint_shouldDrop);
+  } else {
+    setStorageHint(framework::hint_shouldKeep);
   }
 
   event.add(output_coll_name_, result);

--- a/Hcal/src/Hcal/HcalVetoProcessor.cxx
+++ b/Hcal/src/Hcal/HcalVetoProcessor.cxx
@@ -178,17 +178,19 @@ void HcalVetoProcessor::produce(framework::Event &event) {
   result.setNumValidHits(num_valid_hits);
 
   // Skimming rules
-  if (passes_veto && !inverse_skim_) {
-    setStorageHint(framework::hint_shouldKeep);
+  if (!inverse_skim_) {
+    if (passes_veto) {
+      setStorageHint(framework::hint_shouldKeep);
+    } else {
+      setStorageHint(framework::hint_shouldDrop);
+    }
   } else {
-    setStorageHint(framework::hint_shouldDrop);
-  }
-
-  // Inverse skimming rules
-  if (passes_veto && inverse_skim_) {
-    setStorageHint(framework::hint_shouldDrop);
-  } else {
-    setStorageHint(framework::hint_shouldKeep);
+    // Inverse skimming rules
+    if (passes_veto) {
+      setStorageHint(framework::hint_shouldDrop);
+    } else {
+      setStorageHint(framework::hint_shouldKeep);
+    }
   }
 
   event.add(output_coll_name_, result);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1561

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
I ran a skim and it contains events that failed the HCAL veto
