### PR TITLE
Fix Ecal lin-reg bug, switch lin-reg off by default

### DIFF
--- a/Ecal/python/vetos.py
+++ b/Ecal/python/vetos.py
@@ -21,7 +21,7 @@ class EcalVetoProcessor(ldmxcfg.Producer) :
         self.bdt_file = makeBDTPath( "segmip" )
         self.roc_file = makeRoCPath( 'RoC_v14_8gev' )
         self.beam_energy = 8000.0  # in MeV
-        self.run_lin_reg = True
+        self.run_lin_reg = False
         self.linreg_radius = 35.0 # in mm
         self.disc_cut = 0.99741
         self.collection_name = "EcalVeto"

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -1178,7 +1178,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
     // Exclude all hits in a found track from further consideration:
     for (int lHit = 0; lHit < 3; lHit++) {
-      if (!trackingHitList.empty()){
+      if (!trackingHitList.empty()) {
         trackingHitList.erase(trackingHitList.begin() + bestHitNums[lHit]);
       }
     }

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -1178,7 +1178,9 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
     // Exclude all hits in a found track from further consideration:
     for (int lHit = 0; lHit < 3; lHit++) {
-      trackingHitList.erase(trackingHitList.begin() + bestHitNums[lHit]);
+      if (!trackingHitList.empty()){
+        trackingHitList.erase(trackingHitList.begin() + bestHitNums[lHit]);
+      }
     }
     iHit--;
   }  // end loop on all hits


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1661

But since I was there... and we dont use lin-reg for anything at this point, I changed the default to zero.
This will lead to a new gold but it's ok we have another PR that need new gold anyway.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
