### PR TITLE
Update HcalSimpleDigiAndRecProducer.cxx

### DIFF
--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -123,29 +123,27 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
 
       // Checks orientation of side Hcal bars
       if (orientation ==
-        ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
-          xpos += (*position_resolution_smear_)(rng_);
-          ypos = stripCenter.y();
-          zpos = stripCenter.z();
-        }
-      else if (orientation ==
-        ldmx::HcalGeometry::ScintillatorOrientation::vertical) {
-          xpos = stripCenter.x();
-          ypos += (*position_resolution_smear_)(rng_);
-          zpos = stripCenter.z();
-        }
-      else if (orientation ==
-        ldmx::HcalGeometry::ScintillatorOrientation::depth) {
-          xpos = stripCenter.x();
-          ypos = stripCenter.y();
-          zpos += (*position_resolution_smear_)(rng_);
-        }
+          ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
+        xpos += (*position_resolution_smear_)(rng_);
+        ypos = stripCenter.y();
+        zpos = stripCenter.z();
+      } else if (orientation ==
+                 ldmx::HcalGeometry::ScintillatorOrientation::vertical) {
+        xpos = stripCenter.x();
+        ypos += (*position_resolution_smear_)(rng_);
+        zpos = stripCenter.z();
+      } else if (orientation ==
+                 ldmx::HcalGeometry::ScintillatorOrientation::depth) {
+        xpos = stripCenter.x();
+        ypos = stripCenter.y();
+        zpos += (*position_resolution_smear_)(rng_);
+      }
       // This might be irrelevant
       else {
-          xpos = stripCenter.x();
-          ypos = stripCenter.y();
-          zpos = stripCenter.z();
-        }
+        xpos = stripCenter.x();
+        ypos = stripCenter.y();
+        zpos = stripCenter.z();
+      }
     }
 
     recHit.setID(hitID.raw());

--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -121,7 +121,8 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
       recHit.setPE(PE);
       recHit.setMinPE(PE);
 
-      // Checks orientation of side Hcal bars, sets center positions and add smearing along bar orientation axis
+      // Checks orientation of side Hcal bars, sets center positions and add
+      // smearing along bar orientation axis
       if (orientation ==
           ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
         xpos += (*position_resolution_smear_)(rng_);
@@ -138,12 +139,14 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
         ypos = stripCenter.y();
         zpos += (*position_resolution_smear_)(rng_);
       }
-      // This might be irrelevant and the better way to do it would be to raise an exception?
+      // This might be irrelevant and the better way to do it would be to raise
+      // an exception?
       else {
         xpos = stripCenter.x();
         ypos = stripCenter.y();
         zpos = stripCenter.z();
-        // EXCEPTION_RAISE("NoBarOrientation","Hit could not be associated to bar orientation");
+        // EXCEPTION_RAISE("NoBarOrientation","Hit could not be associated to
+        // bar orientation");
       }
     }
 

--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -60,11 +60,12 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
     std::vector<double> pos{0, 0, 0};
     for (auto hit : simhits_in_bar) {
       edep += hit->getEdep();
-      time += hit->getTime() * edep;
+      double edep_hit = hit->getEdep();
+      time += hit->getTime() * edep_hit;
       auto hitPos{hit->getPosition()};
-      pos[0] += hitPos[0] * edep;
-      pos[1] += hitPos[1] * edep;
-      pos[2] += hitPos[2] * edep;
+      pos[0] += hitPos[0] * edep_hit;
+      pos[1] += hitPos[1] * edep_hit;
+      pos[2] += hitPos[2] * edep_hit;
     }
     ldmx::HcalID hitID{barID};
 
@@ -119,10 +120,32 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
       int PE{std::poisson_distribution<int>(mean_pe + mean_noise_)(rng_)};
       recHit.setPE(PE);
       recHit.setMinPE(PE);
-      // TODO: Look into this
-      xpos = stripCenter.x();
-      ypos = stripCenter.y();
-      zpos = stripCenter.z();
+
+      // Checks orientation of side Hcal bars
+      if (orientation ==
+        ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
+          xpos += (*position_resolution_smear_)(rng_);
+          ypos = stripCenter.y();
+          zpos = stripCenter.z();
+        }
+      else if (orientation ==
+        ldmx::HcalGeometry::ScintillatorOrientation::vertical) {
+          xpos = stripCenter.x();
+          ypos += (*position_resolution_smear_)(rng_);
+          zpos = stripCenter.z();
+        }
+      else if (orientation ==
+        ldmx::HcalGeometry::ScintillatorOrientation::depth) {
+          xpos = stripCenter.x();
+          ypos = stripCenter.y();
+          zpos += (*position_resolution_smear_)(rng_);
+        }
+      // This might be irrelevant
+      else {
+          xpos = stripCenter.x();
+          ypos = stripCenter.y();
+          zpos = stripCenter.z();
+        }
     }
 
     recHit.setID(hitID.raw());

--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -121,7 +121,7 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
       recHit.setPE(PE);
       recHit.setMinPE(PE);
 
-      // Checks orientation of side Hcal bars
+      // Checks orientation of side Hcal bars, sets center positions and add smearing along bar orientation axis
       if (orientation ==
           ldmx::HcalGeometry::ScintillatorOrientation::horizontal) {
         xpos += (*position_resolution_smear_)(rng_);
@@ -138,11 +138,12 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
         ypos = stripCenter.y();
         zpos += (*position_resolution_smear_)(rng_);
       }
-      // This might be irrelevant
+      // This might be irrelevant and the better way to do it would be to raise an exception?
       else {
         xpos = stripCenter.x();
         ypos = stripCenter.y();
         zpos = stripCenter.z();
+        // EXCEPTION_RAISE("NoBarOrientation","Hit could not be associated to bar orientation");
       }
     }
 

--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -139,14 +139,11 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
         ypos = stripCenter.y();
         zpos += (*position_resolution_smear_)(rng_);
       }
-      // This might be irrelevant and the better way to do it would be to raise
-      // an exception?
       else {
         xpos = stripCenter.x();
         ypos = stripCenter.y();
         zpos = stripCenter.z();
-        // EXCEPTION_RAISE("NoBarOrientation","Hit could not be associated to
-        // bar orientation");
+        ldmx_log(warn) << "Bar orientation not found. Hit" << hitID.raw() << "positioned at bar center.";
       }
     }
 

--- a/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
+++ b/Hcal/src/Hcal/HcalSimpleDigiAndRecProducer.cxx
@@ -138,12 +138,12 @@ void HcalSimpleDigiAndRecProducer::produce(framework::Event& event) {
         xpos = stripCenter.x();
         ypos = stripCenter.y();
         zpos += (*position_resolution_smear_)(rng_);
-      }
-      else {
+      } else {
         xpos = stripCenter.x();
         ypos = stripCenter.y();
         zpos = stripCenter.z();
-        ldmx_log(warn) << "Bar orientation not found. Hit" << hitID.raw() << "positioned at bar center.";
+        ldmx_log(warn) << "Bar orientation not found. Hit" << hitID.raw()
+                       << "positioned at bar center.";
       }
     }
 


### PR DESCRIPTION
In the energy weighted position average, the cumulative energy was used instead of the individual hit energy. This resulted in the odd distribution of RecHits that you can see in issue #1681 . The energy weighted time average is affected as well.

Further, I have implemented the algorithm for the side Hcal bars but I am happy to receive feedback on how to make the code more efficient or on which parts could be left out which is why I open this PR as a draft.

### What are the issues that this addresses?
This resolves issue #1681 . There you can see how the current code is producing RecHits that are much further spread out than the SimHits which might be due to using the cumulative deposited energy instead of the individual one for each hit to do the weighting. On the issue page, you can also see the same event with the implemented code.

## Check List
- [✅] I successfully compiled _ldmx-sw_ with my developments.
- [✅] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [✅] I ran my developments and the following shows that they are successful.
See issue #1681 for the result of the fix.
