### PR TITLE
Add extended mag field map

### DIFF
--- a/MagFieldMap/README.md
+++ b/MagFieldMap/README.md
@@ -5,3 +5,5 @@ Magnetic field maps for LDMX detectors
 This fieldmap was taken from measurements of the dipole magnet used within HPS
 and then scaled to match the specifications of the dipole magnet expected to be
 used by LDMX.
+
+After v4.2.13 it got extended with zeros for ACTS extrapolations


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1562
(technically, but I'm not sure I like the solution)

I extended the grid to
```
    x_range = np.arange(-500.0, 500.0, 5.0)
    y_range = np.arange(-500.0, 500.0, 5.0)
    z_range = np.arange(-1500.0, 2500.0, 5.0)
```
and added zeros everywhere where the is no value already.
I also tried to just add zeros to the edges of the cude: this didnt work, since the bin size is stepping and it's not available.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments
- [x] I ran my developments and the following shows that they are successful.

The ACTS msg about propagation failure is gone.