### PR TITLE
only copy over golden histograms/logs

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -63,7 +63,11 @@ jobs:
       shell: bash
 
     - name: Git Gold Histograms from trunk
-      run: git checkout origin/trunk -- .github/validation_samples/*/**
+      if: github.event_name == 'issue_comment'
+      run: |
+        git checkout origin/trunk \
+          -- .github/validation_samples/*/**.root .github/validation_samples/*/**.log
+        git status
       shell: bash
 
     - name: Package ldmx-sw Into Artifact


### PR DESCRIPTION
don't override config and don't bother doing this copy for PRs where GitHub handles the merging for us

related to discussion in #1660 