### PR TITLE
Added pass name to tracking code

### DIFF
--- a/Tracking/include/Tracking/Reco/CKFProcessor.h
+++ b/Tracking/include/Tracking/Reco/CKFProcessor.h
@@ -208,6 +208,8 @@ class CKFProcessor final : public TrackingGeometryUser {
   // The interpolated bfield
   std::string field_map_{""};
 
+  std::string input_pass_name_{""};
+
   // The Propagator
   std::unique_ptr<const CkfPropagator> propagator_;
 

--- a/Tracking/include/Tracking/Reco/GreedyAmbiguitySolver.h
+++ b/Tracking/include/Tracking/Reco/GreedyAmbiguitySolver.h
@@ -101,6 +101,8 @@ class GreedyAmbiguitySolver final : public TrackingGeometryUser {
 
   std::string meas_collection_{"DigiTaggerSimHits"};
 
+  std::string input_pass_name_{""};
+
   struct State {
     std::size_t number_of_tracks{};
 

--- a/Tracking/include/Tracking/Reco/SeedFinderProcessor.h
+++ b/Tracking/include/Tracking/Reco/SeedFinderProcessor.h
@@ -110,6 +110,7 @@ class SeedFinderProcessor : public TrackingGeometryUser {
   std::string input_hits_collection_{"TaggerSimHits"};
   /// The name of the tagger Tracks (only for Recoil Seeding)
   std::string tagger_trks_collection_{"TaggerTracks"};
+  std::string input_pass_name_{""};
   /// Location of the perigee for the helix track parameters.
   std::vector<double> perigee_location_{-700., 0., 0};
   /// Minimum cut on the momentum of the seeds.

--- a/Tracking/include/Tracking/Reco/VertexProcessor.h
+++ b/Tracking/include/Tracking/Reco/VertexProcessor.h
@@ -93,6 +93,8 @@ class VertexProcessor : public framework::Producer {
 
   std::string trk_coll_name_{"Tracks"};
 
+  std::string input_pass_name_{""};
+
   // The propagator
   std::shared_ptr<VoidPropagator> propagator_;
 

--- a/Tracking/include/Tracking/Reco/Vertexer.h
+++ b/Tracking/include/Tracking/Reco/Vertexer.h
@@ -76,6 +76,7 @@ class Vertexer : public framework::Producer {
 
   std::string trk_c_name_1{"TaggerTracks"};
   std::string trk_c_name_2{"RecoilTracks"};
+  std::string input_pass_name_{""};
   std::shared_ptr<VoidPropagator> propagator_;
 
   // Monitoring histograms

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -207,7 +207,8 @@ void CKFProcessor::produce(framework::Event& event) {
       std::chrono::duration<double, std::milli>(setup - start).count();
 
   const std::vector<ldmx::Measurement> measurements =
-      event.getCollection<ldmx::Measurement>(measurement_collection_, input_pass_name_);
+      event.getCollection<ldmx::Measurement>(measurement_collection_,
+                                             input_pass_name_);
 
   // check if SimParticleMap is available for truth matching
   std::shared_ptr<tracking::sim::TruthMatchingTool> truthMatchingTool = nullptr;

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -762,6 +762,9 @@ void CKFProcessor::configure(framework::config::Parameters& parameters) {
   // BField Systematics
   map_offset_ =
       parameters.getParameter<std::vector<double>>("map_offset_", {0., 0., 0.});
+
+  input_pass_name_ =
+      parameters.getParameter<std::string>("input_pass_name", "");
 }
 
 auto CKFProcessor::makeGeoIdSourceLinkMap(

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -207,7 +207,7 @@ void CKFProcessor::produce(framework::Event& event) {
       std::chrono::duration<double, std::milli>(setup - start).count();
 
   const std::vector<ldmx::Measurement> measurements =
-      event.getCollection<ldmx::Measurement>(measurement_collection_);
+      event.getCollection<ldmx::Measurement>(measurement_collection_, input_pass_name_);
 
   // check if SimParticleMap is available for truth matching
   std::shared_ptr<tracking::sim::TruthMatchingTool> truthMatchingTool = nullptr;
@@ -232,7 +232,7 @@ void CKFProcessor::produce(framework::Event& event) {
 
   // Retrieve the seeds
   const std::vector<ldmx::Track> seed_tracks =
-      event.getCollection<ldmx::Track>(seed_coll_name_);
+      event.getCollection<ldmx::Track>(seed_coll_name_, input_pass_name_);
 
   ldmx_log(info) << "Number of " << seed_coll_name_
                  << " seed tracks = " << seed_tracks.size();

--- a/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
+++ b/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
@@ -185,10 +185,10 @@ void GreedyAmbiguitySolver::produce(framework::Event& event) {
   auto tg{geometry()};
 
   if (!event.exists(track_collection_)) return;
-  auto tracks{event.getCollection<ldmx::Track>(track_collection_)};
+  auto tracks{event.getCollection<ldmx::Track>(track_collection_, input_pass_name_)};
 
   if (!event.exists(meas_collection_)) return;
-  auto measurements{event.getCollection<ldmx::Measurement>(meas_collection_)};
+  auto measurements{event.getCollection<ldmx::Measurement>(meas_collection_, input_pass_name_)};
 
   computeInitialState(tracks, measurements, state, tg,
                       tracking::sim::utils::sourceLinkHash,

--- a/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
+++ b/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
@@ -185,10 +185,12 @@ void GreedyAmbiguitySolver::produce(framework::Event& event) {
   auto tg{geometry()};
 
   if (!event.exists(track_collection_)) return;
-  auto tracks{event.getCollection<ldmx::Track>(track_collection_, input_pass_name_)};
+  auto tracks{
+      event.getCollection<ldmx::Track>(track_collection_, input_pass_name_)};
 
   if (!event.exists(meas_collection_)) return;
-  auto measurements{event.getCollection<ldmx::Measurement>(meas_collection_, input_pass_name_)};
+  auto measurements{event.getCollection<ldmx::Measurement>(meas_collection_,
+                                                           input_pass_name_)};
 
   computeInitialState(tracks, measurements, state, tg,
                       tracking::sim::utils::sourceLinkHash,

--- a/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
+++ b/Tracking/src/Tracking/Reco/GreedyAmbiguitySolver.cxx
@@ -172,7 +172,8 @@ void GreedyAmbiguitySolver::configure(
 
   meas_collection_ = parameters.getParameter<std::string>("measCollection",
                                                           "DigiTaggerSimHits");
-
+  input_pass_name_ =
+      parameters.getParameter<std::string>("input_pass_name", "");
   n_meas_min_ = parameters.getParameter<int>("nMeasurementsMin", 5);
   maximum_shared_hits_ = parameters.getParameter<int>("maximumSharedHits", 1);
 }

--- a/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -82,6 +82,9 @@ void SeedFinderProcessor::configure(framework::config::Parameters& parameters) {
       "inflate_factors", {10., 10., 10., 10., 10., 10.});
 
   bfield_ = parameters.getParameter<double>("bfield", 1.5);
+
+  input_pass_name_ =
+      parameters.getParameter<std::string>("input_pass_name", "");
 }
 
 void SeedFinderProcessor::produce(framework::Event& event) {

--- a/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -99,11 +99,13 @@ void SeedFinderProcessor::produce(framework::Event& event) {
   std::map<int, ldmx::SimParticle> particleMap;
 
   const std::vector<ldmx::Measurement> measurements =
-      event.getCollection<ldmx::Measurement>(input_hits_collection_, input_pass_name_);
+      event.getCollection<ldmx::Measurement>(input_hits_collection_,
+                                             input_pass_name_);
 
   std::vector<ldmx::Track> tagger_tracks;
   if (event.exists(tagger_trks_collection_)) {
-    tagger_tracks = event.getCollection<ldmx::Track>(tagger_trks_collection_, input_pass_name_);
+    tagger_tracks = event.getCollection<ldmx::Track>(tagger_trks_collection_,
+                                                     input_pass_name_);
   }
 
   // Create an unbound surface at the target

--- a/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/SeedFinderProcessor.cxx
@@ -99,11 +99,11 @@ void SeedFinderProcessor::produce(framework::Event& event) {
   std::map<int, ldmx::SimParticle> particleMap;
 
   const std::vector<ldmx::Measurement> measurements =
-      event.getCollection<ldmx::Measurement>(input_hits_collection_);
+      event.getCollection<ldmx::Measurement>(input_hits_collection_, input_pass_name_);
 
   std::vector<ldmx::Track> tagger_tracks;
   if (event.exists(tagger_trks_collection_)) {
-    tagger_tracks = event.getCollection<ldmx::Track>(tagger_trks_collection_);
+    tagger_tracks = event.getCollection<ldmx::Track>(tagger_trks_collection_, input_pass_name_);
   }
 
   // Create an unbound surface at the target

--- a/Tracking/src/Tracking/Reco/VertexProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/VertexProcessor.cxx
@@ -46,6 +46,10 @@ void VertexProcessor::configure(framework::config::Parameters &parameters) {
 
   trk_coll_name_ =
       parameters.getParameter<std::string>("trk_coll_name", "Tracks");
+
+  input_pass_name_ =
+      parameters.getParameter<std::string>("input_pass_name", "");
+
 }
 
 void VertexProcessor::produce(framework::Event &event) {
@@ -84,11 +88,11 @@ void VertexProcessor::produce(framework::Event &event) {
 
   // Retrieve the track collection
   const std::vector<ldmx::Track> tracks =
-      event.getCollection<ldmx::Track>(trk_coll_name_);
+      event.getCollection<ldmx::Track>(trk_coll_name_, input_pass_name_);
 
   // Retrieve the truth seeds
   const std::vector<ldmx::Track> seeds =
-      event.getCollection<ldmx::Track>("RecoilTruthSeeds");
+      event.getCollection<ldmx::Track>("RecoilTruthSeeds", input_pass_name_);
 
   if (tracks.size() < 1) return;
 

--- a/Tracking/src/Tracking/Reco/VertexProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/VertexProcessor.cxx
@@ -49,7 +49,6 @@ void VertexProcessor::configure(framework::config::Parameters &parameters) {
 
   input_pass_name_ =
       parameters.getParameter<std::string>("input_pass_name", "");
-
 }
 
 void VertexProcessor::produce(framework::Event &event) {

--- a/Tracking/src/Tracking/Reco/Vertexer.cxx
+++ b/Tracking/src/Tracking/Reco/Vertexer.cxx
@@ -125,9 +125,9 @@ void Vertexer::produce(framework::Event& event) {
   // Retrive the two track collections
 
   const std::vector<ldmx::Track> tracks_1 =
-      event.getCollection<ldmx::Track>(trk_c_name_1);
+      event.getCollection<ldmx::Track>(trk_c_name_1, input_pass_name_);
   const std::vector<ldmx::Track> tracks_2 =
-      event.getCollection<ldmx::Track>(trk_c_name_2);
+      event.getCollection<ldmx::Track>(trk_c_name_2, input_pass_name_);
 
   ldmx_log(debug) << "Retrieved track collections" << std::endl
                   << "Track 1 size:" << tracks_1.size() << std::endl

--- a/Tracking/src/Tracking/Reco/Vertexer.cxx
+++ b/Tracking/src/Tracking/Reco/Vertexer.cxx
@@ -85,6 +85,8 @@ void Vertexer::configure(framework::config::Parameters& parameters) {
       parameters.getParameter<std::string>("trk_c_name_1", "TaggerTracks");
   trk_c_name_2 =
       parameters.getParameter<std::string>("trk_c_name_2", "RecoilTracks");
+  input_pass_name_ =
+      parameters.getParameter<std::string>("input_pass_name", "");
 }
 
 void Vertexer::produce(framework::Event& event) {


### PR DESCRIPTION
### What are the issues that this addresses?
Issue #1481 Tracking Code (CFKProcessor, GreedyAmbiguitySolver, SeedFinderProcessor, Vertexer) lacked ability to use pass name. This has been added
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
