### PR TITLE
only fetch acts and compile it if not found in image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "docs/doxygen.conf/doxygen-awesome-css"]
 	path = docs/doxygen.conf/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css
-[submodule "Tracking/acts"]
-	path = Tracking/acts
-	url = https://github.com/acts-project/acts
 [submodule "Trigger/ruckus"]
 	path = Trigger/ruckus
 	url = https://github.com/slaclab/ruckus

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,9 @@ list(APPEND CMAKE_MODULE_PATH ${LDMX_SW_SOURCE_DIR}/cmake/)
 # is set to NOTFOUND.
 include(BuildMacros RESULT_VARIABLE build_macros_found)
 
-# Adding ROOT, ACTS, HLS arb prec as "SYSTEM" 
+# Adding ROOT as "SYSTEM" 
 # which will silence compiler warnings from these 3rd party softwares
 include_directories(SYSTEM /usr/local/include/root)
-include_directories(SYSTEM Tracking/acts/Core/include)
 
 # FunctionalCoreTest.cxx doesnt comply with clang-tidy but that's ok
 set_source_files_properties(Framework/test/FunctionalCoreTest.cxx PROPERTIES COMPILE_OPTIONS "-Wno-null-dereference")

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -71,6 +71,10 @@ if (NOT Acts_FOUND)
       URL_HASH MD5=f543dd8ba030bea2e4ee2f1b07dbe7c0
   )
   FetchContent_MakeAvailable(Acts)
+  FetchContent_GetProperties(Acts)
+  # Adding Acts as "SYSTEM" 
+  # which will silence compiler warnings from these 3rd party softwares
+  include_directories(SYSTEM "${Acts_SOURCE_DIR}/Core/include")
 endif()
 
 setup_geant4_target()

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -58,19 +58,22 @@ if(BUILD_EVENT_ONLY)
      return()
 endif()
 
-# since ACTS changes frequently enough, we build it as a submodule of Tracking
-#   here we could 'set' some CMake variables that we would have passed to 'cmake' on
-#   the command line with '-D' if we were building ACTS directly.
-# for example, disable the building of examples (which is already disabled by default)
-#set(ACTS_BUILD_EXAMPLES OFF)     # don't waste time building examples
-add_subdirectory(acts) # now build acts
-# luckily for us, adding ACTS as a subdirectory produces the same CMake targets
-#   as find_package, so we don't need to do anything else from here on out
-
 find_package(Eigen3 CONFIG REQUIRED)
+# if you want to try an alternate Acts, you can
+# 1. comment out the stuff here and replace with add_subdirectory(acts)
+# 2. git clone acts into this directory and choose your version
+find_package(Acts QUIET)
+if (NOT Acts_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+      Acts
+      URL https://github.com/acts-project/acts/archive/refs/tags/v36.0.0.tar.gz
+      URL_HASH MD5=f543dd8ba030bea2e4ee2f1b07dbe7c0
+  )
+  FetchContent_MakeAvailable(Acts)
+endif()
 
 setup_geant4_target()
-
 
 file(GLOB SRC_FILES CONFIGURE_DEPENDS 
   ${PROJECT_SOURCE_DIR}/src/Tracking/Sim/[a-zA-z]*.cxx

--- a/Tracking/CMakeLists.txt
+++ b/Tracking/CMakeLists.txt
@@ -64,6 +64,7 @@ find_package(Eigen3 CONFIG REQUIRED)
 # 2. git clone acts into this directory and choose your version
 find_package(Acts QUIET)
 if (NOT Acts_FOUND)
+  message(STATUS "Did not find Acts, downloading and compiling it here")
   include(FetchContent)
   FetchContent_Declare(
       Acts
@@ -75,6 +76,8 @@ if (NOT Acts_FOUND)
   # Adding Acts as "SYSTEM" 
   # which will silence compiler warnings from these 3rd party softwares
   include_directories(SYSTEM "${Acts_SOURCE_DIR}/Core/include")
+else()
+  message(STATUS "Found Acts ${Acts_VERSION}")
 endif()
 
 setup_geant4_target()

--- a/cmake/BuildMacros.cmake
+++ b/cmake/BuildMacros.cmake
@@ -25,7 +25,7 @@ function(message)
     list(REMOVE_AT ARGV 0)
     _message("${green}[ INFO ]: ${ARGV}${color_reset}")
   else()
-    _message("${green} ${ARGV} ${color_reset}")
+    _message(${ARGV})
   endif()
 endfunction()
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This does not have a corresponding issue here. I am following up with https://github.com/LDMX-Software/dev-build-context/pull/115 while preparing for a v5 release of the ldmx/dev image.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments. I test compiled with the newer image that has Acts locally. The CI will check that these developments work with the v4.2.2 image that does not have Acts.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
The CI checks that an image without Acts can still compile and run.
I can show that this works with the newer image candidate that has Acts built in.
```
tom@appa:~/code/ldmx/ldmx-sw$ just use ldmx/dev:5.0.0-rc1
denv config image ldmx/dev:5.0.0-rc1
tom@appa:~/code/ldmx/ldmx-sw$ just configure
git fetch --tags && git describe --tags | cut -f 1 -d '-' > VERSION
denv cmake -B build -S . -DADDITIONAL_WARNINGS=ON -DENABLE_CLANG_TIDY=ON 
[ INFO ]: Building all modules.
[ INFO ]: Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: log 
[ INFO ]: Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: system log filesystem thread chrono atomic regex 
[ INFO ]: Deduced git SHA: 06e0b4dcde035ef689ab83b104b0f5f89d212c49
[ INFO ]: Building ROOT dictionary LinkDef
Looking for libboost_python
[ INFO ]: Building the modules necessary for the reconstruction.
[ INFO ]: Found ONNX Runtime version 
[ INFO ]: Found Acts 36.0.0
[ INFO ]: Found Geant4 version 10.2.3
[ INFO ]: Building the modules necessary for the simulation.
[ INFO ]: Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found version "1.83.0") found components: log 
[ INFO ]: Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.83.0/BoostConfig.cmake (found suitable version "1.83.0", minimum required is "1.68") found components: iostreams 
[ INFO ]: Installing all field map files.
-- Configuring done (0.7s)
-- Generating done (0.5s)
-- Build files have been written to: /home/tom/code/ldmx/ldmx-sw/build
```