### PR TITLE
Resolves Iss1568 where LTO build gives warnings about unused variables

### DIFF
--- a/DQM/include/DQM/TrkDeDxMassEstFeatures.h
+++ b/DQM/include/DQM/TrkDeDxMassEstFeatures.h
@@ -24,12 +24,12 @@ class TrkDeDxMassEstFeatures : public framework::Analyzer {
   /**
    * Input python configuration parameters
    */
-  virtual void configure(framework::config::Parameters& ps);
+  virtual void configure(framework::config::Parameters& ps) override;
 
   /**
    * Fills histograms
    */
-  virtual void analyze(const framework::Event& event);
+  virtual void analyze(const framework::Event& event) override;
 
   /// Method executed before processing of events begins.
   void onProcessStart() override;

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -320,10 +320,9 @@ void HcalDigiProducer::produce(framework::Event& event) {
     std::vector<ldmx::HcalDigiID> channelMap;
     int numChannels = 0;
     for (int section = 0; section < hcalGeometry.getNumSections(); section++) {
-      int numChannelsInSection = 0;
+
       for (int layer = 1; layer <= hcalGeometry.getNumLayers(section);
            layer++) {
-        numChannelsInSection += hcalGeometry.getNumStrips(section, layer);
         // Note zero-indexed strip numbering...
         for (int strip = 0; strip < hcalGeometry.getNumStrips(section, layer);
              strip++) {

--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -320,7 +320,6 @@ void HcalDigiProducer::produce(framework::Event& event) {
     std::vector<ldmx::HcalDigiID> channelMap;
     int numChannels = 0;
     for (int section = 0; section < hcalGeometry.getNumSections(); section++) {
-
       for (int layer = 1; layer <= hcalGeometry.getNumLayers(section);
            layer++) {
         // Note zero-indexed strip numbering...

--- a/Recon/include/Recon/TrackDeDxMassEstimator.h
+++ b/Recon/include/Recon/TrackDeDxMassEstimator.h
@@ -31,7 +31,6 @@ class TrackDeDxMassEstimator : public framework::Producer {
   virtual void produce(framework::Event& event) override;
 
  private:
-
   float fit_res_C_{0.};
   float fit_res_K_{-9999.};
 

--- a/Recon/include/Recon/TrackDeDxMassEstimator.h
+++ b/Recon/include/Recon/TrackDeDxMassEstimator.h
@@ -31,8 +31,6 @@ class TrackDeDxMassEstimator : public framework::Producer {
   virtual void produce(framework::Event& event) override;
 
  private:
-  // specific verbosity of this producer
-  int verbose_{0};
 
   float fit_res_C_{0.};
   float fit_res_K_{-9999.};

--- a/TrigScint/include/TrigScint/TrigScintFirmwareTracker.h
+++ b/TrigScint/include/TrigScint/TrigScintFirmwareTracker.h
@@ -43,9 +43,6 @@ class TrigScintFirmwareTracker : public framework::Producer {
   // min threshold for adding a hit to a cluster
   double minThr_{0.};
 
-  // max number of neighboring hits to combine when forming a cluster
-  int maxWidth_{2};
-
   // specific verbosity of this producer
   int verbose_{0};
 
@@ -68,36 +65,11 @@ class TrigScintFirmwareTracker : public framework::Producer {
   // specific pass name to use for track making
   std::string passName_{""};
 
-  // vertical bar start index
-  int vertBarStartIdx_{52};
-
-  // cluster channel nb centroid (will be content weighted)
-  float centroid_{0.};
-
-  // cluster channel nb horizontal centroid (will be content weighted)
-  float centroidX_{-1};
-
-  // cluster channel nb vertical centroid (will be content weighted)
-  float centroidY_{-1};
-
-  // energy (edep), PE, or sth
-  float val_{0.};
-
-  // edep content, only; leave val_ for PE
-  float valE_{0.};
-
   // book keep which channels have already been added to the cluster at hand
   std::vector<unsigned int> v_addedIndices_;
 
   // book keep which channels have already been added to any cluster
   std::vector<unsigned int> v_usedIndices_;
-
-  // fraction of cluster energy deposition associated with beam electron sim
-  // hits
-  float beamE_{0.};
-
-  // cluster time (energy weighted based on hit time)
-  float time_{0.};
 
   // empty map container
   std::map<int, int> hitChannelMap_;

--- a/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
+++ b/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
@@ -12,16 +12,6 @@ namespace trigscint {
 
 void TrigScintFirmwareTracker::configure(framework::config::Parameters &ps) {
 
-  (void)maxWidth_;  // This prevents the unused variable warning
-  (void)vertBarStartIdx_;  // This prevents the unused variable warning
-  (void)centroid_;  // This prevents the unused variable warning
-  (void)centroidX_;  // This prevents the unused variable warning
-  (void)centroidY_;  // This prevents the unused variable warning
-  (void)val_;  // This prevents the unused variable warning
-  (void)valE_;  // This prevents the unused variable warning
-  (void)beamE_;  // This prevents the unused variable warning
-  (void)time_;  // This prevents the unused variable warning
-
   minThr_ = ps.getParameter<double>("clustering_threshold");
   digis1_collection_ = ps.getParameter<std::string>("digis1_collection");
   digis2_collection_ = ps.getParameter<std::string>("digis2_collection");
@@ -31,9 +21,6 @@ void TrigScintFirmwareTracker::configure(framework::config::Parameters &ps) {
   verbose_ = ps.getParameter<int>("verbosity");
   timeTolerance_ = ps.getParameter<double>("time_tolerance");
   padTime_ = ps.getParameter<double>("pad_time");
-
-  // vertBarStartIdx_ = ps.getParameter<int>("vertical_bar_start_index");
-  // maxWidth_ = ps.getParameter<int>("max_cluster_width");
 
   if (verbose_) {
     ldmx_log(info) << "In TrigScintFirmwareTracker: configure done!";

--- a/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
+++ b/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
@@ -11,7 +11,6 @@
 namespace trigscint {
 
 void TrigScintFirmwareTracker::configure(framework::config::Parameters &ps) {
-
   minThr_ = ps.getParameter<double>("clustering_threshold");
   digis1_collection_ = ps.getParameter<std::string>("digis1_collection");
   digis2_collection_ = ps.getParameter<std::string>("digis2_collection");

--- a/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
+++ b/TrigScint/src/TrigScint/TrigScintFirmwareTracker.cxx
@@ -11,6 +11,17 @@
 namespace trigscint {
 
 void TrigScintFirmwareTracker::configure(framework::config::Parameters &ps) {
+
+  (void)maxWidth_;  // This prevents the unused variable warning
+  (void)vertBarStartIdx_;  // This prevents the unused variable warning
+  (void)centroid_;  // This prevents the unused variable warning
+  (void)centroidX_;  // This prevents the unused variable warning
+  (void)centroidY_;  // This prevents the unused variable warning
+  (void)val_;  // This prevents the unused variable warning
+  (void)valE_;  // This prevents the unused variable warning
+  (void)beamE_;  // This prevents the unused variable warning
+  (void)time_;  // This prevents the unused variable warning
+
   minThr_ = ps.getParameter<double>("clustering_threshold");
   digis1_collection_ = ps.getParameter<std::string>("digis1_collection");
   digis2_collection_ = ps.getParameter<std::string>("digis2_collection");
@@ -20,6 +31,10 @@ void TrigScintFirmwareTracker::configure(framework::config::Parameters &ps) {
   verbose_ = ps.getParameter<int>("verbosity");
   timeTolerance_ = ps.getParameter<double>("time_tolerance");
   padTime_ = ps.getParameter<double>("pad_time");
+
+  // vertBarStartIdx_ = ps.getParameter<int>("vertical_bar_start_index");
+  // maxWidth_ = ps.getParameter<int>("max_cluster_width");
+
   if (verbose_) {
     ldmx_log(info) << "In TrigScintFirmwareTracker: configure done!";
     ldmx_log(info) << "\nClustering threshold: " << minThr_


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1568 by removing the unused variables in TrackDeDxMassEstimator.h, TrigScintFirmwareTracker.h, HcalDigiProducer.cxx, and adding override to TrkDeDxMassEstFeatures.h
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
