### PR TITLE
Fix printout in EcalProcessFilter, move to def destructor

### DIFF
--- a/Biasing/include/Biasing/EcalProcessFilter.h
+++ b/Biasing/include/Biasing/EcalProcessFilter.h
@@ -36,7 +36,7 @@ class EcalProcessFilter : public simcore::UserAction {
                     framework::config::Parameters& parameters);
 
   /// Destructor
-  ~EcalProcessFilter();
+  virtual ~EcalProcessFilter() = default;
 
   void stepping(const G4Step* step) override;
 

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -22,8 +22,6 @@ EcalProcessFilter::EcalProcessFilter(const std::string& name,
   process_ = parameters.getParameter<std::string>("process");
 }
 
-EcalProcessFilter::~EcalProcessFilter() {}
-
 G4ClassificationOfNewTrack EcalProcessFilter::ClassifyNewTrack(
     const G4Track* track, const G4ClassificationOfNewTrack& currentTrackClass) {
   // Get the particle type.
@@ -166,12 +164,8 @@ void EcalProcessFilter::stepping(const G4Step* step) {
       return;
     }
 
-    ldmx_log(info) << "There were "
-                   << G4EventManager::GetEventManager()
-                          ->GetConstCurrentEvent()
-                          ->GetEventID()
-                   << " Brem photon produced " << secondaries->size()
-                   << " particle via " << processName << " process.";
+    ldmx_log(info) << " Brem photon produced " << secondaries->size()
+                   << " particles via " << processName << " process.";
     trackInfo->tagBremCandidate(false);
     trackInfo->setSaveFlag(true);
     trackInfo->tagPNGamma();


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

I didnt make an issue since it's such a small change.
I realized that now that we moved the printout to the logging system the event is printed out twice, this PR fixes that.
And since I was there I also change the destructor...

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
