### PR TITLE
Add Hcal digi from correct bar end, when zero suppression is turned off 

### DIFF
--- a/Hcal/src/Hcal/HcalDigiProducer.cxx
+++ b/Hcal/src/Hcal/HcalDigiProducer.cxx
@@ -268,7 +268,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
           hcalDigis.addDigi(posendID.raw(), digi);
         }
         if (negEndActivity) {
-          hcalDigis.addDigi(posendID.raw(), digiToAddPosend);
+          hcalDigis.addDigi(negendID.raw(), digiToAddNegend);
         } else {
           std::vector<ldmx::HgcrocDigiCollection::Sample> digi =
               hgcroc_->noiseDigi(negendID.raw(), 0.0);


### PR DESCRIPTION
### What are the issues that this addresses?
I ran a simulation of the HCal prototype with zero suppression turned off, and expected the same amount of HCal digis on the positive end (0) of bars as on the negative end (1) (all bars have double-ended readout in the prototype). But the positive end had significantly more digis save to file:

[UnbalancedEnds.pdf](https://github.com/user-attachments/files/19398075/UnbalancedEnds.pdf)

By mistake, digis from activity on the negative end were not added properly. Digis that are pure noise are not effected by this, and this code block only runs when zero suppression is turned off. Simple one-line fix. 

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [X] I ran my developments and the following shows that they are successful.

Now the ends are perfectly balanced: 
[BalancedEnds.pdf](https://github.com/user-attachments/files/19398095/BalancedEnds.pdf)

