### PR TITLE
DQM plots to show more info about the PN interactions

### DIFF
--- a/.github/validation_samples/ecal_pn/config.py
+++ b/.github/validation_samples/ecal_pn/config.py
@@ -86,7 +86,7 @@ p.sequence.extend([
         TrigScintClusterProducer.pad3(),
         trigScintTrack,
         count, TriggerProcessor('trigger', 8000.),
-        dqm.PhotoNuclearDQM(verbose=True),
+        dqm.PhotoNuclearDQM(),
         ])
 
 p.sequence.extend(dqm.all_dqm)

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -86,7 +86,7 @@ p.sequence.extend([
         TrigScintClusterProducer.pad3(),
         trigScintTrack,
         count, TriggerProcessor('trigger', 8000.),
-        dqm.PhotoNuclearDQM(verbose=False),
+        dqm.PhotoNuclearDQM(),
         ])
 
 p.sequence.extend(dqm.all_dqm)

--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -112,7 +112,7 @@ p.sequence.extend([
     TrigScintClusterProducer.pad3(),
     trigScintTrack,
     count, TriggerProcessor('trigger', 8000.),
-    dqm.PhotoNuclearDQM(verbose=False),
+    dqm.PhotoNuclearDQM(),
 ])
 
 p.sequence.extend(dqm.all_dqm)

--- a/.github/validation_samples/kaon_enhanced/config.py
+++ b/.github/validation_samples/kaon_enhanced/config.py
@@ -164,7 +164,7 @@ p.sequence.extend([
         hcalDigi, 
         hcalReco, 
         hcal_veto,
-        dqm.PhotoNuclearDQM(verbose=False)
+        dqm.PhotoNuclearDQM()
         ])
 
 p.sequence.extend(dqm.all_dqm)

--- a/DQM/include/DQM/PhotoNuclearDQM.h
+++ b/DQM/include/DQM/PhotoNuclearDQM.h
@@ -1,12 +1,18 @@
 #ifndef DQM_PHOTONUCLEARDQM_H
 #define DQM_PHOTONUCLEARDQM_H
 
-/*~~~~~~~~~~~~~~~*/
-/*   Framework   */
-/*~~~~~~~~~~~~~~~*/
+#include <TVector3.h>
+
+#include <algorithm>
+
 #include "Framework/Configure/Parameters.h"
+#include "Framework/Event.h"
 #include "Framework/EventProcessor.h"
 #include "SimCore/Event/SimParticle.h"
+#include "TH1F.h"
+#include "TH2F.h"
+#include "Tools/AnalysisUtils.h"
+
 namespace dqm {
 
 // Forward declarations within the ldmx workspace
@@ -52,7 +58,7 @@ class PhotoNuclearDQM : public framework::Analyzer {
   PhotoNuclearDQM(const std::string &name, framework::Process &process);
 
   /// Destructor
-  virtual ~PhotoNuclearDQM();
+  virtual ~PhotoNuclearDQM() = default;
 
   /**
    * Configure this analyzer using the user specified parameters.
@@ -68,6 +74,12 @@ class PhotoNuclearDQM : public framework::Analyzer {
    * @param event The event to analyze.
    */
   void analyze(const framework::Event &event) override;
+
+  /// @brief  Helper function to label categorical histos
+  /// @param name : Name of the histo for the labels to set
+  /// @param labels : Labels on the X axis
+  void setHistLabels(const std::string &name,
+                     const std::vector<std::string> &labels);
 
   /// Method executed before processing of events begins.
   void onProcessStart() override;
@@ -142,7 +154,6 @@ class PhotoNuclearDQM : public framework::Analyzer {
     return false;
   }
 
-  bool verbose_;
   bool count_light_ions_;
 };
 

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -490,23 +490,24 @@ class PhotoNuclearDQM(ldmxcfg.Analyzer) :
         p.sequence.append( dqm.PhotoNuclearDQM() )
     """
 
-    def __init__(self,name='PN', verbose=False, count_light_ions=True) :
+    def __init__(self,name='PN', count_light_ions=True) :
         super().__init__(name,'dqm::PhotoNuclearDQM','DQM')
 
         self.count_light_ions=count_light_ions
-        self.verbose = verbose
         self.build1DHistogram("event_type"         , "", 24, -1, 23)
         self.build1DHistogram("event_type_500mev"  , "", 24, -1, 23)
         self.build1DHistogram("event_type_2000mev" , "", 24, -1, 23)
         self.build1DHistogram("event_type_compact"         , "", 8, -1, 7)
         self.build1DHistogram("event_type_compact_500mev"  , "", 8, -1, 7)
         self.build1DHistogram("event_type_compact_2000mev" , "", 8, -1, 7)
-        self.build1DHistogram("1n_event_type"      , "", 7,  -1, 6)
+        self.build1DHistogram("1n_event_type"              , "", 7,  -1, 6)
+        self.build1DHistogram("pn_vertex_volume"           , "", 13,  -0.5, 12.5)
+        self.build1DHistogram("pn_interaction_material"    , "", 10,  -0.5, 9.5)
         self.build1DHistogram("pn_particle_mult"   , "Photo-nuclear Multiplicity", 200, 0, 200)
-        self.build1DHistogram("pn_neutron_mult", "Photo-nuclear Neutron Multiplicity", 200,0, 200)
+        self.build1DHistogram("pn_neutron_mult"    , "Photo-nuclear Neutron Multiplicity", 200,0, 200)
         self.build1DHistogram("pn_gamma_energy"    , "#gamma Energy (MeV)", 100, 0, 10000)
-        self.build1DHistogram("pn_total_ke"  , "Total Kineitc Energy of Photo-Nuclear Products (MeV)", 100, 0, 10000)
-        self.build1DHistogram("pn_total_neutron_ke"  , "Total Kineitc Energy of Photo-Nuclear Neutrons  (MeV)", 100, 0, 10000)
+        self.build1DHistogram("pn_total_ke"        , "Total Kineitc Energy of Photo-Nuclear Products (MeV)", 100, 0, 10000)
+        self.build1DHistogram("pn_total_neutron_ke", "Total Kineitc Energy of Photo-Nuclear Neutrons  (MeV)", 100, 0, 10000)
         self.build1DHistogram("1n_neutron_energy"  , "Neutron Energy (MeV)", 100, 0, 10000)
         self.build1DHistogram("1n_energy_diff"     , "E(#gamma_{PN}) - E(n) (MeV)", 100, 0, 10000)
         self.build1DHistogram("1n_energy_frac"     , "E(n)/E(#gamma_{PN}) (MeV)", 100, 0, 1)
@@ -524,11 +525,11 @@ class PhotoNuclearDQM(ldmxcfg.Analyzer) :
         self.build1DHistogram("recoil_vertex_y",   "Recoil e^{-} Vertex - y (mm)", 80, -80, 80)
         self.build1DHistogram("recoil_vertex_z",   "Recoil e^{-} Vertex - z (mm)", 20, -950, -850)
 
-        self.build1DHistogram("pn_gamma_int_x",    "#gamma Interaction Vertex - x (mm)", 40, 200, 400)
-        self.build1DHistogram("pn_gamma_int_y",    "#gamma Interaction Vertex - y (mm)", 40, 200, 400)
+        self.build1DHistogram("pn_gamma_int_x",    "#gamma Interaction Vertex - x (mm)", 50, -250, 250)
+        self.build1DHistogram("pn_gamma_int_y",    "#gamma Interaction Vertex - y (mm)", 50, -250, 250)
         self.build1DHistogram("pn_gamma_int_z",    "#gamma Interaction Vertex - z (mm)", 40, 200, 400)
 
-        self.build1DHistogram("pn_gamma_vertex_x", "#gamma Vertex - y (mm)", 40,   -40, 40)
+        self.build1DHistogram("pn_gamma_vertex_x", "#gamma Vertex - y (mm)", 40,  -40, 40)
         self.build1DHistogram("pn_gamma_vertex_y", "#gamma Vertex - y (mm)", 80,  -80, 80)
         self.build1DHistogram("pn_gamma_vertex_z", "#gamma Vertex - z (mm)", 10, -5,  5)
 
@@ -570,6 +571,13 @@ class PhotoNuclearDQM(ldmxcfg.Analyzer) :
                            80, -40, 40, 
                            "Recoil electron vertex y (mm)", 
                            160, -80, 80)
+        
+        self.build2DHistogram("pn_gamma_int_x:pn_gamma_int_y", 
+                           "PN gamme interaction vertex x (mm)", 
+                           50, -250, 250, 
+                           "PN gamme interaction vertex x (mm)", 
+                           50, -250, 250)
+        
 
 class TrkDeDxMassEstFeatures(ldmxcfg.Analyzer) :
     """Configured TrkDeDxMassEstFeatures python object

--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -1,32 +1,12 @@
 
 #include "DQM/PhotoNuclearDQM.h"
 
-/*~~~~~~~~~~~~~~~~*/
-/*   C++ StdLib   */
-/*~~~~~~~~~~~~~~~~*/
-#include <algorithm>
-
-//----------//
-//   ROOT   //
-//----------//
-#include "TH1F.h"
-#include "TH2F.h"
-
-//----------//
-//   LDMX   //
-//----------//
-#include <TVector3.h>
-
-#include "Framework/Event.h"
-#include "Tools/AnalysisUtils.h"
-
 namespace dqm {
 
 PhotoNuclearDQM::PhotoNuclearDQM(const std::string &name,
                                  framework::Process &process)
     : framework::Analyzer(name, process) {}
 
-PhotoNuclearDQM::~PhotoNuclearDQM() {}
 std::vector<const ldmx::SimParticle *> PhotoNuclearDQM::findDaughters(
     const std::map<int, ldmx::SimParticle> &particleMap,
     const ldmx::SimParticle *parent) const {
@@ -173,6 +153,15 @@ void PhotoNuclearDQM::findSubleadingKinematics(
     histograms_.fill("1k0_energy_frac", energyFrac);
   }
 }
+
+void PhotoNuclearDQM::setHistLabels(const std::string &name,
+                                    const std::vector<std::string> &labels) {
+  auto histo{histograms_.get(name)};
+  for (std::size_t ibin{1}; ibin <= labels.size(); ibin++) {
+    histo->GetXaxis()->SetBinLabel(ibin, labels[ibin - 1].c_str());
+  }
+}
+
 void PhotoNuclearDQM::onProcessStart() {
   std::vector<std::string> labels = {"",
                                      "Nothing hard",   // 0
@@ -198,18 +187,9 @@ void PhotoNuclearDQM::onProcessStart() {
                                      "multi-body",     // 20
                                      ""};
 
-  std::vector<TH1 *> hists = {
-      histograms_.get("event_type"),
-      histograms_.get("event_type_500mev"),
-      histograms_.get("event_type_2000mev"),
-
-  };
-
-  for (int ilabel{1}; ilabel < labels.size(); ++ilabel) {
-    for (auto &hist : hists) {
-      hist->GetXaxis()->SetBinLabel(ilabel, labels[ilabel - 1].c_str());
-    }
-  }
+  setHistLabels("event_type", labels);
+  setHistLabels("event_type_500mev", labels);
+  setHistLabels("event_type_2000mev", labels);
 
   labels = {"",
             "1 n",      // 0
@@ -220,34 +200,24 @@ void PhotoNuclearDQM::onProcessStart() {
             "Other",    // 5
             ""};
 
-  hists = {
-      histograms_.get("event_type_compact"),
-      histograms_.get("event_type_compact_500mev"),
-      histograms_.get("event_type_compact_2000mev"),
-  };
+  setHistLabels("event_type_compact", labels);
+  setHistLabels("event_type_compact_500mev", labels);
+  setHistLabels("event_type_compact_2000mev", labels);
 
-  for (int ilabel{1}; ilabel < labels.size(); ++ilabel) {
-    for (auto &hist : hists) {
-      hist->GetXaxis()->SetBinLabel(ilabel, labels[ilabel - 1].c_str());
-    }
-  }
+  setHistLabels("1n_event_type", {"nn", "pn", "#pi^{+}n", "#pi^{0}n", "other"});
 
-  std::vector<std::string> n_labels = {"",
-                                       "nn",        // 0
-                                       "pn",        // 1
-                                       "#pi^{+}n",  // 2
-                                       "#pi^{0}n",  // 3
-                                       "other",     // 4
-                                       ""};
+  setHistLabels(
+      "pn_vertex_volume",
+      {"Didn't happen", "Else", "W Cooling", "C Cooling", "PCB",
+       "CarbonBasePlate", "Absorber", "Sensor", "Glue", "Motherboard"});
 
-  TH1 *hist = histograms_.get("1n_event_type");
-  for (int ilabel{1}; ilabel < n_labels.size(); ++ilabel) {
-    hist->GetXaxis()->SetBinLabel(ilabel, n_labels[ilabel - 1].c_str());
-  }
-}
+  setHistLabels("pn_interaction_material",
+                {"Didn't happen", "Else", "Si", "W", "FR4", "Steel", "Epoxy",
+                 "PVT", "Glue", "Air"});
+
+}  // end of onProcessStart
 
 void PhotoNuclearDQM::configure(framework::config::Parameters &parameters) {
-  verbose_ = parameters.getParameter<bool>("verbose");
   count_light_ions_ = parameters.getParameter<bool>("count_light_ions", true);
 }
 
@@ -267,19 +237,88 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
   // photo-nuclear reaction.
   auto pnGamma{Analysis::getPNGamma(particleMap, recoil, 2500.)};
   if (pnGamma == nullptr) {
-    if (verbose_) {
-      std::cout << "[ PhotoNuclearDQM ]: PN Daughter is lost, skipping."
-                << std::endl;
-    }
+    ldmx_log(warn) << "PN Daughter is lost, skipping";
     return;
   }
+
   const auto pnDaughters{findDaughters(particleMap, pnGamma)};
+
+  if (!pnDaughters.empty()) {
+    auto pn_vertex_volume{pnDaughters[0]->getVertexVolume()};
+    auto pn_interaction_material{pnDaughters[0]->getInteractionMaterial()};
+
+    // Let's start with the PN vertex volume
+    if (pn_vertex_volume.find("W_cooling") != std::string::npos) {
+      // W_cooling_volume_X
+      histograms_.fill("pn_vertex_volume", 2);
+    } else if (pn_vertex_volume.find("C_volume") != std::string::npos) {
+      // C_volume_X
+      histograms_.fill("pn_vertex_volume", 3);
+    } else if (pn_vertex_volume.find("PCB_volume") != std::string::npos) {
+      histograms_.fill("pn_vertex_volume", 4);
+    } else if (pn_vertex_volume.find("CarbonBasePlate") != std::string::npos) {
+      // CarbonBasePlate_volume
+      histograms_.fill("pn_vertex_volume", 5);
+    } else if (pn_vertex_volume.find("W_front") != std::string::npos) {
+      // W_front_volume_X
+      histograms_.fill("pn_vertex_volume", 6);
+    } else if (pn_vertex_volume.find("Si_volume") != std::string::npos) {
+      histograms_.fill("pn_vertex_volume", 7);
+    } else if (pn_vertex_volume.find("Glue") != std::string::npos) {
+      ldmx_log(warn) << "Glue volume";
+      histograms_.fill("pn_vertex_volume", 8);
+    } else if (pn_vertex_volume.find("motherboard") != std::string::npos) {
+      histograms_.fill("pn_vertex_volume", 9);
+
+    } else {
+      ldmx_log(warn) << " Else pn_vertex_volume = " << pn_vertex_volume
+                     << " with pn_interaction_material = "
+                     << pn_interaction_material;
+      histograms_.fill("pn_vertex_volume", 1);
+    }
+
+    // Now the interaction material
+    if (pn_interaction_material.find("G4_Si") != std::string::npos) {
+      histograms_.fill("pn_interaction_material", 2);
+    } else if (pn_interaction_material.find("G4_W") != std::string::npos) {
+      histograms_.fill("pn_interaction_material", 3);
+    } else if (pn_interaction_material.find("FR4") != std::string::npos) {
+      // Glass epoxy
+      histograms_.fill("pn_interaction_material", 4);
+    } else if (pn_interaction_material.find("Steel") != std::string::npos) {
+      histograms_.fill("pn_interaction_material", 5);
+    } else if (pn_interaction_material.find("Epoxy") != std::string::npos) {
+      // CarbonEpoxyComposite
+      histograms_.fill("pn_interaction_material", 6);
+    } else if (pn_interaction_material.find("Scintillator") !=
+               std::string::npos) {
+      // This is the notion for PVT
+      histograms_.fill("pn_interaction_material", 7);
+    } else if (pn_interaction_material.find("Glue") != std::string::npos) {
+      // This is the notion for PVT
+      histograms_.fill("pn_interaction_material", 8);
+    } else if (pn_interaction_material.find("G4_AIR") != std::string::npos) {
+      // Air
+      histograms_.fill("pn_interaction_material", 9);
+    } else {
+      ldmx_log(warn) << " Else pn_interaction_material = "
+                     << pn_interaction_material
+                     << " with pn_vertex_volume = " << pn_vertex_volume;
+      histograms_.fill("pn_interaction_material", 1);
+    }
+  } else {
+    histograms_.fill("pn_vertex_volume", 0);
+    histograms_.fill("pn_interaction_material", 0);
+  }
+
   findParticleKinematics(pnDaughters);
 
   histograms_.fill("pn_particle_mult", pnGamma->getDaughters().size());
   histograms_.fill("pn_gamma_energy", pnGamma->getEnergy());
   histograms_.fill("pn_gamma_int_x", pnGamma->getEndPoint()[0]);
   histograms_.fill("pn_gamma_int_y", pnGamma->getEndPoint()[1]);
+  histograms_.fill("pn_gamma_int_x:pn_gamma_int_y", pnGamma->getEndPoint()[0],
+                   pnGamma->getEndPoint()[1]);
   histograms_.fill("pn_gamma_int_z", pnGamma->getEndPoint()[2]);
   histograms_.fill("pn_gamma_vertex_x", pnGamma->getVertex()[0]);
   histograms_.fill("pn_gamma_vertex_y", pnGamma->getVertex()[1]);

--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -271,8 +271,8 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
 
     } else {
       ldmx_log(debug) << " Else pn_vertex_volume = " << pn_vertex_volume
-                     << " with pn_interaction_material = "
-                     << pn_interaction_material;
+                      << " with pn_interaction_material = "
+                      << pn_interaction_material;
       histograms_.fill("pn_vertex_volume", 1);
     }
 
@@ -301,8 +301,8 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
       histograms_.fill("pn_interaction_material", 9);
     } else {
       ldmx_log(debug) << " Else pn_interaction_material = "
-                     << pn_interaction_material
-                     << " with pn_vertex_volume = " << pn_vertex_volume;
+                      << pn_interaction_material
+                      << " with pn_vertex_volume = " << pn_vertex_volume;
       histograms_.fill("pn_interaction_material", 1);
     }
   } else {

--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -265,13 +265,12 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
     } else if (pn_vertex_volume.find("Si_volume") != std::string::npos) {
       histograms_.fill("pn_vertex_volume", 7);
     } else if (pn_vertex_volume.find("Glue") != std::string::npos) {
-      ldmx_log(warn) << "Glue volume";
       histograms_.fill("pn_vertex_volume", 8);
     } else if (pn_vertex_volume.find("motherboard") != std::string::npos) {
       histograms_.fill("pn_vertex_volume", 9);
 
     } else {
-      ldmx_log(warn) << " Else pn_vertex_volume = " << pn_vertex_volume
+      ldmx_log(debug) << " Else pn_vertex_volume = " << pn_vertex_volume
                      << " with pn_interaction_material = "
                      << pn_interaction_material;
       histograms_.fill("pn_vertex_volume", 1);
@@ -301,7 +300,7 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
       // Air
       histograms_.fill("pn_interaction_material", 9);
     } else {
-      ldmx_log(warn) << " Else pn_interaction_material = "
+      ldmx_log(debug) << " Else pn_interaction_material = "
                      << pn_interaction_material
                      << " with pn_vertex_volume = " << pn_vertex_volume;
       histograms_.fill("pn_interaction_material", 1);

--- a/SimCore/include/SimCore/Event/SimParticle.h
+++ b/SimCore/include/SimCore/Event/SimParticle.h
@@ -122,6 +122,15 @@ class SimParticle {
   std::string getVertexVolume() const { return vertexVolume_; }
 
   /**
+   * Get the material name in which this particle was created in.
+   *
+   * The material names are set in the GDML detector description.
+   *
+   * @return The material name in which this particle was created in.
+   */
+  std::string getInteractionMaterial() const { return interactionMaterial_; }
+
+  /**
    * Get the endpoint of this particle where it was destroyed
    * or left the world volume [mm].
    *
@@ -216,6 +225,16 @@ class SimParticle {
    */
   void setVertexVolume(const std::string& vertexVolume) {
     vertexVolume_ = vertexVolume;
+  }
+
+  /**
+   * Set the name of the material that this particle was created in.
+   *
+   * @param[in] interactionMaterial volume name that this particle was
+   *      created in.
+   */
+  void setInteractionMaterial(const std::string& interactionMaterial) {
+    interactionMaterial_ = interactionMaterial;
   }
 
   /**
@@ -393,10 +412,13 @@ class SimParticle {
   /// Volume the track was created in.
   std::string vertexVolume_{""};
 
+  /// Volume the track was created in.
+  std::string interactionMaterial_{""};
+
   /// Map containing the process types.
   static ProcessTypeMap PROCESS_MAP;
 
-  ClassDef(SimParticle, 7);
+  ClassDef(SimParticle, 8);
 
 };  // SimParticle
 }  // namespace ldmx

--- a/SimCore/src/SimCore/TrackMap.cxx
+++ b/SimCore/src/SimCore/TrackMap.cxx
@@ -77,6 +77,7 @@ void TrackMap::save(const G4Track* track) {
 
   auto track_info{UserTrackInformation::get(track)};
   particle.setVertexVolume(track_info->getVertexVolume());
+  particle.setInteractionMaterial(track->GetMaterial()->GetName());
 
   auto vert{track->GetVertexPosition()};
   particle.setVertex(vert.x(), vert.y(), vert.z());


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1619

* Cleanup of the verbose flag
* Some cleanup of axis boundaries
* Add a new member to simhits keeping what material they were created in
* Display the material and volume of the PN interactions in the PN DQM

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

The plots show mostly interactions in W that makes sense, but there is a distribution of other materials, I tested with 100 events, let's see the big stats in the CI 