### PR TITLE
S30XL testbeam development

### DIFF
--- a/TrigScint/exampleConfigs/runQIEDecode.py
+++ b/TrigScint/exampleConfigs/runQIEDecode.py
@@ -7,7 +7,6 @@ import sys
 
 
 nEv=400000
-nChan=16
 #mapFile="channelMapFrontBack_"+str(nChan)+"channels.txt" #../TrigScint/data/channelMapFrontBack.txt")
 
 #p.maxEvents = nEv
@@ -28,6 +27,11 @@ if len(sys.argv) > 6 :
 else :
     logVerbosity=2
 
+if len(sys.argv) > 7 :
+    nChan=int(sys.argv[7])
+else :
+    nChan=16 #default
+    
 from LDMX.TrigScint.qieFormat import QIEDecoder
 dec=QIEDecoder.up(mapFile)
 #dec.input_collection="QIEstreamUp" 
@@ -43,6 +47,15 @@ p.sequence = [
     dec
     ]
 
-p.termLogLevel = 1
-p.logFileName = logName
-p.fileLogLevel = logVerbosity
+#p.termLogLevel = 1
+p.logger.termLevel = 1
+#p.logFileName = logName
+p.logger.FilePath = logName
+#p.fileLogLevel = logVerbosity
+p.logger.fileLevel = logVerbosity
+
+
+#p.logger.logRules=[ "QIEDecoder", 0]
+#p.logger.debug("QIEDecoder") #wrong way, don't pass instance name
+if logVerbosity < 2 :
+    p.logger.debug(dec) #pass instance itself

--- a/TrigScint/exampleConfigs/runRawUnpacker.py
+++ b/TrigScint/exampleConfigs/runRawUnpacker.py
@@ -17,8 +17,10 @@ if len(sys.argv) > 4 :
 else :
     nEv=4e6 #default         
 
-    
-nChannels=16
+if len(sys.argv) > 5 :
+    nChannels=int(sys.argv[5])
+else :
+    nChannels=16 #default           
 lenHeader=4+4+4+3+1 #UTC timeStamp s, timestamp clock ticks, time since spill, evNb, 4bit error words+4bit empty
 nWords=2*nChannels*nTimeSamples+lenHeader
 

--- a/TrigScint/exampleConfigs/runTBHitana.py
+++ b/TrigScint/exampleConfigs/runTBHitana.py
@@ -45,4 +45,6 @@ p.logFileName=outname.replace(".root",".log")
 p.termLogLevel = 2
 p.logFileLevel=1#0
 
+p.logger.debug(tsEv)
+
 json.dumps(p.parameterDump(), indent=2)

--- a/TrigScint/exampleConfigs/runTSLinearizer.py
+++ b/TrigScint/exampleConfigs/runTSLinearizer.py
@@ -27,7 +27,8 @@ tsEv=EventReadoutProducer("eventLinearizer")
 tsEv.input_pass_name=inputPassName
 tsEv.input_collection="decodedQIEUp"
 tsEv.time_shift=timeOffset
-
+if logVerbosity < 1 :
+    tsEv.verbose=True 
 p.sequence = [
     tsEv
     ]
@@ -41,6 +42,11 @@ outname=outname.replace(".root", "_linearize.root")
 p.outputFiles = [ outname ]
 
 
-p.logFileName=p.outputFiles[0].replace(".root",".log")
-p.termLogLevel = 2
-p.fileLogLevel = logVerbosity
+p.logger.filePath=p.outputFiles[0].replace(".root",".log")
+p.logger.termLevel = 2
+p.logger.fileLevel = logVerbosity
+
+#p.pause()
+
+if (logVerbosity < 1 ) :
+    p.logger.debug(tsEv)

--- a/TrigScint/exampleConfigs/runTestBeamClustering.py
+++ b/TrigScint/exampleConfigs/runTestBeamClustering.py
@@ -20,6 +20,7 @@ tbClustersUp  =TestBeamClusterProducer("tbClusters")
 tbClustersUp.input_pass_name=inputPassName
 #tbClustersUp.input_collection="TestBeamHitsUp"
 tbClustersUp.pad_time=0.
+tbClustersUp.threshold=15.
 tbClustersUp.time_tolerance=50.
 tbClustersUp.verbosity=0
 p.sequence = [

--- a/TrigScint/exampleConfigs/runTestBeamHitReco.py
+++ b/TrigScint/exampleConfigs/runTestBeamHitReco.py
@@ -13,6 +13,11 @@ if len(sys.argv) > 2 :
     timeSample=int(sys.argv[2])
 else :
     timeSample=15
+
+if len(sys.argv) > 3 :
+    pulseWidth=int(sys.argv[3])
+else :
+    pulseWidth=5
     
 from LDMX.TrigScint.trigScint import TestBeamHitProducer
 
@@ -25,7 +30,7 @@ gainFileName=sys.argv[1].replace(".root", "_gains.txt")
 gainFileName=gainFileName.replace("_adcTrig", "")  #not derived for adcTrig events 
 
 #pick one file more or less at random as the fallback option
-defaultRun="unpacked_4gev_negativeMu_Apr03_2200_reformat_30timeSamplesFrom0_linearize"
+defaultRun="unpacked_data_20250215_114611_ext_trig_ldmx_sw_parsed_linearize" #unpacked_4gev_negativeMu_Apr03_2200_reformat_30timeSamplesFrom0_linearize"
 dataPath=path.dirname( sys.argv[1] ) #extract the path to where we keep the data
 defaultGainFileName=dataPath+"/"+defaultRun+"_gains.txt"
 
@@ -84,9 +89,9 @@ tbHitsUp.input_collection="QIEsamplesPad1" #"QIEsamplesUp"
 tbHitsUp.pedestals=pedList
 tbHitsUp.gain=gainList 
 tbHitsUp.startSample=timeSample
-tbHitsUp.pulseWidth=7 #5 
-tbHitsUp.pulseWidthLYSO=7 #9 #7 for plastic, 9 for LYSO 
-tbHitsUp.doCleanHits=True
+tbHitsUp.pulseWidth=pulseWidth #5 #7 
+tbHitsUp.pulseWidthLYSO=pulseWidth #5 #7 #9 #7 for plastic, 9 for LYSO 
+tbHitsUp.doCleanHits=False #True
 tbHitsUp.nInstrumentedChannels=12
 p.sequence = [
     tbHitsUp

--- a/TrigScint/include/TrigScint/QIEAnalyzer.h
+++ b/TrigScint/include/TrigScint/QIEAnalyzer.h
@@ -62,7 +62,7 @@ class QIEAnalyzer : public framework::Analyzer {
   TH2F* hPedSubtractedPEvsN[16];
   TH2F* hPedSubtractedPEvsT[16];
   TH2F* hAvgQvsT[16];
-  
+
   TH2F* hTDCfireChanvsEvent;
   double yOffset_{35.};
   double yToIDfactor_{50. / 80.};

--- a/TrigScint/include/TrigScint/QIEAnalyzer.h
+++ b/TrigScint/include/TrigScint/QIEAnalyzer.h
@@ -62,7 +62,7 @@ class QIEAnalyzer : public framework::Analyzer {
   TH2F* hPedSubtractedPEvsN[16];
   TH2F* hPedSubtractedPEvsT[16];
   TH2F* hAvgQvsT[16];
-
+  
   TH2F* hTDCfireChanvsEvent;
   double yOffset_{35.};
   double yToIDfactor_{50. / 80.};

--- a/TrigScint/include/TrigScint/TestBeamHitAnalyzer.h
+++ b/TrigScint/include/TrigScint/TestBeamHitAnalyzer.h
@@ -61,7 +61,6 @@ class TestBeamHitAnalyzer : public framework::Analyzer {
   TH2F* hDeltaPEVsDelta[16];
   TH2F* hPEmaxVsDelta;
   TH2F* hCrossTalk[16][16];
-
 };
 }  // namespace trigscint
 

--- a/TrigScint/include/TrigScint/TestBeamHitAnalyzer.h
+++ b/TrigScint/include/TrigScint/TestBeamHitAnalyzer.h
@@ -60,6 +60,8 @@ class TestBeamHitAnalyzer : public framework::Analyzer {
   TH2F* hPEVsDelta[16];
   TH2F* hDeltaPEVsDelta[16];
   TH2F* hPEmaxVsDelta;
+  TH2F* hCrossTalk[16][16];
+
 };
 }  // namespace trigscint
 

--- a/TrigScint/src/TrigScint/EventReadoutProducer.cxx
+++ b/TrigScint/src/TrigScint/EventReadoutProducer.cxx
@@ -95,23 +95,24 @@ void EventReadoutProducer::produce(framework::Event &event) {
              // nearest edge is 10.35 fC  //ADC=0 corresponds to -16 fC.
     float ped = 0;
     int pedLength = (int)charge.size() /
-      5;  // actually pulse can be up to 12 samples = 2/5*30
+                    5;  // actually pulse can be up to 12 samples = 2/5*30
     int pedOffset = 2;  // but still skip the lowest (and highest) few
-      //	for (int i = pedLength; i < 3*pedLength ; i++) { //use 2nd and third 5th
-    if (charge.size() > 8 ) {
+                        //	for (int i = pedLength; i < 3*pedLength ; i++) {
+                        ////use 2nd and third 5th
+    if (charge.size() > 8) {
       if (verbose_) ldmx_log(debug) << "going into oscillations check ";
       for (int i = 3; i < charge.size() - 4; i++) {
-	float maxSamp = minCharge;
-	for (int iQ = 0; iQ < 4; iQ++) {  // find the local max in the 4 samples
-	  //		ldmx_log(debug) << "got charge " << charge[i+iQ];
-	  if (charge[i + iQ] > maxSamp) maxSamp = charge[i + iQ];
-	}
-	if (verbose_) ldmx_log(debug) << "got max charge " << maxSamp;
-	for (int iQ = 0; iQ < 4;
-	     iQ++)  // store the locally normalized numbers. even if the period is
-	  // 5 this should work for a while
-	  chargeCheck.push_back(charge[i + iQ] / maxSamp);
-	i += 3;  // to increment by 4, do 3 here and 1 in the loop
+        float maxSamp = minCharge;
+        for (int iQ = 0; iQ < 4; iQ++) {  // find the local max in the 4 samples
+          //		ldmx_log(debug) << "got charge " << charge[i+iQ];
+          if (charge[i + iQ] > maxSamp) maxSamp = charge[i + iQ];
+        }
+        if (verbose_) ldmx_log(debug) << "got max charge " << maxSamp;
+        for (int iQ = 0; iQ < 4; iQ++)  // store the locally normalized numbers.
+                                        // even if the period is
+          // 5 this should work for a while
+          chargeCheck.push_back(charge[i + iQ] / maxSamp);
+        i += 3;  // to increment by 4, do 3 here and 1 in the loop
       }
     }
     if (pedLength > 4) {
@@ -119,10 +120,10 @@ void EventReadoutProducer::produce(framework::Event &event) {
       // sorted vector
       std::sort(charge.begin(), charge.end());
       for (int i = pedOffset; i < 2 * pedLength + pedOffset;
-	   i++) {  // use 1st and 2nd 5th
-	ped += charge[i];
+           i++) {  // use 1st and 2nd 5th
+        ped += charge[i];
       }
-    ped /= 2 * pedLength;
+      ped /= 2 * pedLength;
     }
     // median: technically only true for odd number of elements but good enough
     float medQ = charge[(int)charge.size() / 2];
@@ -146,9 +147,9 @@ void EventReadoutProducer::produce(framework::Event &event) {
     // and the noise as the RMSE of that, same interval as pedestal
     float diffSq = 0;
     //    for (int i = pedLength; i < 3*pedLength ; i++) {
-    if (charge.size() > 8 ) {
+    if (charge.size() > 8) {
       for (int i = pedOffset; i < 2 * pedLength + pedOffset; i++) {
-	diffSq += (charge[i] - ped) * (charge[i] - ped);
+        diffSq += (charge[i] - ped) * (charge[i] - ped);
       }
       diffSq /= 2 * pedLength;  // adc.size();
     }
@@ -156,70 +157,71 @@ void EventReadoutProducer::produce(framework::Event &event) {
 
     // oscillation check
     uint flagOscillation = 0;
-    if (charge.size() > 8 ) {
-    // no need to run tedious oscillation check for all-neg channels
+    if (charge.size() > 8) {
+      // no need to run tedious oscillation check for all-neg channels
       if (maxQ > minCharge) {
-	int maxID = 0;
-	// find the first occurence of a local max
-	for (int i = 0; i < chargeCheck.size() - 4; i++) {
-	  if (chargeCheck[i] ==
-	      1) {  // an actual local max has been normalised by its own value
-	    maxID = i;
-	    //		  ldmx_log(debug) << "storing max index " <<maxID <<"
-	    // and size of vector is " << chargeCheck.size()-4;
-	    break;
-	  }
-	}
-	int lastMatchSample = 0;
-	// start from local max
-	bool doBreak = false;
-	for (int i = maxID; i < chargeCheck.size() - 4; i++) {
-	  if (verbose_)
-	    ldmx_log(debug) << "Checking how many matching groups of four we can "
-	      "find, starting at index "
-			    << i;
+        int maxID = 0;
+        // find the first occurence of a local max
+        for (int i = 0; i < chargeCheck.size() - 4; i++) {
+          if (chargeCheck[i] ==
+              1) {  // an actual local max has been normalised by its own value
+            maxID = i;
+            //		  ldmx_log(debug) << "storing max index " <<maxID <<"
+            // and size of vector is " << chargeCheck.size()-4;
+            break;
+          }
+        }
+        int lastMatchSample = 0;
+        // start from local max
+        bool doBreak = false;
+        for (int i = maxID; i < chargeCheck.size() - 4; i++) {
+          if (verbose_)
+            ldmx_log(debug)
+                << "Checking how many matching groups of four we can "
+                   "find, starting at index "
+                << i;
 
-	  for (int iQ = 0; iQ < 4; iQ++) {  // check if they are consistently
-	    // close
-	    if (verbose_)
-	      ldmx_log(debug)
-                << "Comparing " << chargeCheck[i + iQ] << " (sample " << i + iQ
-                << ") to " << chargeCheck[i + 4 + iQ] << " (sample "
-                << i + 4 + iQ << "), ratio is "
-                << chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ];
-	    // we can be generous in these crietira since we will require an
-	    // unbroken suite of 8 matches to call it oscillation
-	    if (fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ] - 1) <
-		0.5 ||  // need this tolerance to be kind of large, most
-		// actual peaks won't pass it by far anyway.
-		(chargeCheck[i + 4 + iQ] < 0.01 &&
-		 fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ]) <
-		 5))  // for very small numbers, one ADC difference can be a
-	      // factor 3 so add some margin
-	      lastMatchSample = i + iQ;
-	    else {
-	      if (verbose_)
-		ldmx_log(debug)
-                  << "Oscillation check for channel " << digi.getChanID()
-                  << " breaking at time sample " << i + iQ;
-	      doBreak = true;  // break outer loop
-	      break;           // break this loop
-	    }
-	  }
-	  if (doBreak) {
-	    break;
-	  }
-	  if (verbose_)
-	    ldmx_log(debug) << "Current lastMatchSample " << lastMatchSample;
-	  if (lastMatchSample - maxID >=
-	      2 * 4) {  // we had at least a couple of oscillations (2nd period
-	    // was fully matched by third)
-	    flagOscillation = 1;  // there is another check possible later too,
-	    // commented for now
-	    break;                // we've seen what we need to see
-	  }
-	  i += 3;
-	}
+          for (int iQ = 0; iQ < 4; iQ++) {  // check if they are consistently
+            // close
+            if (verbose_)
+              ldmx_log(debug)
+                  << "Comparing " << chargeCheck[i + iQ] << " (sample "
+                  << i + iQ << ") to " << chargeCheck[i + 4 + iQ] << " (sample "
+                  << i + 4 + iQ << "), ratio is "
+                  << chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ];
+            // we can be generous in these crietira since we will require an
+            // unbroken suite of 8 matches to call it oscillation
+            if (fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ] - 1) <
+                    0.5 ||  // need this tolerance to be kind of large, most
+                // actual peaks won't pass it by far anyway.
+                (chargeCheck[i + 4 + iQ] < 0.01 &&
+                 fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ]) <
+                     5))  // for very small numbers, one ADC difference can be a
+              // factor 3 so add some margin
+              lastMatchSample = i + iQ;
+            else {
+              if (verbose_)
+                ldmx_log(debug)
+                    << "Oscillation check for channel " << digi.getChanID()
+                    << " breaking at time sample " << i + iQ;
+              doBreak = true;  // break outer loop
+              break;           // break this loop
+            }
+          }
+          if (doBreak) {
+            break;
+          }
+          if (verbose_)
+            ldmx_log(debug) << "Current lastMatchSample " << lastMatchSample;
+          if (lastMatchSample - maxID >=
+              2 * 4) {  // we had at least a couple of oscillations (2nd period
+            // was fully matched by third)
+            flagOscillation = 1;  // there is another check possible later too,
+            // commented for now
+            break;  // we've seen what we need to see
+          }
+          i += 3;
+        }
       }  // if positive maxQ
     }
     // //use the top and bottom ends of the sorted q as another oscillation
@@ -228,15 +230,15 @@ void EventReadoutProducer::produce(framework::Event &event) {
     int nHigh = 0;
     int quartLength = (int)charge.size() / 4;
     for (int i = 4 * quartLength - 2; i >= 3 * quartLength;
-	 i--) {  // maxQ is already at last index
+         i--) {  // maxQ is already at last index
       if (charge[i] / maxQ > 0.66) nHigh++;
     }
-    
+
     /* used to be: >0.9, > 0.25. But this really killed MC pulses which
        all end up in 0.90-0.94, and somewhere >0.05 (at least >0.15)
     */
     uint flagSpike = (maxQ / outEvent.getTotQ() > 0.95) ||
-      (charge[charge.size() - 2] / maxQ <
+                     (charge[charge.size() - 2] / maxQ <
                       0.05);  // skip "unnaturally" narrow hits (all charge in
                               // one sample or huge drop to second highest)
     uint flagPlateau =

--- a/TrigScint/src/TrigScint/EventReadoutProducer.cxx
+++ b/TrigScint/src/TrigScint/EventReadoutProducer.cxx
@@ -89,38 +89,41 @@ void EventReadoutProducer::produce(framework::Event &event) {
     // normalization the same numbers are repeated, it's an oscillation edge
     // case: multiple single PE peaks with that repetition. we probably don't
     // need to keep those anyway
-    if (verbose_) ldmx_log(debug) << "going into oscillations check ";
     std::vector<float> chargeCheck = {NULL};
     float minCharge =
         10;  // no point in looking at oscillations just around the pedestal.
              // nearest edge is 10.35 fC  //ADC=0 corresponds to -16 fC.
-    for (int i = 3; i < charge.size() - 4; i++) {
-      float maxSamp = minCharge;
-      for (int iQ = 0; iQ < 4; iQ++) {  // find the local max in the 4 samples
-        //		ldmx_log(debug) << "got charge " << charge[i+iQ];
-        if (charge[i + iQ] > maxSamp) maxSamp = charge[i + iQ];
-      }
-      if (verbose_) ldmx_log(debug) << "got max charge " << maxSamp;
-      for (int iQ = 0; iQ < 4;
-           iQ++)  // store the locally normalized numbers. even if the period is
-                  // 5 this should work for a while
-        chargeCheck.push_back(charge[i + iQ] / maxSamp);
-      i += 3;  // to increment by 4, do 3 here and 1 in the loop
-    }
-
-    // now calculate the pedestal as the average of the middle half of the
-    // sorted vector
     float ped = 0;
-    std::sort(charge.begin(), charge.end());
     int pedLength = (int)charge.size() /
-                    5;  // actually pulse can be up to 12 samples = 2/5*30
+      5;  // actually pulse can be up to 12 samples = 2/5*30
     int pedOffset = 2;  // but still skip the lowest (and highest) few
-    //	for (int i = pedLength; i < 3*pedLength ; i++) { //use 2nd and third 5th
-    for (int i = pedOffset; i < 2 * pedLength + pedOffset;
-         i++) {  // use 1st and 2nd 5th
-      ped += charge[i];
+      //	for (int i = pedLength; i < 3*pedLength ; i++) { //use 2nd and third 5th
+    if (charge.size() > 8 ) {
+      if (verbose_) ldmx_log(debug) << "going into oscillations check ";
+      for (int i = 3; i < charge.size() - 4; i++) {
+	float maxSamp = minCharge;
+	for (int iQ = 0; iQ < 4; iQ++) {  // find the local max in the 4 samples
+	  //		ldmx_log(debug) << "got charge " << charge[i+iQ];
+	  if (charge[i + iQ] > maxSamp) maxSamp = charge[i + iQ];
+	}
+	if (verbose_) ldmx_log(debug) << "got max charge " << maxSamp;
+	for (int iQ = 0; iQ < 4;
+	     iQ++)  // store the locally normalized numbers. even if the period is
+	  // 5 this should work for a while
+	  chargeCheck.push_back(charge[i + iQ] / maxSamp);
+	i += 3;  // to increment by 4, do 3 here and 1 in the loop
+      }
     }
+    if (pedLength > 4) {
+      // now calculate the pedestal as the average of the middle half of the
+      // sorted vector
+      std::sort(charge.begin(), charge.end());
+      for (int i = pedOffset; i < 2 * pedLength + pedOffset;
+	   i++) {  // use 1st and 2nd 5th
+	ped += charge[i];
+      }
     ped /= 2 * pedLength;
+    }
     // median: technically only true for odd number of elements but good enough
     float medQ = charge[(int)charge.size() / 2];
     float minQ = charge[0];
@@ -143,94 +146,97 @@ void EventReadoutProducer::produce(framework::Event &event) {
     // and the noise as the RMSE of that, same interval as pedestal
     float diffSq = 0;
     //    for (int i = pedLength; i < 3*pedLength ; i++) {
-    for (int i = pedOffset; i < 2 * pedLength + pedOffset; i++) {
-      diffSq += (charge[i] - ped) * (charge[i] - ped);
+    if (charge.size() > 8 ) {
+      for (int i = pedOffset; i < 2 * pedLength + pedOffset; i++) {
+	diffSq += (charge[i] - ped) * (charge[i] - ped);
+      }
+      diffSq /= 2 * pedLength;  // adc.size();
     }
-    diffSq /= 2 * pedLength;  // adc.size();
     outEvent.setNoise(sqrt(diffSq));
 
     // oscillation check
     uint flagOscillation = 0;
+    if (charge.size() > 8 ) {
     // no need to run tedious oscillation check for all-neg channels
-    if (maxQ > minCharge) {
-      int maxID = 0;
-      // find the first occurence of a local max
-      for (int i = 0; i < chargeCheck.size() - 4; i++) {
-        if (chargeCheck[i] ==
-            1) {  // an actual local max has been normalised by its own value
-          maxID = i;
-          //		  ldmx_log(debug) << "storing max index " <<maxID <<"
-          // and size of vector is " << chargeCheck.size()-4;
-          break;
-        }
-      }
-      int lastMatchSample = 0;
-      // start from local max
-      bool doBreak = false;
-      for (int i = maxID; i < chargeCheck.size() - 4; i++) {
-        if (verbose_)
-          ldmx_log(debug) << "Checking how many matching groups of four we can "
-                             "find, starting at index "
-                          << i;
+      if (maxQ > minCharge) {
+	int maxID = 0;
+	// find the first occurence of a local max
+	for (int i = 0; i < chargeCheck.size() - 4; i++) {
+	  if (chargeCheck[i] ==
+	      1) {  // an actual local max has been normalised by its own value
+	    maxID = i;
+	    //		  ldmx_log(debug) << "storing max index " <<maxID <<"
+	    // and size of vector is " << chargeCheck.size()-4;
+	    break;
+	  }
+	}
+	int lastMatchSample = 0;
+	// start from local max
+	bool doBreak = false;
+	for (int i = maxID; i < chargeCheck.size() - 4; i++) {
+	  if (verbose_)
+	    ldmx_log(debug) << "Checking how many matching groups of four we can "
+	      "find, starting at index "
+			    << i;
 
-        for (int iQ = 0; iQ < 4; iQ++) {  // check if they are consistently
-                                          // close
-          if (verbose_)
-            ldmx_log(debug)
+	  for (int iQ = 0; iQ < 4; iQ++) {  // check if they are consistently
+	    // close
+	    if (verbose_)
+	      ldmx_log(debug)
                 << "Comparing " << chargeCheck[i + iQ] << " (sample " << i + iQ
                 << ") to " << chargeCheck[i + 4 + iQ] << " (sample "
                 << i + 4 + iQ << "), ratio is "
                 << chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ];
-          // we can be generous in these crietira since we will require an
-          // unbroken suite of 8 matches to call it oscillation
-          if (fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ] - 1) <
-                  0.5 ||  // need this tolerance to be kind of large, most
-                          // actual peaks won't pass it by far anyway.
-              (chargeCheck[i + 4 + iQ] < 0.01 &&
-               fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ]) <
-                   5))  // for very small numbers, one ADC difference can be a
-                        // factor 3 so add some margin
-            lastMatchSample = i + iQ;
-          else {
-            if (verbose_)
-              ldmx_log(debug)
+	    // we can be generous in these crietira since we will require an
+	    // unbroken suite of 8 matches to call it oscillation
+	    if (fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ] - 1) <
+		0.5 ||  // need this tolerance to be kind of large, most
+		// actual peaks won't pass it by far anyway.
+		(chargeCheck[i + 4 + iQ] < 0.01 &&
+		 fabs(chargeCheck[i + iQ] / chargeCheck[i + 4 + iQ]) <
+		 5))  // for very small numbers, one ADC difference can be a
+	      // factor 3 so add some margin
+	      lastMatchSample = i + iQ;
+	    else {
+	      if (verbose_)
+		ldmx_log(debug)
                   << "Oscillation check for channel " << digi.getChanID()
                   << " breaking at time sample " << i + iQ;
-            doBreak = true;  // break outer loop
-            break;           // break this loop
-          }
-        }
-        if (doBreak) {
-          break;
-        }
-        if (verbose_)
-          ldmx_log(debug) << "Current lastMatchSample " << lastMatchSample;
-        if (lastMatchSample - maxID >=
-            2 * 4) {  // we had at least a couple of oscillations (2nd period
-                      // was fully matched by third)
-          flagOscillation = 1;  // there is another check possible later too,
-                                // commented for now
-          break;                // we've seen what we need to see
-        }
-        i += 3;
-      }
-    }  // if positive maxQ
-
+	      doBreak = true;  // break outer loop
+	      break;           // break this loop
+	    }
+	  }
+	  if (doBreak) {
+	    break;
+	  }
+	  if (verbose_)
+	    ldmx_log(debug) << "Current lastMatchSample " << lastMatchSample;
+	  if (lastMatchSample - maxID >=
+	      2 * 4) {  // we had at least a couple of oscillations (2nd period
+	    // was fully matched by third)
+	    flagOscillation = 1;  // there is another check possible later too,
+	    // commented for now
+	    break;                // we've seen what we need to see
+	  }
+	  i += 3;
+	}
+      }  // if positive maxQ
+    }
     // //use the top and bottom ends of the sorted q as another oscillation
     // catcher: we don't expect that the top values will be high and basically
     // identical unless they are from an oscillation
     int nHigh = 0;
     int quartLength = (int)charge.size() / 4;
     for (int i = 4 * quartLength - 2; i >= 3 * quartLength;
-         i--) {  // maxQ is already at last index
+	 i--) {  // maxQ is already at last index
       if (charge[i] / maxQ > 0.66) nHigh++;
     }
-
+    
     /* used to be: >0.9, > 0.25. But this really killed MC pulses which
        all end up in 0.90-0.94, and somewhere >0.05 (at least >0.15)
     */
     uint flagSpike = (maxQ / outEvent.getTotQ() > 0.95) ||
-                     (charge[charge.size() - 2] / maxQ <
+      (charge[charge.size() - 2] / maxQ <
                       0.05);  // skip "unnaturally" narrow hits (all charge in
                               // one sample or huge drop to second highest)
     uint flagPlateau =

--- a/TrigScint/src/TrigScint/QIEAnalyzer.cxx
+++ b/TrigScint/src/TrigScint/QIEAnalyzer.cxx
@@ -128,7 +128,7 @@ void QIEAnalyzer::onProcessStart() {
             << std::endl;
   getHistoDirectory();
 
-  int nTimeSamp = 40;
+  int nTimeSamp = 68;  //40
   int PEmax = 100;
   int nPEbins = 5 * PEmax;
   float Qmax = PEmax / (6250. / 4.e6);
@@ -194,6 +194,7 @@ void QIEAnalyzer::onProcessStart() {
                    nTimeSamp, -0.5, nTimeSamp - 0.5);
     }
   }
+
 
   hTDCfireChanvsEvent =
       new TH2F("hTDCfireChanvsEvent", ";channel with TDC < 63;event number",

--- a/TrigScint/src/TrigScint/QIEAnalyzer.cxx
+++ b/TrigScint/src/TrigScint/QIEAnalyzer.cxx
@@ -128,7 +128,7 @@ void QIEAnalyzer::onProcessStart() {
             << std::endl;
   getHistoDirectory();
 
-  int nTimeSamp = 68;  //40
+  int nTimeSamp = 68;  // 40
   int PEmax = 100;
   int nPEbins = 5 * PEmax;
   float Qmax = PEmax / (6250. / 4.e6);
@@ -194,7 +194,6 @@ void QIEAnalyzer::onProcessStart() {
                    nTimeSamp, -0.5, nTimeSamp - 0.5);
     }
   }
-
 
   hTDCfireChanvsEvent =
       new TH2F("hTDCfireChanvsEvent", ";channel with TDC < 63;event number",

--- a/TrigScint/src/TrigScint/QIEDecoder.cxx
+++ b/TrigScint/src/TrigScint/QIEDecoder.cxx
@@ -247,8 +247,9 @@ void QIEDecoder::produce(framework::Event &event) {
         }
         // this is LETDC; only the two most significant bits included
         // they are shipped as least significant bits --> shift them
-        TDCmap[iQ].at(iS) = (val + 1) * 16;  // want LE TDC = 3 to correspond to
+        //TDCmap[iQ].at(iS) = (val + 1) * 16;  // want LE TDC = 3 to correspond to
                                              // 64 > 49 (which is maxTDC in sim)
+        TDCmap[iQ].at(iS) = val;  // have full 6-bit TDC at SLAC 
       }
       iWord++;
     }

--- a/TrigScint/src/TrigScint/QIEDecoder.cxx
+++ b/TrigScint/src/TrigScint/QIEDecoder.cxx
@@ -247,9 +247,10 @@ void QIEDecoder::produce(framework::Event &event) {
         }
         // this is LETDC; only the two most significant bits included
         // they are shipped as least significant bits --> shift them
-        //TDCmap[iQ].at(iS) = (val + 1) * 16;  // want LE TDC = 3 to correspond to
-                                             // 64 > 49 (which is maxTDC in sim)
-        TDCmap[iQ].at(iS) = val;  // have full 6-bit TDC at SLAC 
+        // TDCmap[iQ].at(iS) = (val + 1) * 16;  // want LE TDC = 3 to correspond
+        // to
+        // 64 > 49 (which is maxTDC in sim)
+        TDCmap[iQ].at(iS) = val;  // have full 6-bit TDC at SLAC
       }
       iWord++;
     }

--- a/TrigScint/src/TrigScint/TestBeamHitAnalyzer.cxx
+++ b/TrigScint/src/TrigScint/TestBeamHitAnalyzer.cxx
@@ -60,6 +60,14 @@ void TestBeamHitAnalyzer::analyze(const framework::Event& event) {
     hPE[bar]->Fill(PE);
     if (chan.getQualityFlag() == 0 && bar < 12 && 15 < PE && PE < 40)
       existsIntermediatePE = true;
+
+    //cross talk/correlations
+    for (auto chanProbe : channels) {
+      int barProbe = chanProbe.getBarID();
+      if (barProbe >= bar) //we don't define the lower diagonal of the matrix of histograms 
+	hCrossTalk[bar][barProbe]->Fill( PE, chanProbe.getPE() );
+    }
+    
   }  // over channels
 
   if (existsIntermediatePE && fillNb < nEv) {
@@ -96,7 +104,7 @@ void TestBeamHitAnalyzer::onProcessStart() {
 
   getHistoDirectory();
 
-  int nTimeSamp = 40;
+  int nTimeSamp = 7;
   int PEmax = 400;
   int nPEbins = 2 * PEmax;
   // float Qmax = PEmax / (6250. / 4.e6);
@@ -123,7 +131,7 @@ void TestBeamHitAnalyzer::onProcessStart() {
   for (int iE = 0; iE < nEv; iE++) {
     for (int iB = 0; iB < nChannels; iB++) {
       hOut[iE][iB] =
-          new TH1F(Form("hCharge_chan%i_nv%i", iB, iE),
+          new TH1F(Form("hCharge_chan%i_ev%i", iB, iE),
                    Form(";time sample; Q, chan %i, ev %i [fC]", iB, iE),
                    nTimeSamp, -0.5, nTimeSamp - 0.5);
     }
@@ -138,6 +146,17 @@ void TestBeamHitAnalyzer::onProcessStart() {
                        nEv + 0.5, nChannels, -0.5, nChannels - 0.5);
 
   fillNb = 0;
+
+  
+  for (int iBtag = 0; iBtag < nChannels; iBtag++) {
+    for (int iBprobe = iBtag; iBprobe < nChannels; iBprobe++) { //use one side of diagonal
+      hCrossTalk[iBtag][iBprobe] =
+	new TH2F(Form("hPE_chan%i_vs_chan%i", iBprobe, iBtag),
+		 Form(";PE, channel %i; PE, channel %i", iBprobe, iBtag),
+		 nPEbins,0,PEmax, nPEbins,0,PEmax);
+    }
+  }
+  
 
   return;
 }

--- a/TrigScint/src/TrigScint/TestBeamHitAnalyzer.cxx
+++ b/TrigScint/src/TrigScint/TestBeamHitAnalyzer.cxx
@@ -61,13 +61,14 @@ void TestBeamHitAnalyzer::analyze(const framework::Event& event) {
     if (chan.getQualityFlag() == 0 && bar < 12 && 15 < PE && PE < 40)
       existsIntermediatePE = true;
 
-    //cross talk/correlations
+    // cross talk/correlations
     for (auto chanProbe : channels) {
       int barProbe = chanProbe.getBarID();
-      if (barProbe >= bar) //we don't define the lower diagonal of the matrix of histograms 
-	hCrossTalk[bar][barProbe]->Fill( PE, chanProbe.getPE() );
+      if (barProbe >= bar)  // we don't define the lower diagonal of the matrix
+                            // of histograms
+        hCrossTalk[bar][barProbe]->Fill(PE, chanProbe.getPE());
     }
-    
+
   }  // over channels
 
   if (existsIntermediatePE && fillNb < nEv) {
@@ -147,16 +148,15 @@ void TestBeamHitAnalyzer::onProcessStart() {
 
   fillNb = 0;
 
-  
   for (int iBtag = 0; iBtag < nChannels; iBtag++) {
-    for (int iBprobe = iBtag; iBprobe < nChannels; iBprobe++) { //use one side of diagonal
+    for (int iBprobe = iBtag; iBprobe < nChannels;
+         iBprobe++) {  // use one side of diagonal
       hCrossTalk[iBtag][iBprobe] =
-	new TH2F(Form("hPE_chan%i_vs_chan%i", iBprobe, iBtag),
-		 Form(";PE, channel %i; PE, channel %i", iBprobe, iBtag),
-		 nPEbins,0,PEmax, nPEbins,0,PEmax);
+          new TH2F(Form("hPE_chan%i_vs_chan%i", iBprobe, iBtag),
+                   Form(";PE, channel %i; PE, channel %i", iBprobe, iBtag),
+                   nPEbins, 0, PEmax, nPEbins, 0, PEmax);
     }
   }
-  
 
   return;
 }

--- a/TrigScint/util/extractPedsAndGains.C
+++ b/TrigScint/util/extractPedsAndGains.C
@@ -13,8 +13,14 @@
 #include <iostream>
 #include <fstream>
 
+TCanvas * c1;
+// global, to allow drawing of dark current Lambda estimates 
+TCanvas * cLambda;
+bool hasDrawnLambda=false;
+TGraphErrors *gLambdaCorr;
+TGraphErrors *gXi;
 
-TGraphErrors * isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim, int nSamples);
+TGraphErrors * isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim, int nSamples, int channelNb);
 TGraphErrors * findAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim);
 
 
@@ -69,8 +75,9 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
   vector <int> minVals = {-500};  // should cover most negative pedestals 
   vector <float> binFactor = {0.05}; // histogram binning 
 
-  TCanvas * c1 = new TCanvas("c1", "plot canvas", 600, 500);
-
+  //  if (!c1)
+  c1 = new TCanvas("c1", "plot canvas", 600, 500);
+    
   vector<string> cuts;
   vector<TH1F*> v_hOut;
 
@@ -83,7 +90,7 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 	cuts.push_back( Form("%s %s_%s.chanID_==%i", cleanStr.c_str(), digiName.c_str(),decodePassName.c_str(), iC));
 
   c1->SetRightMargin( 1.5*c1->GetRightMargin());
-
+    
   for (unsigned int iV = 0; iV < vars.size(); iV++) {
 	for (unsigned int iC = 0; iC < cuts.size(); iC++) {
 	  string cut =cuts[iC];
@@ -96,6 +103,7 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 	  string nSamp = Form("%i", nSamples);
 	  std::cout<<"At channel " << bin << std::endl;
 	  std::cout<<"Using cut " << cut << std::endl;
+	  c1->cd();
 	  tree->Draw( (nSamp+"*("+digiName+"_"+decodePassName+"."+vars[iV]+"_) >> h"+bin+"("+bins+")").c_str(), cut.c_str() );
 	  //get them each and keep for later
 	  TH1F *hOut = (TH1F*)gDirectory->Get(Form("h%i", iC)); 
@@ -119,6 +127,15 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
   // it is reasonable to assume that we will have a hunch how wide each PE peak will be.
   // we can pass that param to the fitting function. 
 
+
+  //draw lambda points (peak count ratios) for every channel
+  cLambda=new TCanvas("cLambda", "Lambda canvas", 1200, 1500);
+  cLambda->Divide(nChannels/4, 4);
+  //store some noise parameter values too 
+  gLambdaCorr = new TGraphErrors(nChannels);
+  gXi = new TGraphErrors(nChannels);
+
+  
   float fitRangeWidth=125.; // take this window to either side of mean to catch peak 
   vector <TGraphErrors*> v_g;
   TGraphErrors* gGains = new TGraphErrors(nChannels);
@@ -132,7 +149,7 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 	//do the actual peak fitting 
 	std::cout<< "----> Fitting gain for channel " << iH << std::endl;
 	//	TGraphErrors * g= findAndFitPeaks( v_hOut.at(iH), fitRangeWidth, verbosePrint, isSim); 
-	TGraphErrors * g= isolateAndFitPeaks( v_hOut.at(iH), fitRangeWidth, verbosePrint, isSim, nSamples); 
+	TGraphErrors * g= isolateAndFitPeaks( v_hOut.at(iH), fitRangeWidth, verbosePrint, isSim, nSamples, iH); 
 	if (!g) { //null pointer returned --> didn't get enough peaks to fit; skip this channel
 	  std::cout<< "----> No gain curve for channel " << iH << std::endl;
 	  skippedGraphs.push_back(iH);
@@ -141,6 +158,7 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 	  continue;
 	}
 	nChanToWrite++;
+	c1->cd();
 	g->Draw("ap");
 	g->SetTitle(";Peak nb;Total charge [fC]");
 	g->SetName(Form("g_gainChan%i", iH));
@@ -163,6 +181,21 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 	v_g.push_back( g );
   }
 
+  TCanvas * cLambdaCorr = new TCanvas("cLam", "corrected lambda canvas", 500, 600);
+  gLambdaCorr->Draw("ap"); // draw lambda vs channel nb
+  
+  TCanvas * cXi = new TCanvas("cXi", "xi*exp(-xi) canvas", 500, 600);
+  TF1 * fXiexi=new TF1("fXiexi", "x*TMath::Exp(-x)", -2, 2);
+  fXiexi->Draw();
+  for (int iC=0; iC<gXi->GetN(); iC++){
+    TF1 * fLine=new TF1("fLine", "[0]", -2, 2);
+    double point, val;
+    gXi->GetPoint(iC, point, val);
+    fLine->SetParameter(0, val);
+    fLine->SetLineColor( iC+1);
+    fLine->DrawCopy("same");
+  }
+  
   //store this to a root file for later plotting
   TString outFile = inFile;
   outFile=outFile.ReplaceAll(".root", "_gain.root");
@@ -217,11 +250,17 @@ void extractPedsAndGains(string inFile, int deadChannel=-1, string decodePassNam
 }
 
 
-TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim, int nSamples )
+TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim, int nSamples, int channelNb )
 {
   float mean = hIn->GetBinCenter( hIn->GetMaximumBin() );
 //make a clone where we can iteratively remove what is to the left of peak of interest 
   TH1F * hToFit = (TH1F*)hIn->Clone();
+
+  if ( hToFit->GetEntries()==0) {
+    std::cerr << "Charge histogram is empty! Exiting" << std::endl;
+    return NULL;
+  }
+  
   float oldMean = hIn->GetXaxis()->GetXmin()+5;
   float maxVal = hIn->GetXaxis()->GetXmax();
   float minVal = oldMean;
@@ -242,13 +281,15 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
   int norm = 0;
   float sigma=0;                                                                                                        
   bool hasAdjustedWidth=false;
-
+  vector<float> peakIntegrals;
+  vector<float> peakIntegralErrors;
+  
   while ( max <= maxVal ) {
     if (verbose) {
       std::cout<<"Fitting for peak " << iP << ": around mean=" << mean
                << " between " << minVal << " and " << max
                <<  std::endl;
-    }
+    }//if verbose
     TFitResultPtr ptr = hToFit->Fit(fGaus, "QRS", "same", minVal, max);//mean-width, mean+width);     
 	if (ptr || ptr->Parameter(1) < oldMean || ptr->Parameter(2) < 0.2*sigma) {//ptr is not 0 --> not converged, try again with narrower range, given that we probably nailed the peak already                                                    
       minVal=mean-0.4*width;
@@ -257,7 +298,7 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
         std::cout<<"\tFitting again for peak " << iP << ": around mean=" << mean
                  << " between " << minVal << " and " << max
                  <<  std::endl;
-      }
+      }//if verbose
       ptr = hToFit->Fit(fGaus, "RS", "same",  minVal, max);// mean-0.8*width, mean+0.8*width);                                                                    
     }
    
@@ -268,10 +309,13 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
 	   std::cout<<"\tUpdating width to " << width
 				<<  std::endl;
 	 }
-   }
+   }//adjust initial width guess 
 
    mean=ptr->Parameter(1);
    sigma=ptr->Parameter(2);
+   peakIntegrals.emplace_back( fGaus->Integral( mean-3*sigma, mean+3*sigma) );
+   peakIntegralErrors.emplace_back( fGaus->IntegralError( mean-3*sigma, mean+3*sigma) );
+
    fGaus->DrawCopy("same");
    //could keep track of last bin which was reset, for some speed gain
    for (int iB=1; iB<hToFit->FindBin( mean+TMath::Min(width,float(7*sigma)) ); iB++)
@@ -279,7 +323,6 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
       
    oldMean=mean;
    mean=hToFit->GetBinCenter( hToFit->GetMaximumBin() );
-
    minVal=TMath::Max(minVal, float(mean-1.25*width));
    max=mean+1.25*width;     								
    norm+=ptr->Parameter(0);   //keep track of how much stats we have left to work with
@@ -301,25 +344,28 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
    if (!isSim)
 	 bkgLevel=fBkg->Eval(ptr->Parameter(1));
    //   if (hIn->GetEntries()-norm < 0.05*hIn->GetEntries() || ptr->Parameter(0)-bkgLevel< 8) { //don't fit peaks with just a few entries                          
-   if (hToFit->Integral() < 0.01*hIn->Integral() || ptr->Parameter(0)-bkgLevel< 8 || hToFit->Integral() < 10) { //don't fit peaks with just a few entries                          
+   if (hToFit->Integral() < 0.001*hIn->Integral() || ptr->Parameter(0)-bkgLevel< 8 || hToFit->Integral() < 10) { //don't fit peaks with just a few entries                          
 	 std::cout<<"\tHitting stats break factor at peak integral " << ptr->Parameter(0)
 			  << " and (in data) fitted background level " << bkgLevel
 			  << " and histogram entries " << hToFit->Integral()
 			  << " out of total from start " << hIn->Integral()
 			  <<  std::endl;
 	 break;
-   }
+   }//if stats too low 
    
-  } 
-  const int nPoints = vPtrs.size();
+  }
+  const int nPoints = TMath::Min(int(vPtrs.size()), 6);
 
   if (nPoints < 3 ) {// this is too few to fit. probably there was a problem with this channel
-    std::cout<<"\tOnly got " << nPoints << " peaks for this channel . Breaking"
+    std::cout<<"\tOnly got " << nPoints << " peaks for this channel. Breaking before gain fit"
 	                <<  std::endl;
 	return NULL;
   }
  
-	
+
+  
+  TGraphErrors *gLambda = new TGraphErrors((const int) nPoints-1); //always combination of two peak counts 
+    
   double x[(const int) nPoints];
   double ex[(const int) nPoints];
   double y[(const int) nPoints];
@@ -330,13 +376,41 @@ TGraphErrors* isolateAndFitPeaks( TH1F * hIn, float width, bool verbose, bool is
 	ex[iP] = 0;
 	y[iP] = vPtrs.at(iP)->Parameter(1);
 	ey[iP] = vPtrs.at(iP)->Parameter(2);
-	if ( iP > 0 ) { //extract the noise level from relative size of peaks
+	if ( iP > 0 ) { //extract the noise level from relative size of peaks (ratio of counts this/previous)
+	  float relHeight=vPtrs.at(iP)->Parameter(0)/vPtrs.at(iP-1)->Parameter(0);							       
+	  std::cout << "\tEstimate n_"<< iP << iP-1 << " from height = " <<relHeight << " +/- " <<  relHeight*sqrt( TMath::Power(vPtrs.at(iP)->ParError(0)/vPtrs.at(iP)->Parameter(0), 2) + TMath::Power(vPtrs.at(iP-1)->ParError(0)/vPtrs.at(iP-1)->Parameter(0),2)) << std::endl;
+	  float relIntegral=peakIntegrals.at(iP)/peakIntegrals.at(iP-1);
+	  gLambda->SetPoint(iP-1, iP-1, relIntegral );
+	  gLambda->SetPointError(iP-1, 0, relIntegral*sqrt( TMath::Power(peakIntegralErrors.at(iP)/peakIntegrals.at(iP), 2) + TMath::Power(peakIntegralErrors.at(iP-1)/peakIntegrals.at(iP-1), 2) ) );
+	  std::cout << "\tEstimate n_"<< iP << iP-1 << " from peak integrals = " << relIntegral << " +/- " << gLambda->GetErrorY(iP-1)  << std::endl;
 	  std::cout << "Estimate Lambda(peak " << iP << ") = " << vPtrs.at(iP)->Parameter(0)/vPtrs.at(iP-1)->Parameter(0)/(iP*nSamples) << std::endl;
 	  noise+=vPtrs.at(iP)->Parameter(0)/vPtrs.at(iP-1)->Parameter(0)/(iP*nSamples);
 	}
   }
   std::cout<<"Average noise/time sample from all used peaks = " << noise/(nPoints-1) <<std::endl;
   std::cout<<"Average noise/event from all used peaks = " << noise/(nPoints-1)*nSamples <<std::endl;
+
+  cLambda->cd(channelNb+1);
+  //  if (!hasDrawnLambda) {
+  //  gLambda->Draw("ap");
+  //  hasDrawnLambda=true;
+  //}
+  gLambda->Draw("ap");
+  gLambda->SetTitle(Form("Channel %i; numerator peak number; #lambda estimate", channelNb) );
+  gLambda->SetMarkerStyle(kFullTriangleUp);
+  gLambda->Draw("ap");
+
+  //stored on the denominator index so second number
+  double n21, n32, pointNb;
+  gLambda->GetPoint( 1, pointNb, n21);
+  gLambda->GetPoint( 2, pointNb, n32);
+  float xiexi=sqrt( n21*(n32-n21/2));//xi*exp(-xi)
+  float lambda= n21-xiexi;
+  cout << "\t\t--> Found xi*exp(-xi) = " << xiexi << " and corrected Lambda = " << lambda << " for channel " << channelNb << std::endl;
+  cout<<"\t\t    amounting to DCR of " << lambda/(25*nSamples)*1000 << " kHz" << std::endl;
+
+  gLambdaCorr->SetPoint(channelNb, channelNb, lambda);
+  gXi->SetPoint(channelNb, channelNb, xiexi);
   
   TGraphErrors * g= new TGraphErrors( nPoints, x, y, ex, ey);
   
@@ -411,6 +485,7 @@ TGraphErrors* findAndFitPeaks( TH1F * hIn, float width, bool verbose, bool isSim
 				   <<  std::endl;
 		}
 	  }
+	  c1->cd();
 	  fGaus->DrawCopy("same");
 	}
 	oldMean=ptr->Parameter(1);

--- a/TrigScint/util/makeEventCanvas.C
+++ b/TrigScint/util/makeEventCanvas.C
@@ -5,6 +5,7 @@
 #include <TTree.h>
 #include <TCanvas.h>
 #include <TLegend.h>
+#include <TLatex.h>
 #include <TGaxis.h>
 #include <TFile.h>
 #include <TGraphErrors.h>
@@ -72,7 +73,8 @@ void makeEventCanvas(string inFile, int maxEvents = 200, int deadChannel =8, int
    TFile * fIn = TFile::Open( inFile.c_str(), "READ");
    if (!fIn)
 	 std::cout << "Couldn't open " << inFile << std::endl;
-   fIn->cd("QIEplotMaker");
+   //   fIn->cd("QIEplotMaker");
+   fIn->cd("plotMaker");
    fIn->ls();
    
    TLatex * latex = new TLatex();
@@ -213,7 +215,7 @@ void makeEventCanvas(string inFile, int maxEvents = 200, int deadChannel =8, int
 	 //	c2->cd();
 	 //	latex->DrawLatex(0.4, 0.9, Form("Event %i",iE) ); //add event number
 	 // save space by not saving the .png, uncomment if needed
-	 // c1->SaveAs(Form("%s/hCharge_ev%i.png", outDir.Data(), iE));
+	 c1->SaveAs(Form("%s/hCharge_ev%i.png", outDir.Data(), iE));
 	 c1->SaveAs(Form("%s/hCharge_ev%i.pdf", outDir.Data(), iE));
 	 c2->SetTopMargin(0.2);
 	 c2->cd(2);
@@ -222,6 +224,5 @@ void makeEventCanvas(string inFile, int maxEvents = 200, int deadChannel =8, int
 	 //c2->SaveAs(Form("%s/hCharge_ev%i_standardized.png", outDir.Data(), iE));
 	 c2->SaveAs(Form("%s/hCharge_ev%i_standardized.pdf", outDir.Data(), iE));
    }
-  
    //Done.
 }


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Some changes to the setup compared to CERN testbeam 2022 (notably: number of time samples, number of bits actually used in TDC format, and the number of channels) meant that some tweaks to a series of producers and analyzers were due. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful.

![some sample event of not-very-great-data from S30XL](https://github.com/user-attachments/assets/55913ed1-c18f-43a0-bbaf-5eebf458979c)
![sample event from SLAC testbench](https://github.com/user-attachments/assets/ecfa9b93-c60a-4e3f-8b7f-0c3443dd1f63)
![example PE plot](https://github.com/user-attachments/assets/8c2553ff-557a-4ff1-8a19-30ac4b0613f6)

