### PR TITLE
Improve Exception handling printout

### DIFF
--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -117,11 +117,12 @@ int main(int argc, char* argv[]) try {
     //  if an Exception is thrown, we haven't gotten to the end of Process::run
     //  where logging is closed, so we can do one more error message and then
     //  close it.
-    auto theLog_{framework::logging::makeLogger(
-        "fire")};  // ldmx_log macro needs this variable to be named 'theLog_'
+    // ldmx_log macro needs this variable to be named 'theLog_'
+    auto theLog_{framework::logging::makeLogger("fire")};  
     ldmx_log(fatal) << "[" << e.name() << "] : " << e.message() << "\n"
                     << "  at " << e.module() << ":" << e.line() << " in "
-                    << e.function() << std::endl;
+                    << e.function();
+    ldmx_log(debug) << e.stackTrace();
     framework::logging::close();
     return 1;  // return non-zero error-status
   }

--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -118,7 +118,7 @@ int main(int argc, char* argv[]) try {
     //  where logging is closed, so we can do one more error message and then
     //  close it.
     // ldmx_log macro needs this variable to be named 'theLog_'
-    auto theLog_{framework::logging::makeLogger("fire")};  
+    auto theLog_{framework::logging::makeLogger("fire")};
     ldmx_log(fatal) << "[" << e.name() << "] : " << e.message() << "\n"
                     << "  at " << e.module() << ":" << e.line() << " in "
                     << e.function();


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1644

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x]  I ran my developments and the following shows that they are successful.


```
[ fire ] 1 fatal: [ProductNotFound] : No product found for name 'EcalScoringPlaneHits' and pass 'test'
  at /home/vamitamas/ldmx-analysis/ldmx-sw/Framework/include/Framework/Event.h:358 in getObject    
    
    0 std::vector<ldmx::SimTrackerHit, std::allocator<ldmx::SimTrackerHit> > const& framework::Event::getObject<std::vector<ldmx::SimTrackerHit, std::allocator<ldmx::SimTrackerHit> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const + 5113 
    1 tracking::dqm::TrackingRecoDQM::analyze(framework::Event const&) + 2550 
    2 framework::Process::process(int, int, framework::Event&) const + 153 
    3 framework::Process::run() + 9336 
    4 fire(+0x614c) [0x555de0fb314c]
    5 /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f6878b81d90]
````
