### PR TITLE
increment iDigi in out-of-time condition

### DIFF
--- a/TrigScint/src/TrigScint/TrigScintClusterProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintClusterProducer.cxx
@@ -174,7 +174,10 @@ void TrigScintClusterProducer::produce(framework::Event &event) {
       }
 
       // don't add in late hits
-      if (digi.getTime() > padTime_ + timeTolerance_) continue;
+      if (digi.getTime() > padTime_ + timeTolerance_) {
+        iDigi++;
+        continue;
+      }
 
       hitChannelMap_.insert(std::pair<int, int>(ID, iDigi));
       // the channel number is the key, the digi list index is the value


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1592. 
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Here is some log output showing the change relative to the behavior documented in the issue.

```
[ Process ] 44  info: Processing 44 Run 10036 Event 44  (2025-02-11 11:12:06.304602000-0800)
[ trigScintClustersPad1 ] 44 debug: TrigScintClusterProducer: produce() starts! Event number: 44
[ trigScintClustersPad1 ] 44 debug: Got digi collection trigScintRecHitsPad1_overlay with 2 entries 
[ trigScintClustersPad1 ] 44 debug: Mapping digi hit nb 1 with energy = 0.291239 MeV, nPE = 72.8098 > 0 to key/channel 29
[ trigScintClustersPad1 ] 44 debug: 	 At hit with channel nb 29.
[ trigScintClustersPad1 ] 44 debug: Seeding cluster with channel 29; content 72.8098
[ trigScintClustersPad1 ] 44 debug:    In addHit, adding hit at 29 with amplitude 72.8098, updating cluster to current centroid 29 and energy 72.8098. index vector now ends with 29
[ trigScintClustersPad1 ] 44 debug: 	 itr is pointing at hit with channel nb 29.
[ trigScintClustersPad1 ] 44 debug: Now have 1 hits in the cluster 
TrigScintCluster { Energy: 0.291239, Number of hits: 1, Seed channel 29, Channel centroid: 29 }
  --  Constituent hit channel ids: {  29  }
[ trigScintClustersPad1 ] 44 debug: 	 Finished processing of seeding hit with channel nb 29.
[ trigScintClustersPad2 ] 44 debug: TrigScintClusterProducer: produce() starts! Event number: 44
[ trigScintClustersPad2 ] 44 debug: Got digi collection trigScintRecHitsPad2_overlay with 1 entries 
[ trigScintClustersPad2 ] 44 debug: Mapping digi hit nb 0 with energy = 0.490913 MeV, nPE = 122.728 > 0 to key/channel 29
[ trigScintClustersPad2 ] 44 debug: 	 At hit with channel nb 29.
[ trigScintClustersPad2 ] 44 debug: Seeding cluster with channel 29; content 122.728
[ trigScintClustersPad2 ] 44 debug:    In addHit, adding hit at 29 with amplitude 122.728, updating cluster to current centroid 29 and energy 122.728. index vector now ends with 29
[ trigScintClustersPad2 ] 44 debug: 	 itr is pointing at hit with channel nb 29.
[ trigScintClustersPad2 ] 44 debug: Now have 1 hits in the cluster 
```

Here the high-PE hit is correctly mapped to index 1, and we successfully form a cluster in Pad 1.
The effects of this change on out-of-time pileup samples are also documented [here](https://indico.fnal.gov/event/67873/contributions/308859/attachments/185027/254603/TS02052025.pdf).
