### PR TITLE
New "just" command that fails when LTO warning exists

### DIFF
--- a/.github/workflows/compile_clang_lto.yml
+++ b/.github/workflows/compile_clang_lto.yml
@@ -25,5 +25,5 @@ jobs:
 
     - name: Compile and Install ldmx-sw
       run: | 
-        just install-denv init configure-clang-lto
+        just install-denv init configure-clang-lto-fail-on-warning
         just build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,14 +24,6 @@ project(LDMX_SW VERSION ${LDMXSW_VERSION_NUM}
 )
 
 set(CMAKE_CXX_STANDARD 20)
-option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
-
-if (WARNINGS_AS_ERRORS)
-    message(STATUS "Warnings will be treated as errors!")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-
 
 # Load additional macros used by this project. 
 list(APPEND CMAKE_MODULE_PATH ${LDMX_SW_SOURCE_DIR}/cmake/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ project(LDMX_SW VERSION ${LDMXSW_VERSION_NUM}
 )
 
 set(CMAKE_CXX_STANDARD 20)
+option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+
+if (WARNINGS_AS_ERRORS)
+    message(STATUS "Warnings will be treated as errors!")
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+
 
 # Load additional macros used by this project. 
 list(APPEND CMAKE_MODULE_PATH ${LDMX_SW_SOURCE_DIR}/cmake/)

--- a/justfile
+++ b/justfile
@@ -79,7 +79,7 @@ configure-force-error: (configure "-DWARNINGS_AS_ERRORS=ON")
 # Use alternative compiler and enable LTO (test compiling only, won't run properly)
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
-configure-clang-lto-fail-on-warning: (configure-clang-lto "-DWARNINGS_AS_ERRORS=ON")
+configure-clang-lto-fail-on-warning: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DWARNINGS_AS_ERRORS=ON")
 # Keep debug symbols so running with gdb provides more helpful detail
 configure-gdb: (configure-base "-DCMAKE_BUILD_TYPE=Debug")
 # compile and install ldmx-sw

--- a/justfile
+++ b/justfile
@@ -79,12 +79,7 @@ configure-force-error: (configure "-DWARNINGS_AS_ERRORS=ON")
 # Use alternative compiler and enable LTO (test compiling only, won't run properly)
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
-configure-clang-lto-final:
-    rm -rf build  # Ensure a fresh build
-    denv cmake -B build -S . -DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DWARNINGS_AS_ERRORS=ON
-
-
-
+configure-clang-lto-fail-on-warning: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DWARNINGS_AS_ERRORS=ON")
 # Keep debug symbols so running with gdb provides more helpful detail
 configure-gdb: (configure-base "-DCMAKE_BUILD_TYPE=Debug")
 # compile and install ldmx-sw

--- a/justfile
+++ b/justfile
@@ -79,6 +79,12 @@ configure-force-error: (configure "-DWARNINGS_AS_ERRORS=ON")
 # Use alternative compiler and enable LTO (test compiling only, won't run properly)
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
+configure-clang-lto-final:
+    rm -rf build  # Ensure a fresh build
+    denv cmake -B build -S . -DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DWARNINGS_AS_ERRORS=ON
+
+
+
 # Keep debug symbols so running with gdb provides more helpful detail
 configure-gdb: (configure-base "-DCMAKE_BUILD_TYPE=Debug")
 # compile and install ldmx-sw

--- a/justfile
+++ b/justfile
@@ -79,7 +79,7 @@ configure-force-error: (configure "-DWARNINGS_AS_ERRORS=ON")
 # Use alternative compiler and enable LTO (test compiling only, won't run properly)
 configure-clang-lto: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang") 
 
-configure-clang-lto-fail-on-warning: (configure "-DENABLE_LTO=ON -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DWARNINGS_AS_ERRORS=ON")
+configure-clang-lto-fail-on-warning: (configure-clang-lto "-DWARNINGS_AS_ERRORS=ON")
 # Keep debug symbols so running with gdb provides more helpful detail
 configure-gdb: (configure-base "-DCMAKE_BUILD_TYPE=Debug")
 # compile and install ldmx-sw


### PR DESCRIPTION
### What are the issues that this addresses?
Adds another "just" command that fails on LTO warnings rather than continuing on. The user would need to fix the warnings then re-run.

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1542

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
