### PR TITLE
unify when RunHeader is printed to info logging

### DIFF
--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -350,8 +350,8 @@ void Process::run() {
           if (rh != nullptr) {
             runHeader_ = rh;
             ldmx_log(info) << "Got new run header from '"
-                           << masterFile->getFileName() << "'"
-            newRun(*runHeader_);
+                           << masterFile->getFileName()
+                           << "'" newRun(*runHeader_);
           } else {
             ldmx_log(warn) << "Run header for run " << wasRun
                            << " was not found!";

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -245,7 +245,6 @@ void Process::run() {
 
     runHeader.setRunEnd(std::time(nullptr));
     runHeader.setNumTries(totalTries);
-    ldmx_log(info) << runHeader;
     outFile.writeRunTree();
 
     // Give a warning that this filter has very low efficiency
@@ -351,8 +350,7 @@ void Process::run() {
           if (rh != nullptr) {
             runHeader_ = rh;
             ldmx_log(info) << "Got new run header from '"
-                           << masterFile->getFileName() << "' ...\n"
-                           << *runHeader_;
+                           << masterFile->getFileName() << "'"
             newRun(*runHeader_);
           } else {
             ldmx_log(warn) << "Run header for run " << wasRun
@@ -486,6 +484,7 @@ void Process::newRun(ldmx::RunHeader &header) {
       performance_->stop(performance::Callback::onNewRun, i_proc);
   }
   if (performance_) performance_->stop(performance::Callback::onNewRun, 0);
+  ldmx_log(info) << header;
 }
 
 bool Process::process(int n, int n_try, Event &event) const {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -350,8 +350,8 @@ void Process::run() {
           if (rh != nullptr) {
             runHeader_ = rh;
             ldmx_log(info) << "Got new run header from '"
-                           << masterFile->getFileName()
-                           << "'"; newRun(*runHeader_);
+                           << masterFile->getFileName() << "'";
+            newRun(*runHeader_);
           } else {
             ldmx_log(warn) << "Run header for run " << wasRun
                            << " was not found!";

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -351,7 +351,7 @@ void Process::run() {
             runHeader_ = rh;
             ldmx_log(info) << "Got new run header from '"
                            << masterFile->getFileName()
-                           << "'" newRun(*runHeader_);
+                           << "'"; newRun(*runHeader_);
           } else {
             ldmx_log(warn) << "Run header for run " << wasRun
                            << " was not found!";


### PR DESCRIPTION
Instead of having the RunHeader be printed at different times depending on if we are in production mode (no input files) or reco mode (with input files), I move the printing of the RunHeader to the end of the `newRun` function. This will keep the printing in the same "time" for reco mode but will move it to the beginning of the run (before the event printouts) for production mode.


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This doesn't resolve any issues, but I was chatting with @tvami on slack and realized that the run header is printed to the log at wildly different times according to which mode we are running in. This change forces the run header to always be printed to the log (at info level) at the end of `newRun` (so after processors and calibrations have a chance to add parameters) but before the run actually starts.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments. Thanks @tvami for adding the `;`.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful.

Skipping the unrelated stuff in the logs from the acts magnetic field warnings/errors.

```diff
33a34,60
  > [ Process ] 0  info: RunHeader { run: 1, numTries: 0, detectorName: ldmx-det-v14-8gev, description: One e- fired far upstream with Dark Brem turned on and biased up in target
  >   intParameters: 
  >     BiasOperator::DarkBrem::Bias All Electrons = 0
  >     Included Scoring Planes = 1
  >     RandomNumberMasterSeed[test] = 1
  >     Use Random Seed from Event Header = 0
  >   floatParameters: 
  >     BiasOperator::DarkBrem::Factor = 1e+06
  >     Gen0 Direction X = 0.0485658
  >     Gen0 Direction Y = 0
  >     Gen0 Direction Z = 0.99882
  >     Gen0 Energy [GeV] = 8
  >     Gen0 Time [ns] = 0
  >     Gen0 X [mm] = -21.7459
  >     Gen0 Y [mm] = 0
  >     Gen0 Z [mm] = -883
  >     Smear Beam Spot [mm] X = 20
  >     Smear Beam Spot [mm] Y = 80
  >     Smear Beam Spot [mm] Z = 0
  >   stringParameters: 
  >     BiasOperator::DarkBrem::Volume = target_region
  >     Geant4 revision = 
  >     Gen0 Class = simcore::generators::ParticleGun
  >     Gen0 Particle = e-
  >     ldmx-sw revision = 40d8071ef3f111792[31](https://github.com/LDMX-Software/ldmx-sw/actions/runs/13532728239/job/37819198585#step:7:34)66c68b1a7050ba7f64b60
  >     ldmx-sw version = v4.2.13
  > }
...
  < [ Process ] 10000  info: RunHeader { run: 1, numTries: 75583, detectorName: ldmx-det-v14-8gev, description: One e- fired far upstream with Dark Brem turned on and biased up in target
  <   intParameters: 
  <     BiasOperator::DarkBrem::Bias All Electrons = 0
  <     Included Scoring Planes = 1
  <     RandomNumberMasterSeed[test] = 1
  <     Use Random Seed from Event Header = 0
  <   floatParameters: 
  <     BiasOperator::DarkBrem::Factor = 1e+06
  <     Gen0 Direction X = 0.0485658
  <     Gen0 Direction Y = 0
  <     Gen0 Direction Z = 0.99882
  <     Gen0 Energy [GeV] = 8
  <     Gen0 Time [ns] = 0
  <     Gen0 X [mm] = -21.7459
  <     Gen0 Y [mm] = 0
  <     Gen0 Z [mm] = -883
  <     Smear Beam Spot [mm] X = 20
  <     Smear Beam Spot [mm] Y = 80
  <     Smear Beam Spot [mm] Z = 0
  <   stringParameters: 
  <     BiasOperator::DarkBrem::Volume = target_region
  <     Geant4 revision = 
  <     Gen0 Class = simcore::generators::ParticleGun
  <     Gen0 Particle = e-
  <     ldmx-sw revision = eae9559d1d747984c40f8bb72db96fc52b3e14be
  <     ldmx-sw version = v4.2.13
  < }
  137805c137805
```