### PR TITLE
Prep for ldmx/dev v5 with some more compiler patches

### DIFF
--- a/Biasing/include/Biasing/DeepEcalProcessFilter.h
+++ b/Biasing/include/Biasing/DeepEcalProcessFilter.h
@@ -74,10 +74,8 @@ class DeepEcalProcessFilter : public simcore::UserAction {
   double ecal_min_Z_{400.};
   /// Require that the hard brem photon originates from the target
   bool require_photon_fromTarget_{false};
-  /// Enable logging
-  enableLogging("DeepEcalProcessFilter")
-      /// member used to help tag events where the photon comes from the target
-      bool photonFromTarget_{false};
+  /// member used to help tag events where the photon comes from the target
+  bool photonFromTarget_{false};
   /// member used to help tag events that have a deep-ecal process ocurr
   bool hasDeepEcalProcess_{false};
 };  // DeepEcalProcessFilter

--- a/Biasing/include/Biasing/EcalProcessFilter.h
+++ b/Biasing/include/Biasing/EcalProcessFilter.h
@@ -64,9 +64,6 @@ class EcalProcessFilter : public simcore::UserAction {
   /// Process to filter
   std::string process_{""};
 
-  /// Enable logging
-  enableLogging("EcalProcessFilter")
-
 };  // EcalProcessFilter
 }  // namespace biasing
 

--- a/Biasing/include/Biasing/NonFiducialFilter.h
+++ b/Biasing/include/Biasing/NonFiducialFilter.h
@@ -65,9 +65,6 @@ class NonFiducialFilter : public simcore::UserAction {
   double recoil_max_p_{1500};  // MeV
   /// If turned on, this aborts fiducial events.
   bool abort_fiducial_{true};
-  /// Enable logging
-  enableLogging("NonFiducialFilter")
-
 };  // NonFiducialFilter
 }  // namespace biasing
 

--- a/Biasing/include/Biasing/PrimaryToEcalFilter.h
+++ b/Biasing/include/Biasing/PrimaryToEcalFilter.h
@@ -63,8 +63,6 @@ class PrimaryToEcalFilter : public simcore::UserAction {
   /// Energy [MeV] below which a primary should be vetoed.
   double threshold_;
 
-  enableLogging("PrimaryToEcalFilter");
-
 };  // PrimaryToEcalFilter
 
 }  // namespace biasing

--- a/Biasing/include/Biasing/TaggerHitFilter.h
+++ b/Biasing/include/Biasing/TaggerHitFilter.h
@@ -61,8 +61,6 @@ class TaggerHitFilter : public simcore::UserAction {
   std::set<int> layer_count_;
   /// Total number of hits required to persist an event.
   int layers_hit_{8};
-  /// Enable logging
-  enableLogging("TaggerHitFilter")
 
 };  // TaggerHitFilter
 }  // namespace biasing

--- a/Biasing/include/Biasing/TaggerVetoFilter.h
+++ b/Biasing/include/Biasing/TaggerVetoFilter.h
@@ -84,8 +84,6 @@ class TaggerVetoFilter : public simcore::UserAction {
   // entered the tagger region?
   bool reject_primaries_missing_tagger_{true};
 
-  enableLogging("TaggerVetoFilter");
-
 };  // TaggerVetoFilter
 
 }  // namespace biasing

--- a/Biasing/include/Biasing/TargetBremFilter.h
+++ b/Biasing/include/Biasing/TargetBremFilter.h
@@ -71,8 +71,6 @@ class TargetBremFilter : public simcore::UserAction {
   /// Flag indicating if the recoil electron track should be killed
   bool killRecoil_{false};
 
-  enableLogging("TargetBremFilter");
-
 };  // TargetBremFilter
 }  // namespace biasing
 

--- a/Biasing/include/Biasing/TargetDarkBremFilter.h
+++ b/Biasing/include/Biasing/TargetDarkBremFilter.h
@@ -141,9 +141,6 @@ class TargetDarkBremFilter : public simcore::UserAction {
    */
   void AbortEvent(const std::string& reason) const;
 
-  /** Enable logging for this class */
-  enableLogging("TargetDarkBremFilter");
-
  private:
   /**
    * Minimum energy [MeV] that the A' should have to keep the event.

--- a/Biasing/include/Biasing/TargetENProcessFilter.h
+++ b/Biasing/include/Biasing/TargetENProcessFilter.h
@@ -61,8 +61,6 @@ class TargetENProcessFilter : public simcore::UserAction {
   /// Process to filter on
   std::string process_{"electronNuclear"};
 
-  enableLogging("TargetENProcessFilter");
-
 };  // TargetENProcessFilter
 }  // namespace biasing
 

--- a/Biasing/include/Biasing/TargetProcessFilter.h
+++ b/Biasing/include/Biasing/TargetProcessFilter.h
@@ -68,8 +68,6 @@ class TargetProcessFilter : public simcore::UserAction {
 
   /// The process to bias
   std::string process_{""};
-
-  enableLogging("TargetBremFilter");
 };
 
 }  // namespace biasing

--- a/Biasing/src/Biasing/DeepEcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/DeepEcalProcessFilter.cxx
@@ -53,11 +53,9 @@ void DeepEcalProcessFilter::stepping(const G4Step* step) {
   }
 
   // Check in which volume the particle is currently
-  auto volume = track->GetVolume()->GetLogicalVolume();
-  auto volume_name = volume->GetName();
-  if (!volume_name) {
-    volume_name = "undefined";
-  }
+  auto phys_vol{track->GetVolume()};
+  auto volume{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
+  auto volume_name{volume ? volume->GetName() : "undefined"};
 
   auto trackInfo{simcore::UserTrackInformation::get(track)};
   // Tag the brem photon from the primary electron

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -48,6 +48,11 @@ G4ClassificationOfNewTrack EcalProcessFilter::ClassifyNewTrack(
 }
 
 void EcalProcessFilter::stepping(const G4Step* step) {
+  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  if (!calorimeter_region) {
+    ldmx_log(warn)
+        << "Region 'CalorimeterRegion' not found in Geant4 region store";
+  }
   // Get the track associated with this step.
   auto track{step->GetTrack()};
 
@@ -63,13 +68,10 @@ void EcalProcessFilter::stepping(const G4Step* step) {
 
   // Get the region the particle is currently in.  Continue processing
   // the particle only if it's in the calorimeter region.
-  auto region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
-  if (!region) {
-    ldmx_log(warn)
-        << "Region 'CalorimeterRegion' not found in Geant4 region store";
-  }
-
-  if (track->GetVolume()->GetLogicalVolume()->GetRegion() != region) {
+  auto phys_vol{track->GetVolume()};
+  auto lv{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
+  auto region{lv ? lv->GetRegion() : nullptr};
+  if (region != calorimeter_region) {
     // If secondaries were produced outside of the volume of interest,
     // and there aren't additional brems to process, abort the
     // event.  Otherwise, suspend the track and move on to the next
@@ -106,16 +108,17 @@ void EcalProcessFilter::stepping(const G4Step* step) {
     /**
      * Check if the photon will be exiting the ecal
      *
-     * The 'hcal_PV' volume name is automatically constructed by Geant4's
-     * GDML parser and was found by inspecting the geometry using a
-     * visualization. This Physical Volume (PV) is associated with the
-     * hcal parent volume and so it will break if the hcal parent volume
-     * changes its name.
+     * The 'hadronic_calorimeter' logical volume name is the parent
+     * volume to all of the HCal components.
      */
-    auto volume_after_exiting_ecal =
+    static auto volume_after_exiting_ecal =
         simcore::g4user::ptrretrieval::getLogicalVolume("hadronic_calorimeter");
-    auto volume = track->GetNextVolume()->GetLogicalVolume();
-    if (volume == volume_after_exiting_ecal) {
+    if (!volume_after_exiting_ecal) {
+      ldmx_log(warn) << "Unable to find 'hadronic_calorimeter' logical volume.";
+    }
+    auto next_phys_vol = track->GetNextVolume();
+    auto next_log_vol{next_phys_vol ? next_phys_vol->GetLogicalVolume() : nullptr};
+    if (next_log_vol == volume_after_exiting_ecal) {
       /*
       std::cout << "[ EcalProcessFilter ]: "
             <<

--- a/Biasing/src/Biasing/EcalProcessFilter.cxx
+++ b/Biasing/src/Biasing/EcalProcessFilter.cxx
@@ -48,7 +48,8 @@ G4ClassificationOfNewTrack EcalProcessFilter::ClassifyNewTrack(
 }
 
 void EcalProcessFilter::stepping(const G4Step* step) {
-  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  static auto calorimeter_region =
+      simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
   if (!calorimeter_region) {
     ldmx_log(warn)
         << "Region 'CalorimeterRegion' not found in Geant4 region store";
@@ -117,7 +118,8 @@ void EcalProcessFilter::stepping(const G4Step* step) {
       ldmx_log(warn) << "Unable to find 'hadronic_calorimeter' logical volume.";
     }
     auto next_phys_vol = track->GetNextVolume();
-    auto next_log_vol{next_phys_vol ? next_phys_vol->GetLogicalVolume() : nullptr};
+    auto next_log_vol{next_phys_vol ? next_phys_vol->GetLogicalVolume()
+                                    : nullptr};
     if (next_log_vol == volume_after_exiting_ecal) {
       /*
       std::cout << "[ EcalProcessFilter ]: "

--- a/Biasing/src/Biasing/MidShowerDiMuonBkgdFilter.cxx
+++ b/Biasing/src/Biasing/MidShowerDiMuonBkgdFilter.cxx
@@ -4,8 +4,8 @@
 #include "G4Gamma.hh"
 #include "G4RunManager.hh"
 #include "G4Step.hh"
-#include "SimCore/UserTrackInformation.h"
 #include "SimCore/G4User/PtrRetrieval.h"
+#include "SimCore/UserTrackInformation.h"
 
 namespace biasing {
 
@@ -87,7 +87,8 @@ void MidShowerDiMuonBkgdFilter::NewStage() {
 
 bool MidShowerDiMuonBkgdFilter::isOutsideCalorimeterRegion(
     const G4Step* step) const {
-  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  static auto calorimeter_region =
+      simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
   if (!calorimeter_region) {
     ldmx_log(warn)
         << "Region 'CalorimeterRegion' not found in Geant4 region store";

--- a/Biasing/src/Biasing/MidShowerDiMuonBkgdFilter.cxx
+++ b/Biasing/src/Biasing/MidShowerDiMuonBkgdFilter.cxx
@@ -5,6 +5,7 @@
 #include "G4RunManager.hh"
 #include "G4Step.hh"
 #include "SimCore/UserTrackInformation.h"
+#include "SimCore/G4User/PtrRetrieval.h"
 
 namespace biasing {
 
@@ -86,12 +87,16 @@ void MidShowerDiMuonBkgdFilter::NewStage() {
 
 bool MidShowerDiMuonBkgdFilter::isOutsideCalorimeterRegion(
     const G4Step* step) const {
+  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  if (!calorimeter_region) {
+    ldmx_log(warn)
+        << "Region 'CalorimeterRegion' not found in Geant4 region store";
+  }
   // the pointers in this chain are assumed to be always valid
-  auto reg{step->GetTrack()->GetVolume()->GetLogicalVolume()->GetRegion()};
-  if (reg) return (reg->GetName() != "CalorimeterRegion");
-  // region is nullptr ==> no region defined for current volume
-  //  ==> outside CalorimeterRegion
-  return true;
+  auto phys_vol{step->GetTrack()->GetVolume()};
+  auto log_vol{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
+  auto reg{log_vol ? log_vol->GetRegion() : nullptr};
+  return (reg != calorimeter_region);
 }
 
 void MidShowerDiMuonBkgdFilter::save(const G4Track* track) const {

--- a/Biasing/src/Biasing/MidShowerNuclearBkgdFilter.cxx
+++ b/Biasing/src/Biasing/MidShowerNuclearBkgdFilter.cxx
@@ -3,8 +3,8 @@
 #include "G4EventManager.hh"
 #include "G4RunManager.hh"
 #include "G4Step.hh"
-#include "SimCore/UserTrackInformation.h"
 #include "SimCore/G4User/PtrRetrieval.h"
+#include "SimCore/UserTrackInformation.h"
 
 namespace biasing {
 
@@ -74,7 +74,8 @@ void MidShowerNuclearBkgdFilter::NewStage() {
 
 bool MidShowerNuclearBkgdFilter::isOutsideCalorimeterRegion(
     const G4Step* step) const {
-  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  static auto calorimeter_region =
+      simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
   if (!calorimeter_region) {
     ldmx_log(warn)
         << "Region 'CalorimeterRegion' not found in Geant4 region store";

--- a/Biasing/src/Biasing/MidShowerNuclearBkgdFilter.cxx
+++ b/Biasing/src/Biasing/MidShowerNuclearBkgdFilter.cxx
@@ -4,6 +4,7 @@
 #include "G4RunManager.hh"
 #include "G4Step.hh"
 #include "SimCore/UserTrackInformation.h"
+#include "SimCore/G4User/PtrRetrieval.h"
 
 namespace biasing {
 
@@ -73,12 +74,16 @@ void MidShowerNuclearBkgdFilter::NewStage() {
 
 bool MidShowerNuclearBkgdFilter::isOutsideCalorimeterRegion(
     const G4Step* step) const {
+  static auto calorimeter_region = simcore::g4user::ptrretrieval::getRegion("CalorimeterRegion");
+  if (!calorimeter_region) {
+    ldmx_log(warn)
+        << "Region 'CalorimeterRegion' not found in Geant4 region store";
+  }
   // the pointers in this chain are assumed to be always valid
-  auto reg{step->GetTrack()->GetVolume()->GetLogicalVolume()->GetRegion()};
-  if (reg) return (reg->GetName() != "CalorimeterRegion");
-  // region is nullptr ==> no region defined for current volume
-  //  ==> outside CalorimeterRegion
-  return true;
+  auto phys_vol{step->GetTrack()->GetVolume()};
+  auto log_vol{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
+  auto reg{log_vol ? log_vol->GetRegion() : nullptr};
+  return (reg != calorimeter_region);
 }
 
 bool MidShowerNuclearBkgdFilter::isNuclearProcess(

--- a/Biasing/src/Biasing/NonFiducialFilter.cxx
+++ b/Biasing/src/Biasing/NonFiducialFilter.cxx
@@ -48,7 +48,8 @@ void NonFiducialFilter::stepping(const G4Step* step) {
   }
 
   // Check in which volume the electron is currently
-  auto volume = track->GetVolume()->GetLogicalVolume();
+  auto phys_vol = track->GetVolume();
+  auto volume{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
 
   // Check if the track is tagged.
   auto electronCheck{simcore::UserTrackInformation::get(track)};
@@ -63,7 +64,7 @@ void NonFiducialFilter::stepping(const G4Step* step) {
     }
     // Check if the track ever enters the ECal. If it does, kill the track and
     // abort the event.
-    auto volume_name = volume->GetName();
+    auto volume_name{volume ? volume->GetName() : "undefined"};
     auto is_in_ecal =
         simcore::g4user::volumechecks::isInEcal(volume, volume_name);
     if (abort_fiducial_ && is_in_ecal) {
@@ -81,7 +82,7 @@ void NonFiducialFilter::stepping(const G4Step* step) {
     return;
   } else {
     // Check if the particle enters the recoil tracker.
-    auto recoil_volume =
+    static auto recoil_volume =
         simcore::g4user::ptrretrieval::getLogicalVolume("recoil");
     if (!recoil_volume) {
       ldmx_log(warn) << "Volume 'recoil' not found in Geant4 volume store";

--- a/Biasing/src/Biasing/TaggerHitFilter.cxx
+++ b/Biasing/src/Biasing/TaggerHitFilter.cxx
@@ -34,15 +34,19 @@ void TaggerHitFilter::stepping(const G4Step* step) {
   }
 
   // Only electrons in the Tagger region are of interest.
-  auto current_region = (track->GetVolume()->GetLogicalVolume()->GetRegion());
-  auto tagger_region = simcore::g4user::ptrretrieval::getRegion("tagger");
+  auto phys_vol{track->GetVolume()};
+  auto volume{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
+  auto current_region{volume ? volume->GetRegion() : nullptr};
+  static auto tagger_region = simcore::g4user::ptrretrieval::getRegion("tagger");
   if (!tagger_region) {
     ldmx_log(warn) << "Region 'tagger' not found in Geant4 region store";
   }
   if (current_region != tagger_region) return;
 
   // Check if we are exiting the tagger
-  auto next_region = (track->GetNextVolume()->GetLogicalVolume()->GetRegion());
+  auto next_phy_vol{track->GetNextVolume()};
+  auto next_log_vol{next_phy_vol ? next_phy_vol->GetLogicalVolume() : nullptr};
+  auto next_region{next_log_vol ? next_log_vol->GetRegion() : nullptr};
   if (next_region != tagger_region) {
     checkAbortEvent(track);
     return;
@@ -51,7 +55,7 @@ void TaggerHitFilter::stepping(const G4Step* step) {
   // A particle will only leave hits in the active silicon so other volumes can
   // be skipped for now.
   auto current_volume = (track->GetVolume());
-  auto tagger_physical_volume =
+  static auto tagger_physical_volume =
       simcore::g4user::ptrretrieval::getPhysicalVolume("tagger_PV");
   if (!tagger_physical_volume) {
     ldmx_log(warn) << "Volume 'tagger_PV' not found in Geant4 volume store";

--- a/Biasing/src/Biasing/TaggerHitFilter.cxx
+++ b/Biasing/src/Biasing/TaggerHitFilter.cxx
@@ -37,7 +37,8 @@ void TaggerHitFilter::stepping(const G4Step* step) {
   auto phys_vol{track->GetVolume()};
   auto volume{phys_vol ? phys_vol->GetLogicalVolume() : nullptr};
   auto current_region{volume ? volume->GetRegion() : nullptr};
-  static auto tagger_region = simcore::g4user::ptrretrieval::getRegion("tagger");
+  static auto tagger_region =
+      simcore::g4user::ptrretrieval::getRegion("tagger");
   if (!tagger_region) {
     ldmx_log(warn) << "Region 'tagger' not found in Geant4 region store";
   }

--- a/Biasing/src/Biasing/TaggerHitFilter.cxx
+++ b/Biasing/src/Biasing/TaggerHitFilter.cxx
@@ -64,7 +64,7 @@ void TaggerHitFilter::stepping(const G4Step* step) {
   auto* preStepPoint = step->GetPreStepPoint();
   if (preStepPoint) {
     // Get the touchable handle
-    auto touchableHandle = preStepPoint->GetTouchableHandle();
+    const auto& touchableHandle = preStepPoint->GetTouchableHandle();
     if (touchableHandle) {
       // Get the history
       auto* history = touchableHandle->GetHistory();

--- a/Biasing/src/Biasing/TargetBremFilter.cxx
+++ b/Biasing/src/Biasing/TargetBremFilter.cxx
@@ -64,7 +64,8 @@ void TargetBremFilter::stepping(const G4Step* step) {
 
   // Get the region the particle is currently in.  Continue processing
   // the particle only if it's in the target region.
-  static auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
+  static auto target_region =
+      simcore::g4user::ptrretrieval::getRegion("target");
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }

--- a/Biasing/src/Biasing/TargetBremFilter.cxx
+++ b/Biasing/src/Biasing/TargetBremFilter.cxx
@@ -64,11 +64,12 @@ void TargetBremFilter::stepping(const G4Step* step) {
 
   // Get the region the particle is currently in.  Continue processing
   // the particle only if it's in the target region.
-  auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
+  static auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }
-  auto track_region = track->GetVolume()->GetLogicalVolume()->GetRegion();
+  auto log_vol{track->GetVolume() ? track->GetVolume()->GetLogicalVolume() : nullptr};
+  auto track_region{log_vol ? log_vol->GetRegion() : nullptr};
   if (track_region != target_region) return;
 
   /*

--- a/Biasing/src/Biasing/TargetBremFilter.cxx
+++ b/Biasing/src/Biasing/TargetBremFilter.cxx
@@ -68,7 +68,8 @@ void TargetBremFilter::stepping(const G4Step* step) {
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }
-  auto log_vol{track->GetVolume() ? track->GetVolume()->GetLogicalVolume() : nullptr};
+  auto phy_vol{track->GetVolume()};
+  auto log_vol{phy_vol ? phy_vol->GetLogicalVolume() : nullptr};
   auto track_region{log_vol ? log_vol->GetRegion() : nullptr};
   if (track_region != target_region) return;
 

--- a/Biasing/src/Biasing/TargetProcessFilter.cxx
+++ b/Biasing/src/Biasing/TargetProcessFilter.cxx
@@ -63,7 +63,8 @@ void TargetProcessFilter::stepping(const G4Step* step) {
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }
-  auto log_vol{track->GetVolume()->GetLogicalVolume()};
+  auto phy_vol{track->GetVolume()};
+  auto log_vol{phy_vol ? phy_vol->GetLogicalVolume() : nullptr};
   auto current_region{log_vol ? log_vol->GetRegion() : nullptr};
   if (current_region != target_region) {
     // If secondaries were produced outside of the volume of interest,

--- a/Biasing/src/Biasing/TargetProcessFilter.cxx
+++ b/Biasing/src/Biasing/TargetProcessFilter.cxx
@@ -58,7 +58,8 @@ void TargetProcessFilter::stepping(const G4Step* step) {
 
   // Get the region the particle is currently in. Continue processing
   // the particle only if it's in the target region.
-  static auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
+  static auto target_region =
+      simcore::g4user::ptrretrieval::getRegion("target");
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }

--- a/Biasing/src/Biasing/TargetProcessFilter.cxx
+++ b/Biasing/src/Biasing/TargetProcessFilter.cxx
@@ -58,11 +58,12 @@ void TargetProcessFilter::stepping(const G4Step* step) {
 
   // Get the region the particle is currently in. Continue processing
   // the particle only if it's in the target region.
-  auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
+  static auto target_region = simcore::g4user::ptrretrieval::getRegion("target");
   if (!target_region) {
     ldmx_log(warn) << "Region 'target' not found in Geant4 region store";
   }
-  auto current_region = track->GetVolume()->GetLogicalVolume()->GetRegion();
+  auto log_vol{track->GetVolume()->GetLogicalVolume()};
+  auto current_region{log_vol ? log_vol->GetRegion() : nullptr};
   if (current_region != target_region) {
     // If secondaries were produced outside of the volume of interest,
     // and there aren't additional brems to process, abort the event.
@@ -98,9 +99,9 @@ void TargetProcessFilter::stepping(const G4Step* step) {
      * We also check for 'World_PV' because in later geometries, there is
      * an air gap between the target region and the recoil tracker.
      */
-    auto recoil_physical_volume =
+    static auto recoil_physical_volume =
         simcore::g4user::ptrretrieval::getPhysicalVolume("recoil_PV");
-    auto world_physical_volume =
+    static auto world_physical_volume =
         simcore::g4user::ptrretrieval::getPhysicalVolume("World_PV");
 
     if (!recoil_physical_volume) {

--- a/Biasing/src/Biasing/Utility/StepPrinter.cxx
+++ b/Biasing/src/Biasing/Utility/StepPrinter.cxx
@@ -58,15 +58,24 @@ void StepPrinter::stepping(const G4Step* step) {
 
   // Get the volume the particle is in.
   auto volume{track->GetVolume()};
-  auto volumeName{volume->GetName()};
+  auto volumeName{volume ? volume->GetName() : "undefined"};
 
   // Get the next volume (can fail if current volume is WorldPV and next is
   // outside the world)
-  auto nextVolume{track->GetNextVolume() ? track->GetNextVolume()->GetName()
-                                         : "undefined"};
+  auto nextVolumePtr{track->GetNextVolume()};
+  auto nextVolume{nextVolumePtr ? nextVolumePtr->GetName() : "undefined"};
 
   // Get the region
-  auto regionName{volume->GetLogicalVolume()->GetRegion()->GetName()};
+  G4String regionName{"undefined"};
+  if (volume) {
+    auto lv{volume->GetLogicalVolume()};
+    if (lv) {
+      auto region{lv->GetRegion()};
+      if (region) {
+        regionName = region->GetName();
+      }
+    }
+  }
 
   std::cout << " Step " << track->GetCurrentStepNumber() << " ("
             << track->GetParticleDefinition()->GetParticleName() << ") {"

--- a/DetDescr/src/DetDescr/EcalGeometry.cxx
+++ b/DetDescr/src/DetDescr/EcalGeometry.cxx
@@ -95,7 +95,7 @@ EcalID EcalGeometry::getID(double x, double y, double z, bool fallible) const {
   static const double tolerance = 0.3;  // thickness of Si
   int layer_id{-1};
   for (const auto& [lid, layer_xyz] : layer_pos_xy_) {
-    if (abs(std::get<2>(layer_xyz) - z) < tolerance) {
+    if (std::abs(std::get<2>(layer_xyz) - z) < tolerance) {
       layer_id = lid;
       break;
     }

--- a/Ecal/include/Ecal/MyClusterWeight.h
+++ b/Ecal/include/Ecal/MyClusterWeight.h
@@ -39,7 +39,7 @@ class MyClusterWeight {
     double dijT = pow(pow(aX - bX, 2) + pow(aY - bY, 2), 0.5);
 
     double weightT = exp(pow(dijT / rmol, 2)) - 1;
-    double weightZ = (exp(abs(dijz) / dzchar) - 1);
+    double weightZ = (exp(std::abs(dijz) / dzchar) - 1);
 
     // Return the highest of the two weights
     if (weightT <= weightZ) {

--- a/Recon/src/Recon/TrackDeDxMassEstimator.cxx
+++ b/Recon/src/Recon/TrackDeDxMassEstimator.cxx
@@ -62,7 +62,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
       continue;
     }
 
-    float momentum = 1. / abs(theQoP) * 1000;  // unit: MeV
+    float momentum = 1. / std::abs(theQoP) * 1000;  // unit: MeV
     ldmx_log(debug) << "Track " << i << " has momentum " << momentum;
 
     /// Get the hits associated with the truth track

--- a/SimCore/include/SimCore/G4User/PtrRetrieval.h
+++ b/SimCore/include/SimCore/G4User/PtrRetrieval.h
@@ -59,6 +59,16 @@ inline const G4VProcess* getPhotonuclearProcess() {
  * @brief Retrieve a Geant4 region by name.
  * @param name Name of the region.
  * @return Pointer to the region if found, nullptr otherwise.
+ *
+ * It can be helpful to store a copy of the pointer in a local
+ * variable so that the search doesn't need to be performed every time
+ * a comparison needs to be made.
+ * In many cases, this can be achieved by a `static` variable that
+ * will call this function when it first needs to be constructed
+ * and then just uses that value for the rest of running.
+ * ```cpp
+ * static auto reg = simcore::g4user::ptrretrieval::getRegion("MyRegion");
+ * ```
  */
 inline G4Region* getRegion(const std::string& name) {
   G4Region* region = G4RegionStore::GetInstance()->GetRegion(name);

--- a/SimCore/include/SimCore/UserAction.h
+++ b/SimCore/include/SimCore/UserAction.h
@@ -20,6 +20,7 @@
 /*   Framework   */
 /*~~~~~~~~~~~~~~~*/
 #include "Framework/Configure/Parameters.h"
+#include "Framework/Logger.h"
 #include "SimCore/Event/SimParticle.h"
 #include "SimCore/Factory.h"
 #include "SimCore/UserEventInformation.h"
@@ -182,6 +183,9 @@ class UserAction {
 
   /// The set of parameters used to configure this class
   framework::config::Parameters parameters_;
+
+  /// the logging channel user actions can use `ldmx_log` with
+  mutable ::framework::logging::logger theLog_;
 
 };  // UserAction
 

--- a/SimCore/src/SimCore/SDs/EcalSD.cxx
+++ b/SimCore/src/SimCore/SDs/EcalSD.cxx
@@ -51,7 +51,7 @@ G4bool EcalSD::ProcessHits(G4Step* aStep, G4TouchableHistory*) {
 
   auto preStepPoint = aStep->GetPreStepPoint();
   if (preStepPoint) {
-    auto touchableHandle = preStepPoint->GetTouchableHandle();
+    const auto& touchableHandle = preStepPoint->GetTouchableHandle();
     if (touchableHandle) {
       auto history = touchableHandle->GetHistory();
       if (history) {

--- a/SimCore/src/SimCore/UserAction.cxx
+++ b/SimCore/src/SimCore/UserAction.cxx
@@ -15,7 +15,9 @@ namespace simcore {
 
 UserAction::UserAction(const std::string& name,
                        framework::config::Parameters& parameters)
-  : name_{name}, parameters_{parameters}, theLog_{::framework::logging::makeLogger(name)} {}
+    : name_{name},
+      parameters_{parameters},
+      theLog_{::framework::logging::makeLogger(name)} {}
 
 UserEventInformation* UserAction::getEventInfo() const {
   return static_cast<UserEventInformation*>(

--- a/SimCore/src/SimCore/UserAction.cxx
+++ b/SimCore/src/SimCore/UserAction.cxx
@@ -14,10 +14,8 @@
 namespace simcore {
 
 UserAction::UserAction(const std::string& name,
-                       framework::config::Parameters& parameters) {
-  name_ = name;
-  parameters_ = parameters;
-}
+                       framework::config::Parameters& parameters)
+  : name_{name}, parameters_{parameters}, theLog_{::framework::logging::makeLogger(name)} {}
 
 UserEventInformation* UserAction::getEventInfo() const {
   return static_cast<UserEventInformation*>(

--- a/Tracking/src/Tracking/TrackerVetoProcessor.cxx
+++ b/Tracking/src/Tracking/TrackerVetoProcessor.cxx
@@ -40,7 +40,8 @@ void TrackerVetoProcessor::produce(framework::Event& event) {
   // Start with tagger tracks
   int tagger_n{0};
   for (const auto& trk : tagger_track_collection) {
-    if ((std::abs(trk.getD0()) < max_d0_) && (std::abs(trk.getZ0()) < max_z0_)) {
+    if ((std::abs(trk.getD0()) < max_d0_) &&
+        (std::abs(trk.getZ0()) < max_z0_)) {
       auto charge_over_momentum = trk.getQoP();
       auto tagger_momentum = 1000. / std::abs(charge_over_momentum);
       float chi2_per_ndf = trk.getChi2() / trk.getNdf();
@@ -59,7 +60,8 @@ void TrackerVetoProcessor::produce(framework::Event& event) {
   int recoil_n{0};
   for (const auto& trk : recoil_track_collection) {
     float chi2_per_ndf = trk.getChi2() / trk.getNdf();
-    if ((std::abs(trk.getD0()) < max_d0_) && (std::abs(trk.getZ0()) < max_z0_) &&
+    if ((std::abs(trk.getD0()) < max_d0_) &&
+        (std::abs(trk.getZ0()) < max_z0_) &&
         (chi2_per_ndf < max_chi2_per_ndf_) &&
         (trk.getNhits() > min_recoil_hits_)) {
       // we may wanna use these in the future, keeping them commented

--- a/Tracking/src/Tracking/TrackerVetoProcessor.cxx
+++ b/Tracking/src/Tracking/TrackerVetoProcessor.cxx
@@ -40,9 +40,9 @@ void TrackerVetoProcessor::produce(framework::Event& event) {
   // Start with tagger tracks
   int tagger_n{0};
   for (const auto& trk : tagger_track_collection) {
-    if ((abs(trk.getD0()) < max_d0_) && (abs(trk.getZ0()) < max_z0_)) {
+    if ((std::abs(trk.getD0()) < max_d0_) && (std::abs(trk.getZ0()) < max_z0_)) {
       auto charge_over_momentum = trk.getQoP();
-      auto tagger_momentum = 1000. / abs(charge_over_momentum);
+      auto tagger_momentum = 1000. / std::abs(charge_over_momentum);
       float chi2_per_ndf = trk.getChi2() / trk.getNdf();
       if ((tagger_momentum > min_tagger_momentum_) &&
           (chi2_per_ndf < max_chi2_per_ndf_) &&
@@ -59,7 +59,7 @@ void TrackerVetoProcessor::produce(framework::Event& event) {
   int recoil_n{0};
   for (const auto& trk : recoil_track_collection) {
     float chi2_per_ndf = trk.getChi2() / trk.getNdf();
-    if ((abs(trk.getD0()) < max_d0_) && (abs(trk.getZ0()) < max_z0_) &&
+    if ((std::abs(trk.getD0()) < max_d0_) && (std::abs(trk.getZ0()) < max_z0_) &&
         (chi2_per_ndf < max_chi2_per_ndf_) &&
         (trk.getNhits() > min_recoil_hits_)) {
       // we may wanna use these in the future, keeping them commented

--- a/Trigger/Algo/src/Trigger/TrigElectronProducer.cxx
+++ b/Trigger/Algo/src/Trigger/TrigElectronProducer.cxx
@@ -156,7 +156,8 @@ float TrigElectronProducer::getP(bool isX, float e, float d) {
            prof->GetXaxis()->GetBinCenter(bin1),
            prof->GetXaxis()->GetBinCenter(bin2), res1, res2,
            std::abs(frac / diff) * res2 + (1 - std::abs(frac / diff)) * res1);
-  return e * (std::abs(frac / diff) * res2 + (1 - std::abs(frac / diff)) * res1);
+  return e *
+         (std::abs(frac / diff) * res2 + (1 - std::abs(frac / diff)) * res1);
 }
 
 void TrigElectronProducer::onProcessStart() {

--- a/Trigger/Algo/src/Trigger/TrigElectronProducer.cxx
+++ b/Trigger/Algo/src/Trigger/TrigElectronProducer.cxx
@@ -155,8 +155,8 @@ float TrigElectronProducer::getP(bool isX, float e, float d) {
     printf("%f %f %f %f :: %f %f %f \n", d, e,
            prof->GetXaxis()->GetBinCenter(bin1),
            prof->GetXaxis()->GetBinCenter(bin2), res1, res2,
-           abs(frac / diff) * res2 + (1 - abs(frac / diff)) * res1);
-  return e * (abs(frac / diff) * res2 + (1 - abs(frac / diff)) * res1);
+           std::abs(frac / diff) * res2 + (1 - std::abs(frac / diff)) * res1);
+  return e * (std::abs(frac / diff) * res2 + (1 - std::abs(frac / diff)) * res1);
 }
 
 void TrigElectronProducer::onProcessStart() {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1656 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful.

The CI checks backwards compatibility with ldmx/dev:4.2.2.
Using ldmx/dev:5.0.0-rc2...
- a `configure-clang-lto-fail-on-warning` build succeeded 
[clang-lto-fail-on-warning.log](https://github.com/user-attachments/files/19541478/clang-lto-fail-on-warning.log)
- a `configure-force-error` build succeeded [configure-force-error.log](https://github.com/user-attachments/files/19553674/configure-force-error.log)

### Roadmap

After merging this PR, I want to do all of the following in rather quick succession, probably in the same day, to avoid confusion. ~Hopefully that day can be this week.~
Going to wait for #1629 and #1668 for the minor release but still merge this PR before the next patch.

- Double check that tests are passing on trunk with ldmx/dev:5.0.0 locally
- Release ldmx/dev:5.0.0
- Release ldmx-sw 4.3.0
  - new release so the golden histograms are generated with 5.0.0 (good test too)
  - new minor version so its easier to state where the line of "easy" support for 5.0.0 is