### PR TITLE
Ability to run on an event range when reading files

### DIFF
--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -174,6 +174,9 @@ class Process {
   /** Limit on events to process. */
   int eventLimit_;
 
+  /** When reading a file in, what's the first event to read */
+  int minEvents_;
+
   /** Number of events we'd like to produce
    independetly of the number of tries it would take.
    Be warned about infinite loops!*/

--- a/Framework/python/ldmxcfg.py
+++ b/Framework/python/ldmxcfg.py
@@ -521,6 +521,8 @@ class Process:
     maxEvents : int
         Maximum number events to process.
         If totalEvents is set, this will be ignored.
+    minEvents : int
+        Index of the first events to process.
     maxTriesPerEvent : int
         Maximum number of attempts to make in a row before giving up on an event
         Only used in Production Mode (no input files)
@@ -570,6 +572,7 @@ class Process:
 
         self.passName=passName
         self.maxEvents=-1
+        self.minEvents=-1
         self.maxTriesPerEvent=1
         self.run=-1
         self.inputFiles=[]

--- a/Framework/python/ldmxcfg.py
+++ b/Framework/python/ldmxcfg.py
@@ -523,6 +523,9 @@ class Process:
         If totalEvents is set, this will be ignored.
     minEvents : int
         Index of the first events to process.
+        The skipping process is relatively slow, if used for anything outside of debugging
+        make a  skim to a new file and then run again rather than use this.
+        Note: this skips events of *each* input file, you a single file only.
     maxTriesPerEvent : int
         Maximum number of attempts to make in a row before giving up on an event
         Only used in Production Mode (no input files)

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -29,6 +29,7 @@ Process::Process(const framework::config::Parameters &configuration)
 
   maxTries_ = configuration.getParameter<int>("maxTriesPerEvent", 1);
   eventLimit_ = configuration.getParameter<int>("maxEvents", -1);
+  minEvents_ = configuration.getParameter<int>("minEvents", -1);
   totalEvents_ = configuration.getParameter<int>("totalEvents", -1);
   logFrequency_ = configuration.getParameter<int>("logFrequency", -1);
   compressionSetting_ =
@@ -327,6 +328,11 @@ void Process::run() {
         // empty output file list, use inputFile as master file
         inFile.setupEvent(&theEvent);
         masterFile = &inFile;
+      }
+
+      // In case we'd like to skip up to the event of minEvents_
+      while(n_events_processed < (minEvents_-1) && masterFile->nextEvent()) {
+        n_events_processed++;
       }
 
       bool event_completed = true;

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -331,7 +331,8 @@ void Process::run() {
       }
 
       // In case we'd like to skip up to the event of minEvents_
-      while(n_events_processed < (minEvents_-1) && masterFile->nextEvent()) {
+      while (n_events_processed < (minEvents_ - 1) &&
+             masterFile->nextEvent(false)) {
         n_events_processed++;
       }
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1570

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I had a file which had
```
...
[ Recoil_TrackFinder ] 51  info: found tracks size = 1
[ Recoil_TrackFinder ] 52  info: found tracks size = 1
[ Recoil_TrackFinder ] 53  info: found tracks size = 1
[ Recoil_TrackFinder ] 54  info: found tracks size = 0
[ Recoil_TrackFinder ] 55  info: found tracks size = 0
[ Recoil_TrackFinder ] 56  info: found tracks size = 1
[ Recoil_TrackFinder ] 57  info: found tracks size = 1
...
```

now if I run
```
p.minEvents = 54
p.maxEvents = 55 
```
I only get 
[ Recoil_TrackFinder ] 54  info: found tracks size = 0
[ Recoil_TrackFinder ] 55  info: found tracks size = 0
```
Given that it was surrounded with events that had 1 track, I'm pretty certain it's the correct event.