### PR TITLE
Add input pass names + printout to existence checks

### DIFF
--- a/Recon/src/Recon/PFEcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFEcalClusterProducer.cxx
@@ -22,7 +22,7 @@ void PFEcalClusterProducer::configure(framework::config::Parameters& ps) {
 
 void PFEcalClusterProducer::produce(framework::Event& event) {
   if (!event.exists(hitCollName_, hitPassName_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_;
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_ << " with pass name " << hitPassName_;
     return;
   }
   const auto ecalRecHits =

--- a/Recon/src/Recon/PFEcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFEcalClusterProducer.cxx
@@ -22,7 +22,8 @@ void PFEcalClusterProducer::configure(framework::config::Parameters& ps) {
 
 void PFEcalClusterProducer::produce(framework::Event& event) {
   if (!event.exists(hitCollName_, hitPassName_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_ << " with pass name " << hitPassName_;
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_
+                    << " with pass name " << hitPassName_;
     return;
   }
   const auto ecalRecHits =

--- a/Recon/src/Recon/PFEcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFEcalClusterProducer.cxx
@@ -21,7 +21,10 @@ void PFEcalClusterProducer::configure(framework::config::Parameters& ps) {
 }
 
 void PFEcalClusterProducer::produce(framework::Event& event) {
-  if (!event.exists(hitCollName_)) return;
+  if (!event.exists(hitCollName_, hitPassName_)) {
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_;
+    return;
+  }
   const auto ecalRecHits =
       event.getCollection<ldmx::EcalHit>(hitCollName_, hitPassName_);
 

--- a/Recon/src/Recon/PFHcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFHcalClusterProducer.cxx
@@ -25,7 +25,10 @@ void PFHcalClusterProducer::configure(framework::config::Parameters& ps) {
 }
 
 void PFHcalClusterProducer::produce(framework::Event& event) {
-  if (!event.exists(hitCollName_)) return;
+  if (!event.exists(hitCollName_, hitPassName_)) {
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_;
+    return;
+  }
   const auto hcalRecHits =
       event.getCollection<ldmx::HcalHit>(hitCollName_, hitPassName_);
   float eTotal = 0;

--- a/Recon/src/Recon/PFHcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFHcalClusterProducer.cxx
@@ -26,7 +26,8 @@ void PFHcalClusterProducer::configure(framework::config::Parameters& ps) {
 
 void PFHcalClusterProducer::produce(framework::Event& event) {
   if (!event.exists(hitCollName_, hitPassName_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_ << "_" << hitPassName_;
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_ << "_"
+                    << hitPassName_;
     return;
   }
   const auto hcalRecHits =

--- a/Recon/src/Recon/PFHcalClusterProducer.cxx
+++ b/Recon/src/Recon/PFHcalClusterProducer.cxx
@@ -26,7 +26,7 @@ void PFHcalClusterProducer::configure(framework::config::Parameters& ps) {
 
 void PFHcalClusterProducer::produce(framework::Event& event) {
   if (!event.exists(hitCollName_, hitPassName_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_;
+    ldmx_log(fatal) << "Couldn't find input collection " << hitCollName_ << "_" << hitPassName_;
     return;
   }
   const auto hcalRecHits =

--- a/Recon/src/Recon/PFTrackProducer.cxx
+++ b/Recon/src/Recon/PFTrackProducer.cxx
@@ -18,7 +18,7 @@ double getP(const ldmx::SimTrackerHit& tk) {
 
 void PFTrackProducer::produce(framework::Event& event) {
   if (!event.exists(inputTrackCollName_, input_pass_name_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_;
+    ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_ << "_" << input_pass_name;
     return;
   }
   const auto ecalSpHits = event.getCollection<ldmx::SimTrackerHit>(

--- a/Recon/src/Recon/PFTrackProducer.cxx
+++ b/Recon/src/Recon/PFTrackProducer.cxx
@@ -18,7 +18,8 @@ double getP(const ldmx::SimTrackerHit& tk) {
 
 void PFTrackProducer::produce(framework::Event& event) {
   if (!event.exists(inputTrackCollName_, input_pass_name_)) {
-    ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_ << "_" << input_pass_name;
+    ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_
+                    << "_" << input_pass_name;
     return;
   }
   const auto ecalSpHits = event.getCollection<ldmx::SimTrackerHit>(

--- a/Recon/src/Recon/PFTrackProducer.cxx
+++ b/Recon/src/Recon/PFTrackProducer.cxx
@@ -20,7 +20,7 @@ void PFTrackProducer::produce(framework::Event& event) {
   if (!event.exists(inputTrackCollName_, input_pass_name_)) {
     ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_;
     return;
-  } 
+  }
   const auto ecalSpHits = event.getCollection<ldmx::SimTrackerHit>(
       inputTrackCollName_, input_pass_name_);
 

--- a/Recon/src/Recon/PFTrackProducer.cxx
+++ b/Recon/src/Recon/PFTrackProducer.cxx
@@ -17,10 +17,10 @@ double getP(const ldmx::SimTrackerHit& tk) {
 }
 
 void PFTrackProducer::produce(framework::Event& event) {
-  if (!event.exists(inputTrackCollName_)) {
-    ldmx_log(fatal) << "Input track collection not found";
+  if (!event.exists(inputTrackCollName_, input_pass_name_)) {
+    ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_;
     return;
-  }
+  } 
   const auto ecalSpHits = event.getCollection<ldmx::SimTrackerHit>(
       inputTrackCollName_, input_pass_name_);
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This at least partly resolves #1677

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful:
After running the recipe in #1677, I now see non-empty cluster and track collections: the processors no longer return if the specified combination of collection and pass name exists in the file. 
![Screenshot 2025-04-03 at 15 41 16](https://github.com/user-attachments/assets/dc10001b-bfde-49ad-bf4a-4664a24b3521)
