### PR TITLE
Persist the pass name's version in the event header

### DIFF
--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -53,7 +53,7 @@ class Process {
    * Get the processing pass label.
    * @return The processing pass label.
    */
-  const std::string &getPassName() const { return passname_; }
+  const std::string &getPassName() const { return pass_name_; }
 
   /**
    * Get the current run number or the run number to be used when initiating new
@@ -169,7 +169,7 @@ class Process {
   framework::config::Parameters config_;
 
   /** Processing pass name. */
-  std::string passname_;
+  std::string pass_name_;
 
   /** Limit on events to process. */
   int eventLimit_;

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -461,7 +461,8 @@ void Process::newRun(ldmx::RunHeader &header) {
   // the run header through 'beforeNewRun' method
 
   // Put the version into the rh string param
-  header.setStringParameter("Pass = " + pass_name_ + " version", LDMXSW_VERSION);
+  header.setStringParameter("Pass = " + pass_name_ + " version",
+                            LDMXSW_VERSION);
   if (performance_) performance_->start(performance::Callback::beforeNewRun, 0);
   std::size_t i_proc{0};
   for (auto module : sequence_) {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -461,7 +461,7 @@ void Process::newRun(ldmx::RunHeader &header) {
   // the run header through 'beforeNewRun' method
 
   // Put the version into the rh string param
-  header.setStringParameter(pass_name_ + "_version", LDMXSW_VERSION);
+  header.setStringParameter("Pass = " + pass_name_ + " version", LDMXSW_VERSION);
   if (performance_) performance_->start(performance::Callback::beforeNewRun, 0);
   std::size_t i_proc{0};
   for (auto module : sequence_) {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -24,7 +24,7 @@ Process::Process(const framework::config::Parameters &configuration)
     : conditions_{*this} {
   config_ = configuration;
 
-  passname_ = configuration.getParameter<std::string>("passName", "");
+  pass_name_ = configuration.getParameter<std::string>("passName", "");
   histoFilename_ = configuration.getParameter<std::string>("histogramFile", "");
 
   maxTries_ = configuration.getParameter<int>("maxTriesPerEvent", 1);
@@ -149,7 +149,7 @@ void Process::run() {
   NtupleManager::getInstance().reset();
 
   // event bus for this process
-  Event theEvent(passname_);
+  Event theEvent(pass_name_);
   // the EventHeader object is created with the event bus as
   // one of its members, we obtain a pointer for the header
   // here so we can share it with the conditions system
@@ -459,6 +459,9 @@ TDirectory *Process::openHistoFile() {
 void Process::newRun(ldmx::RunHeader &header) {
   // Producers are allowed to put parameters into
   // the run header through 'beforeNewRun' method
+
+  // Put the version into the rh string param
+  header.setStringParameter(pass_name_ + "_version", LDMXSW_VERSION);
   if (performance_) performance_->start(performance::Callback::beforeNewRun, 0);
   std::size_t i_proc{0};
   for (auto module : sequence_) {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -461,7 +461,7 @@ void Process::newRun(ldmx::RunHeader &header) {
   // the run header through 'beforeNewRun' method
 
   // Put the version into the rh string param
-  header.setStringParameter("Pass = " + pass_name_ + " version",
+  header.setStringParameter("Pass = " + pass_name_ + ", version",
                             LDMXSW_VERSION);
   if (performance_) performance_->start(performance::Callback::beforeNewRun, 0);
   std::size_t i_proc{0};

--- a/SimCore/src/SimCore/Simulator.cxx
+++ b/SimCore/src/SimCore/Simulator.cxx
@@ -113,8 +113,8 @@ void Simulator::beforeNewRun(ldmx::RunHeader& header) {
                       "G4 Version string.";
   }
 
-  header.setStringParameter("ldmx-sw version", LDMXSW_VERSION);
-  header.setStringParameter("ldmx-sw revision", GIT_SHA1);
+  header.setStringParameter("SIM version", LDMXSW_VERSION);
+  header.setStringParameter("SIM revision", GIT_SHA1);
 }
 
 void Simulator::onNewRun(const ldmx::RunHeader& runHeader) {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1559

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

The printout 
```
  stringParameters: 
    BiasOperators::PhotoNuclear::Volume = ecal
    Geant4 revision = 
    Gen0 Class = simcore::generators::ParticleGun
    Gen0 Particle = e-
    ldmx-sw revision = 446e5c3345e00ee7aff45e249d6502d2e69b861f
    ldmx-sw version = v4.2.13
    test_version = v4.2.13
```