### PR TITLE
Make target PN bias configurable to 4 or 8 GeV beam energy.

### DIFF
--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -100,22 +100,35 @@ def photo_nuclear( detector, generator ) :
     sim.setDetector( detector , True )
 
     # Set run parameters
-    sim.description = "ECal photo-nuclear, xsec bias 450"
+    if generator.energy == 8.0:
+          xsec_bias = 550.
+          xsec_bias_threshold = 5000.
+          tagger_threshold = 7600.
+          recoil_max_p = 3000.
+          brem_min_e = 5000.
+    else:
+          xsec_bias = 450.
+          xsec_bias_threshold = 2500.
+          tagger_threshold = 3800.
+          recoil_max_p = 1500.
+          brem_min_e = 2500.
+    
+    sim.description = "ECal photo-nuclear, xsec bias " + str(xsec_bias) + " xsec threshold " + str(xsec_bias_threshold) + " GeV"
     sim.beamSpotSmear = [20., 80., 0.]
 
     sim.generators.append(generator)
 
     # Enable and configure the biasing
-    sim.biasing_operators = [ bias_operators.PhotoNuclear('target',450.,2500.,only_children_of_primary=True) ]
+    sim.biasing_operators = [ bias_operators.PhotoNuclear('target',xsec_bias,xsec_bias_threshold,only_children_of_primary=True) ]
 
     # the following filters are in a library that needs to be included
     includeBiasing.library()
 
     # Configure the sequence in which user actions should be called.
     sim.actions.extend([
-            filters.TaggerVetoFilter(),
+            filters.TaggerVetoFilter(threesh = tagger_threshold),
             # Only consider events where a hard brem occurs
-            filters.TargetBremFilter(),
+            filters.TargetBremFilter(recoil_max_p = recoil_max_p, brem_min_e = brem_min_e),
             filters.TargetPNFilter(),
             # Tag all photo-nuclear tracks to persist them to the event.
             util.TrackProcessFilter.photo_nuclear()

--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -126,7 +126,7 @@ def photo_nuclear( detector, generator ) :
 
     # Configure the sequence in which user actions should be called.
     sim.actions.extend([
-            filters.TaggerVetoFilter(threesh = tagger_threshold),
+            filters.TaggerVetoFilter(thresh = tagger_threshold),
             # Only consider events where a hard brem occurs
             filters.TargetBremFilter(recoil_max_p = recoil_max_p, brem_min_e = brem_min_e),
             filters.TargetPNFilter(),


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Target PN biasing is no longer hard-coded for a 4 GeV beam and now depends on the energy of the input generator, similar to how ECal PN biasing is done now.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

I ran a test macro for a target PN simulation, with a similar run configuration as in [the example script in LDCS](https://github.com/LDMX-Software/LDCS/blob/muon-conversion/exampleConfigs/8GeV_targetPN.py).
Below is the RunHeader, showing that the correct biasing factor, threshold, and biased volume are applied for an input beam energy of 8 GeV.
```
[ Process ] 0  info: RunHeader { run: 12345, numTries: 0, detectorName: ldmx-det-v14-8gev, description: 8 GeV target PN simulation
  intParameters: 
    BiasOperators::PhotoNuclear::Bias Conv Down = 1
    BiasOperators::PhotoNuclear::Only Children Of Primary = 1
    Included Scoring Planes = 1
    RandomNumberMasterSeed[sim] = 12345
    Use Random Seed from Event Header = 0
  floatParameters: 
    BiasOperators::PhotoNuclear::Factor = 550
    BiasOperators::PhotoNuclear::Threshold = 5000
    Gen0 Direction X = 0.0485658
    Gen0 Direction Y = 0
    Gen0 Direction Z = 0.99882
    Gen0 Energy [GeV] = 8
    Gen0 Time [ns] = 0
    Gen0 X [mm] = -21.7459
    Gen0 Y [mm] = 0
    Gen0 Z [mm] = -883
    Smear Beam Spot [mm] X = 20
    Smear Beam Spot [mm] Y = 80
    Smear Beam Spot [mm] Z = 0
  stringParameters: 
    BiasOperators::PhotoNuclear::Volume = target
    Geant4 revision = 
    Gen0 Class = simcore::generators::ParticleGun
    Gen0 Particle = e-
    Pass = sim, version = v4.3.0
    SIM revision = d3dd4179f7c94bd37904b7328d24aff46b52c3e8
    SIM version = v4.3.0
}
```
I do, however, want to note that while the piece of code I'm modifying makes the correct change, my test script failed due to an unrelated issue:
```
[ fire ] 9 fatal: [ProductNotFound] : No product found for name 'RecoilTracksClean'
  at /Users/tyler/Desktop/ldmx/ldmx-sw/Framework/include/Framework/Event.h:293 in getObject
```