### PR TITLE
Add PDG ID to dEdx estimate, make ID based mass estimates

### DIFF
--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -665,6 +665,11 @@ class TrkDeDxMassEstFeatures(ldmxcfg.Analyzer) :
         self.build1DHistogram("harmonic_mean_dedx", "I_{h} [MeV/cm]", 50, 0., 30.)
         self.build1DHistogram("mass_estimate", "Mass Estimate [MeV]", 100, 0., 2000.)
         self.build1DHistogram("mass_estimate_low_p", "Mass Estimate [MeV]", 100, 0., 2000.)
+        self.build1DHistogram("mass_estimate_very_low_p", "Mass Estimate [MeV]", 100, 0., 2000.)
+        self.build1DHistogram("mass_estimate_very_low_p_electron", "Mass Estimate for electrons [MeV]", 20, 0., 200.)
+        self.build1DHistogram("mass_estimate_very_low_p_pion", "Mass Estimate for pions [MeV]", 20, 0., 200.)
+        self.build1DHistogram("mass_estimate_very_low_p_kaon", "Mass Estimate for kaons [MeV]", 60, 200., 800.)
+        self.build1DHistogram("mass_estimate_very_low_p_proton", "Mass Estimate for proton [MeV]", 40, 800., 1200.)
         self.build1DHistogram("track_type", "Track Type", 3, 0, 3)
         
 

--- a/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
+++ b/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
@@ -19,19 +19,37 @@ void TrkDeDxMassEstFeatures::analyze(const framework::Event &event) {
   for (const auto &mass_est : mass_estimates_) {
     auto momentum = mass_est.getMomentum();
     histograms_.fill("momentum:harmonic_mean_dedx", momentum, mass_est.getIh());
-    if (momentum < 2000)
+    if (momentum < 2000.)
       histograms_.fill("momentum_low:harmonic_mean_dedx", momentum,
                        mass_est.getIh());
     histograms_.fill("harmonic_mean_dedx", mass_est.getIh());
     histograms_.fill("mass_estimate", mass_est.getMass());
-    if (momentum < 1000)
+    if (momentum < 1000.) {
       histograms_.fill("mass_estimate_low_p", mass_est.getMass());
+    }
+    if (momentum < 500.) {
+      histograms_.fill("mass_estimate_very_low_p", mass_est.getMass());
+      if ((mass_est.getPdgId() == 11) || (mass_est.getPdgId() == -11)) {
+        histograms_.fill("mass_estimate_very_low_p_electron", mass_est.getMass());
+      }
+      if ((mass_est.getPdgId() == 211) || (mass_est.getPdgId() == -211)) {
+        histograms_.fill("mass_estimate_very_low_p_pion", mass_est.getMass());
+      } 
+      if ((mass_est.getPdgId() == 321) || (mass_est.getPdgId() == -321)) {
+        histograms_.fill("mass_estimate_very_low_p_kaon", mass_est.getMass());
+      }
+      if ((mass_est.getPdgId() == 2212) || (mass_est.getPdgId() == -2212)) {
+        histograms_.fill("mass_estimate_very_low_p_proton", mass_est.getMass());
+      }   
+    }
     histograms_.fill("track_type", mass_est.getTrackType());
+
+
   }
 
   return;
 }
-
+ 
 void TrkDeDxMassEstFeatures::onProcessStart() {
   std::vector<std::string> labels = {"Other",   // 0
                                      "Tagger",  // 1

--- a/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
+++ b/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
@@ -30,26 +30,25 @@ void TrkDeDxMassEstFeatures::analyze(const framework::Event &event) {
     if (momentum < 500.) {
       histograms_.fill("mass_estimate_very_low_p", mass_est.getMass());
       if ((mass_est.getPdgId() == 11) || (mass_est.getPdgId() == -11)) {
-        histograms_.fill("mass_estimate_very_low_p_electron", mass_est.getMass());
+        histograms_.fill("mass_estimate_very_low_p_electron",
+                         mass_est.getMass());
       }
       if ((mass_est.getPdgId() == 211) || (mass_est.getPdgId() == -211)) {
         histograms_.fill("mass_estimate_very_low_p_pion", mass_est.getMass());
-      } 
+      }
       if ((mass_est.getPdgId() == 321) || (mass_est.getPdgId() == -321)) {
         histograms_.fill("mass_estimate_very_low_p_kaon", mass_est.getMass());
       }
       if ((mass_est.getPdgId() == 2212) || (mass_est.getPdgId() == -2212)) {
         histograms_.fill("mass_estimate_very_low_p_proton", mass_est.getMass());
-      }   
+      }
     }
     histograms_.fill("track_type", mass_est.getTrackType());
-
-
   }
 
   return;
 }
- 
+
 void TrkDeDxMassEstFeatures::onProcessStart() {
   std::vector<std::string> labels = {"Other",   // 0
                                      "Tagger",  // 1

--- a/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
+++ b/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
@@ -82,6 +82,12 @@ class TrackDeDxMassEstimate {
   void setTrackType(int track_type) { track_type_ = track_type; }
 
   /**
+   * Set the PDG ID of the track.
+   * @param pdg_id The PDG ID of the track.
+   */
+  void setPdgId(int pdg_id) { pdg_id_ = pdg_id; }
+
+  /**
    * Get the momentum of the particle/track.
    * @return The momentum of the particle/track.
    */
@@ -111,6 +117,14 @@ class TrackDeDxMassEstimate {
    */
   int getTrackType() const { return track_type_; }
 
+  /**
+   * Get the PDG ID of the track.
+   * @return The DPG ID of the track.
+   */
+  int getPdgId() const { return pdg_id_; }
+
+  
+
  private:
   /* The momentum of the particle/track */
   float momentum_{0.};
@@ -127,10 +141,13 @@ class TrackDeDxMassEstimate {
   /* The type of the track */
   int track_type_{-1};
 
+  /* PDG ID of the track*/
+  int pdg_id_{0};
+
   /**
    * The ROOT class definition.
    */
-  ClassDef(TrackDeDxMassEstimate, 2);
+  ClassDef(TrackDeDxMassEstimate, 3);
 };
 }  // namespace ldmx
 

--- a/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
+++ b/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
@@ -123,8 +123,6 @@ class TrackDeDxMassEstimate {
    */
   int getPdgId() const { return pdg_id_; }
 
-  
-
  private:
   /* The momentum of the particle/track */
   float momentum_{0.};

--- a/Recon/src/Recon/Event/TrackDeDxMassEstimate.cxx
+++ b/Recon/src/Recon/Event/TrackDeDxMassEstimate.cxx
@@ -11,6 +11,7 @@ void TrackDeDxMassEstimate::Clear() {
   mass_ = 0.;
   track_index_ = -1;
   track_type_ = -1;
+  pdg_id_ = 0;
 }
 
 void TrackDeDxMassEstimate::Print() const {
@@ -19,7 +20,9 @@ void TrackDeDxMassEstimate::Print() const {
             << "Ih: " << theIh_ << ", "
             << "Mass: " << mass_ << ", "
             << "Track Index: " << track_index_ << ", "
-            << "Track Type: " << track_type_ << " }" << std::endl;
+            << "Track Type: " << track_type_ << " }" 
+            << "PDG ID: " << pdg_id_ << " }" 
+            << std::endl;
 }
 
 }  // namespace ldmx

--- a/Recon/src/Recon/Event/TrackDeDxMassEstimate.cxx
+++ b/Recon/src/Recon/Event/TrackDeDxMassEstimate.cxx
@@ -20,9 +20,8 @@ void TrackDeDxMassEstimate::Print() const {
             << "Ih: " << theIh_ << ", "
             << "Mass: " << mass_ << ", "
             << "Track Index: " << track_index_ << ", "
-            << "Track Type: " << track_type_ << " }" 
-            << "PDG ID: " << pdg_id_ << " }" 
-            << std::endl;
+            << "Track Type: " << track_type_ << " }"
+            << "PDG ID: " << pdg_id_ << " }" << std::endl;
 }
 
 }  // namespace ldmx

--- a/Recon/src/Recon/TrackDeDxMassEstimator.cxx
+++ b/Recon/src/Recon/TrackDeDxMassEstimator.cxx
@@ -22,9 +22,9 @@ void TrackDeDxMassEstimator::configure(framework::config::Parameters &ps) {
 }
 
 void TrackDeDxMassEstimator::produce(framework::Event &event) {
-  if (!event.exists(track_collection_)) {
+  if (!event.exists(track_collection_, input_pass_name_)) {
     ldmx_log(error) << "Track collection " << track_collection_
-                    << " not in event";
+                    << "_" << input_pass_name_ << " not in event, exiting...";
     return;
   }
   const std::vector<ldmx::Track> tracks{
@@ -44,9 +44,12 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     track_type = 0;
     simhit_collection_ = "";
   }
-
+ 
   // Retrieve the simhits
-  if (!event.exists(simhit_collection_)) return;
+  if (!event.exists(simhit_collection_, input_pass_name_)) {
+    ldmx_log(error) << " SimHit collection (" << simhit_collection_ << "_" << input_pass_name_ << ") does not exists, exiting...";
+    return;
+  }
   auto simhits{event.getCollection<ldmx::SimTrackerHit>(simhit_collection_,
                                                         input_pass_name_)};
 
@@ -62,6 +65,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
       continue;
     }
 
+    int pdg_id = track.getPdgID();
     float momentum = 1. / std::abs(theQoP) * 1000;  // unit: MeV
     ldmx_log(debug) << "Track " << i << " has momentum " << momentum;
 
@@ -102,6 +106,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     mass_est.setMass(mass);
     mass_est.setTrackIndex(i);
     mass_est.setTrackType(track_type);
+    mass_est.setPdgId(pdg_id);
     mass_estimates_.push_back(mass_est);
   }
 

--- a/Recon/src/Recon/TrackDeDxMassEstimator.cxx
+++ b/Recon/src/Recon/TrackDeDxMassEstimator.cxx
@@ -23,8 +23,8 @@ void TrackDeDxMassEstimator::configure(framework::config::Parameters &ps) {
 
 void TrackDeDxMassEstimator::produce(framework::Event &event) {
   if (!event.exists(track_collection_, input_pass_name_)) {
-    ldmx_log(error) << "Track collection " << track_collection_
-                    << "_" << input_pass_name_ << " not in event, exiting...";
+    ldmx_log(error) << "Track collection " << track_collection_ << "_"
+                    << input_pass_name_ << " not in event, exiting...";
     return;
   }
   const std::vector<ldmx::Track> tracks{
@@ -44,10 +44,11 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     track_type = 0;
     simhit_collection_ = "";
   }
- 
+
   // Retrieve the simhits
   if (!event.exists(simhit_collection_, input_pass_name_)) {
-    ldmx_log(error) << " SimHit collection (" << simhit_collection_ << "_" << input_pass_name_ << ") does not exists, exiting...";
+    ldmx_log(error) << " SimHit collection (" << simhit_collection_ << "_"
+                    << input_pass_name_ << ") does not exists, exiting...";
     return;
   }
   auto simhits{event.getCollection<ldmx::SimTrackerHit>(simhit_collection_,


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

 * Add PDG ID to dEdx estimate
 * Add very low momentum dEdx mass plots
 * Add per ID plots

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
