### PR TITLE
Additional information for 'dump files' used in firmware testbenchs

### DIFF
--- a/Trigger/Algo/include/Trigger/DiscreteInputs.h
+++ b/Trigger/Algo/include/Trigger/DiscreteInputs.h
@@ -11,22 +11,47 @@ namespace trigger {
 namespace ldmx_int {
 
 struct EcalTP {
+  uint8_t tp;
   uint32_t tid;
-  uint32_t tp;  // store linear version
-  // uint8_t tp;
-
+  // extra data for added convenience
+  uint32_t tp_lin;
+  uint32_t layer;
+  uint32_t module;
+  uint32_t cell;
+  
   bool operator<(const EcalTP &other) const { return tp > other.tp; }
-  void fill(int _tid, float _tp) {
+  void fill(int _tid, int _tp) {
     tid = _tid;
     tp = _tp;
+    // derived data, optional
+    layer   = 0;
+    module  = 0;
+    cell    = 0;
+    tp_lin  = 0;
+  }
+  void fill(int _tid, int _tp, int _layer, int _module, int _cell, float _tp_lin) {
+    tid     = _tid;
+    tp      = _tp;
+    layer   = _layer;
+    module  = _module;
+    cell    = _cell;
+    tp_lin  = _tp_lin;
   }
   void writeToFile(FILE *file) const {
+    fwrite(&tp, sizeof(uint8_t), 1, file);
     fwrite(&tid, sizeof(uint32_t), 1, file);
-    fwrite(&tp, sizeof(uint32_t), 1, file);
+    fwrite(&layer , sizeof(uint32_t), 1, file);
+    fwrite(&module, sizeof(uint32_t), 1, file);
+    fwrite(&cell  , sizeof(uint32_t), 1, file);
+    fwrite(&tp_lin, sizeof(uint32_t), 1, file);
   }
   void readFromFile(FILE *file) {
+    fread(&tp, sizeof(uint8_t), 1, file);
     fread(&tid, sizeof(uint32_t), 1, file);
-    fread(&tp, sizeof(uint32_t), 1, file);
+    fread(&layer , sizeof(uint32_t), 1, file);
+    fread(&module, sizeof(uint32_t), 1, file);
+    fread(&cell  , sizeof(uint32_t), 1, file);
+    fread(&tp_lin, sizeof(uint32_t), 1, file);
   }
 };
 

--- a/Trigger/Algo/include/Trigger/DiscreteInputs.h
+++ b/Trigger/Algo/include/Trigger/DiscreteInputs.h
@@ -18,39 +18,40 @@ struct EcalTP {
   uint32_t layer;
   uint32_t module;
   uint32_t cell;
-  
+
   bool operator<(const EcalTP &other) const { return tp > other.tp; }
   void fill(int _tid, int _tp) {
     tid = _tid;
     tp = _tp;
     // derived data, optional
-    layer   = 0;
-    module  = 0;
-    cell    = 0;
-    tp_lin  = 0;
+    layer = 0;
+    module = 0;
+    cell = 0;
+    tp_lin = 0;
   }
-  void fill(int _tid, int _tp, int _layer, int _module, int _cell, int _tp_lin) {
-    tid     = _tid;
-    tp      = _tp;
-    layer   = _layer;
-    module  = _module;
-    cell    = _cell;
-    tp_lin  = _tp_lin;
+  void fill(int _tid, int _tp, int _layer, int _module, int _cell,
+            int _tp_lin) {
+    tid = _tid;
+    tp = _tp;
+    layer = _layer;
+    module = _module;
+    cell = _cell;
+    tp_lin = _tp_lin;
   }
   void writeToFile(FILE *file) const {
     fwrite(&tp, sizeof(uint8_t), 1, file);
     fwrite(&tid, sizeof(uint32_t), 1, file);
-    fwrite(&layer , sizeof(uint32_t), 1, file);
+    fwrite(&layer, sizeof(uint32_t), 1, file);
     fwrite(&module, sizeof(uint32_t), 1, file);
-    fwrite(&cell  , sizeof(uint32_t), 1, file);
+    fwrite(&cell, sizeof(uint32_t), 1, file);
     fwrite(&tp_lin, sizeof(uint32_t), 1, file);
   }
   void readFromFile(FILE *file) {
     fread(&tp, sizeof(uint8_t), 1, file);
     fread(&tid, sizeof(uint32_t), 1, file);
-    fread(&layer , sizeof(uint32_t), 1, file);
+    fread(&layer, sizeof(uint32_t), 1, file);
     fread(&module, sizeof(uint32_t), 1, file);
-    fread(&cell  , sizeof(uint32_t), 1, file);
+    fread(&cell, sizeof(uint32_t), 1, file);
     fread(&tp_lin, sizeof(uint32_t), 1, file);
   }
 };

--- a/Trigger/Algo/include/Trigger/DiscreteInputs.h
+++ b/Trigger/Algo/include/Trigger/DiscreteInputs.h
@@ -29,7 +29,7 @@ struct EcalTP {
     cell    = 0;
     tp_lin  = 0;
   }
-  void fill(int _tid, int _tp, int _layer, int _module, int _cell, float _tp_lin) {
+  void fill(int _tid, int _tp, int _layer, int _module, int _cell, int _tp_lin) {
     tid     = _tid;
     tp      = _tp;
     layer   = _layer;

--- a/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
+++ b/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
@@ -24,14 +24,12 @@ void DumpFileWriter::analyze(const framework::Event& event) {
     // compressed ECal digis are 8xADCs (HCal will be 4x)
     ecalTpToE cvt;
     float e = cvt.calc(trigDigi.linearPrimitive(), tid.layer());
-    // float sie = 8 * trigDigi.linearPrimitive() * gain *
-    //             mVtoMeV;  // in MeV, before layer corrections
-    // float e = (sie / mipSiEnergy * layerWeights.at(tid.layer()) + sie) *
-    //           secondOrderEnergyCorrection;
 
     ldmx_int::EcalTP tp;
     // tp.fill( trigDigi.getId(), trigDigi.getPrimitive() );
-    tp.fill(trigDigi.getId(), e);  // store linearized E
+    // store complete information for firmware studies
+    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), e);
+    printf("%d %d (%d) %d %d %d \n",tp.tid,tp.tp,tp.tp_lin,tp.layer,tp.module,tp.cell);
     myEvent.EcalTPs.push_back(tp);
   }
 

--- a/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
+++ b/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
@@ -28,8 +28,7 @@ void DumpFileWriter::analyze(const framework::Event& event) {
     ldmx_int::EcalTP tp;
     // tp.fill( trigDigi.getId(), trigDigi.getPrimitive() );
     // store complete information for firmware studies
-    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), int(e));
-    printf("%d %d (%d) %d %d %d \n",tp.tid,tp.tp,tp.tp_lin,tp.layer,tp.module,tp.cell);
+    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), int(e));    
     myEvent.EcalTPs.push_back(tp);
   }
 

--- a/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
+++ b/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
@@ -28,7 +28,7 @@ void DumpFileWriter::analyze(const framework::Event& event) {
     ldmx_int::EcalTP tp;
     // tp.fill( trigDigi.getId(), trigDigi.getPrimitive() );
     // store complete information for firmware studies
-    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), e);
+    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), int(e));
     printf("%d %d (%d) %d %d %d \n",tp.tid,tp.tp,tp.tp_lin,tp.layer,tp.module,tp.cell);
     myEvent.EcalTPs.push_back(tp);
   }

--- a/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
+++ b/Trigger/Algo/src/Trigger/DumpFileWriter.cxx
@@ -28,7 +28,8 @@ void DumpFileWriter::analyze(const framework::Event& event) {
     ldmx_int::EcalTP tp;
     // tp.fill( trigDigi.getId(), trigDigi.getPrimitive() );
     // store complete information for firmware studies
-    tp.fill(trigDigi.getId(),trigDigi.getPrimitive(),tid.layer(), tid.module(), tid.triggercell(), int(e));    
+    tp.fill(trigDigi.getId(), trigDigi.getPrimitive(), tid.layer(),
+            tid.module(), tid.triggercell(), int(e));
     myEvent.EcalTPs.push_back(tp);
   }
 


### PR DESCRIPTION
I am expanding the information saved in the 'dump file' event format, used the pass trigger primitives to the firmware test bench setups.  Instead of just a packed detector ID and its encoded energy, extra information is saved for the module, layer, cell, and linearized energy in order to avoid duplicating the unpacking logic outside of ldmx-sw.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

I dumped 20 events into this new format and verified that I can read them in the firmware testbench.