### PR TITLE
missing <array> header in EcalVetoResult

### DIFF
--- a/Ecal/include/Ecal/Event/EcalVetoResult.h
+++ b/Ecal/include/Ecal/Event/EcalVetoResult.h
@@ -12,9 +12,9 @@
 //----------------//
 //   C++ StdLib   //
 //----------------//
+#include <array>
 #include <iostream>
 #include <map>
-#include <array>
 
 //----------//
 //   ROOT   //

--- a/Ecal/include/Ecal/Event/EcalVetoResult.h
+++ b/Ecal/include/Ecal/Event/EcalVetoResult.h
@@ -14,6 +14,7 @@
 //----------------//
 #include <iostream>
 #include <map>
+#include <array>
 
 //----------//
 //   ROOT   //


### PR DESCRIPTION
This is only noticed in the newer compiler in the v5 dev image where
(I'm assuming) the STL was updated to not automatically include <array>
when other STL headers are included.
