### PR TITLE
Fix typo in PFTrackProducer

### DIFF
--- a/Recon/src/Recon/PFTrackProducer.cxx
+++ b/Recon/src/Recon/PFTrackProducer.cxx
@@ -19,7 +19,7 @@ double getP(const ldmx::SimTrackerHit& tk) {
 void PFTrackProducer::produce(framework::Event& event) {
   if (!event.exists(inputTrackCollName_, input_pass_name_)) {
     ldmx_log(fatal) << "Couldn't find input collection " << inputTrackCollName_
-                    << "_" << input_pass_name;
+                    << "_" << input_pass_name_;
     return;
   }
   const auto ecalSpHits = event.getCollection<ldmx::SimTrackerHit>(


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Fixes
```
/home/runner/work/ldmx-sw/ldmx-sw/Recon/src/Recon/PFTrackProducer.cxx:22:31: error: 'input_pass_name' was not declared in this scope; did you mean 'input_pass_name_'?
   22 |                     << "_" << input_pass_name;
      |                               ^~~~~~~~~~~~~~~
      |                               input_pass_name_
```

## Check List
- [ ] I successfully compiled _ldmx-sw_ with my developments.
- [ ] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [ ] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
