### PR TITLE
Add flag to not run ECAL lin-reg

### DIFF
--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -179,6 +179,7 @@ class EcalVetoProcessor : public framework::Producer {
   double bdtCutVal_{0};
 
   double beamEnergyMeV_{0};
+  bool run_lin_reg_{true};
   double linreg_radius_{0};
 
   bool verbose_{false};

--- a/Ecal/python/vetos.py
+++ b/Ecal/python/vetos.py
@@ -21,6 +21,7 @@ class EcalVetoProcessor(ldmxcfg.Producer) :
         self.bdt_file = makeBDTPath( "segmip" )
         self.roc_file = makeRoCPath( 'RoC_v14_8gev' )
         self.beam_energy = 8000.0  # in MeV
+        self.run_lin_reg = True
         self.linreg_radius = 35.0 # in mm
         self.disc_cut = 0.99741
         self.collection_name = "EcalVeto"

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -142,6 +142,7 @@ void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
   ecalLayerTime_.resize(nEcalLayers_, 0);
 
   beamEnergyMeV_ = parameters.getParameter<double>("beam_energy");
+  run_lin_reg_ = parameters.getParameter<bool>("run_lin_reg");
   linreg_radius_ = parameters.getParameter<double>("linreg_radius");
 
   // Set the collection name as defined in the configuration
@@ -1044,7 +1045,9 @@ void EcalVetoProcessor::produce(framework::Event &event) {
                  << trackingHitList.size() << " hits using a radius of "
                  << linreg_radius_ << " mm";
 
-  for (int iHit = 0; iHit < trackingHitList.size(); iHit++) {
+  int max_lin_reg_hit{0};
+  if (run_lin_reg_) max_lin_reg_hit = trackingHitList.size();
+  for (int iHit = 0; iHit < max_lin_reg_hit; iHit++) {
     // Hits being considered at a given time
     std::vector<int> hitsInRegion;
     TMatrixD Vm(3, 3);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

We will do this correctly too when factorizing the EcalVeto (in progress by @JYoo001 ) 
But since this takes a long time I wanted a quick and dirty solution to switch off running the ECAL lin-reg

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
