### PR TITLE
Exit CKF processor early if conditions are not met

### DIFF
--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -547,7 +547,17 @@ void CKFProcessor::produce(framework::Event& event) {
       trk.setMomentum(track.momentum()[0], track.momentum()[1],
                       track.momentum()[2]);
 
-      ldmx_log(debug) << "starting extrapolations";
+      // At least min_hits_ hits and p > 50 MeV
+      if (trk.getNhits() < min_hits_ || abs(1. / trk.getQoP()) < 0.05) {
+        ldmx_log(debug)
+            << "  > Track candidate did NOT meet the requirements: Nhits = "
+            << trk.getNhits() << " and p = " << abs(1. / trk.getQoP())
+            << " GeV";
+        // No point of doing the extrapolations if the track candidate anyway
+        // wont be kept
+        continue;
+      }
+
       // Extrapolations
       // To ECAL
       const double ECAL_SCORING_PLANE = 240.5;

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -379,10 +379,6 @@ void CKFProcessor::produce(framework::Event& event) {
   profiling_map_["ckf_setup"] +=
       std::chrono::duration<double, std::milli>(ckf_setup - seeds).count();
 
-  auto ckf_run = std::chrono::high_resolution_clock::now();
-  profiling_map_["ckf_run"] +=
-      std::chrono::duration<double, std::milli>(ckf_run - ckf_setup).count();
-
   Acts::VectorTrackContainer vtc;
   Acts::VectorMultiTrajectory mtj;
   Acts::TrackContainer tc{vtc, mtj};
@@ -635,13 +631,15 @@ void CKFProcessor::produce(framework::Event& event) {
         trk.setTruthProb(truthInfo.truthProb);
       }
 
-      // At least min_hits_ hits and p > 50 MeV
-      if (trk.getNhits() > min_hits_ && abs(1. / trk.getQoP()) > 0.05) {
-        tracks.push_back(trk);
-        ntracks_++;
-      }
+      // Push the track candidate into the final track collecion
+      tracks.push_back(trk);
+      ntracks_++;
     }
   }  // loop seed track parameters
+
+  auto ckf_run = std::chrono::high_resolution_clock::now();
+  profiling_map_["ckf_run"] +=
+      std::chrono::duration<double, std::milli>(ckf_run - ckf_setup).count();
 
   // Calculating Shared Hits
 

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -544,7 +544,7 @@ void CKFProcessor::produce(framework::Event& event) {
                       track.momentum()[2]);
 
       // At least min_hits_ hits and p > 50 MeV
-      if (trk.getNhits() < min_hits_ || abs(1. / trk.getQoP()) < 0.05) {
+      if ((trk.getNhits() < min_hits_) || (abs(1. / trk.getQoP()) < 0.05)) {
         ldmx_log(debug)
             << "  > Track candidate did NOT meet the requirements: Nhits = "
             << trk.getNhits() << " and p = " << abs(1. / trk.getQoP())


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

https://github.com/LDMX-Software/ldmx-sw/pull/1572 changed too much in the test, so I'm doing the minimal now in this PR

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

Based on the printouts we do exit early