### PR TITLE
Add Hit Reconstruction from Axial and Stereo Tracking Layers to rLDMX Tracking

### DIFF
--- a/.github/validation_samples/reduced_ldmx/config.py
+++ b/.github/validation_samples/reduced_ldmx/config.py
@@ -16,7 +16,7 @@ myGun.pdgID = 11
 myGun.enablePoisson = False #True   
 
 mySim = sim.simulator( "mySim" ) # Build simulator object
-det = 'ldmx-reduced-v1'
+det = 'ldmx-reduced-v2'
 mySim.setDetector(det, True )
 mySim.beamSpotSmear = [20.,80.,0.]
 mySim.description = 'Reduced ECal Electron Gun Test Simulation'
@@ -113,7 +113,6 @@ rSeedTracking.layer23_midpoint = layer23_mid
 rSeedTracking.layer34_midpoint = layer34_mid
 rSeedTracking.recoil_uncertainty = [0.006, 0.085]
 rSeedTracking.ecal_distance_threshold = 15.0
-rSeedTracking.buildHistograms()
 
 rTracking = reducedTracking.LinearTrackFinder("LinearTrackFinder")
 rTracking.seed_collection = "LinearRecoilSeedTracks"

--- a/.github/validation_samples/reduced_ldmx/config.py
+++ b/.github/validation_samples/reduced_ldmx/config.py
@@ -16,7 +16,7 @@ myGun.pdgID = 11
 myGun.enablePoisson = False #True   
 
 mySim = sim.simulator( "mySim" ) # Build simulator object
-det = 'ldmx-reduced-v2'
+det = 'ldmx-reduced-v1'
 mySim.setDetector(det, True )
 mySim.beamSpotSmear = [20.,80.,0.]
 mySim.description = 'Reduced ECal Electron Gun Test Simulation'
@@ -111,7 +111,9 @@ rSeedTracking.out_seed_collection = "LinearRecoilSeedTracks"
 rSeedTracking.layer12_midpoint = layer12_mid
 rSeedTracking.layer23_midpoint = layer23_mid
 rSeedTracking.layer34_midpoint = layer34_mid
+rSeedTracking.recoil_uncertainty = [0.006, 0.085]
 rSeedTracking.ecal_distance_threshold = 15.0
+rSeedTracking.buildHistograms()
 
 rTracking = reducedTracking.LinearTrackFinder("LinearTrackFinder")
 rTracking.seed_collection = "LinearRecoilSeedTracks"

--- a/EventDisplay/python/rLDMX_EventDisplay.py
+++ b/EventDisplay/python/rLDMX_EventDisplay.py
@@ -27,9 +27,10 @@ def addBranch(tree, ldmx_class, branch_name):
 
     return branch
     
-def trackPlotter(tree, event_number, tag, save):
+def trackPlotter(tree, event_number, tag, save, save_tag):
     
     recoilSimHits = addBranch(tree, 'SimTrackerHit', 'RecoilSimHits_{}'.format(tag))
+    targetSP = addBranch(tree, 'SimTrackerHit', 'TargetScoringPlaneHits_{}'.format(tag))
     ecalRecHit = addBranch(tree, 'EcalHit', 'EcalRecHits_{}'.format(tag))
     digiRecoil = addBranch(tree, 'Measurement', 'DigiRecoilSimHits_{}'.format(tag))
     recoilTruth = addBranch(tree, 'StraightTrack', 'LinearRecoilTruthTracks_{}'.format(tag))
@@ -61,6 +62,10 @@ def trackPlotter(tree, event_number, tag, save):
     ecal_end_NOISE_y = []
     ecal_end_NOISE_z = []
     
+    targetSP_x = []
+    targetSP_y = []
+    targetSP_z = []
+    
     trackParams = []
     truthTrackParams = []
 
@@ -68,6 +73,12 @@ def trackPlotter(tree, event_number, tag, save):
         recoilSim_z.append(particle.getPosition()[2])
         recoilSim_x.append(particle.getPosition()[0])
         recoilSim_y.append(particle.getPosition()[1])
+        
+    for sp_particle in targetSP:
+        if (sp_particle.getPosition()[2] > 0):
+            targetSP_z.append(sp_particle.getPosition()[2])
+            targetSP_x.append(sp_particle.getPosition()[0])
+            targetSP_y.append(sp_particle.getPosition()[1])
         
     for x_digi in digiRecoil:
         zpos_digi_tot.append(x_digi.getGlobalPosition()[0])
@@ -102,6 +113,7 @@ def trackPlotter(tree, event_number, tag, save):
     ecalRecHits = np.column_stack((ecal_end_z, ecal_end_x, ecal_end_y))
     ecalRecHits_noise = np.column_stack((ecal_end_NOISE_z, ecal_end_NOISE_x, ecal_end_NOISE_y))
     recoilSim = np.column_stack((recoilSim_z, recoilSim_x, recoilSim_y))
+    targetSP_hits = np.column_stack((targetSP_z, targetSP_x, targetSP_y))
     first_sensor_pos = np.column_stack((first_sensor_z, first_sensor_x, first_sensor_y))
     second_sensor_pos = np.column_stack((second_sensor_z, second_sensor_x, second_sensor_y))
     
@@ -109,7 +121,7 @@ def trackPlotter(tree, event_number, tag, save):
     ax = fig.add_subplot(111, projection='3d')
 
     x_sensor_uncertainty = 0.006 #mm
-    y_sensor_uncertainty = 20./np.sqrt(12) # mm
+    y_sensor_uncertainty = 0.085 # mm
     
     for zi, xi, yi in zip(first_sensor_pos[:,0], first_sensor_pos[:,1], first_sensor_pos[:,2]):
         ax.plot([zi, zi], [xi - x_sensor_uncertainty, xi + x_sensor_uncertainty], [yi, yi], color='black',linewidth=2)  # x error
@@ -122,6 +134,7 @@ def trackPlotter(tree, event_number, tag, save):
     ax.scatter(digiPoints[:,0], digiPoints[:,1], digiPoints[:,2], c='b', marker='o', label='DigiRecoil SimHit', s=25)
     ax.scatter(ecalRecHits[:, 0], ecalRecHits[:, 1], ecalRecHits[:, 2], c='purple', label='ECalRecHit', s=50, alpha=0.5)
     ax.scatter(recoilSim[:, 0], recoilSim[:, 1], recoilSim[:, 2], marker='o', c='gray', label='RecoilSimHits', s=100, alpha=0.25)
+    ax.scatter(targetSP_hits[:, 0], targetSP_hits[:, 1], targetSP_hits[:, 2], marker='o', c='yellow', label='Target SP Hits', s=50, alpha=0.5)
     ax.scatter(first_sensor_pos[:,0], first_sensor_pos[:,1], first_sensor_pos[:,2], marker='o', c='red', label='First Sensor Point', s=30, alpha=0.75)
     ax.scatter(second_sensor_pos[:,0], second_sensor_pos[:,1], second_sensor_pos[:,2], marker='o', c='orange', label='Second Sensor Point', s=30, alpha=0.75)
     
@@ -138,22 +151,23 @@ def trackPlotter(tree, event_number, tag, save):
         for truthTrack in truthTrackParams:
             ax.plot([0.0, ecalRecHits[0][0]], [truthTrack[1], truthTrack[0]*ecalRecHits[0][0]+truthTrack[1]], [truthTrack[3], truthTrack[2]*ecalRecHits[0][0]+truthTrack[3]], color='blue', label=f'Truth Track, d_RecHit = {truthTrack[4]:.2f} mm, chi2 = {truthTrack[5]:.3f}')
     
-    x = ecalRecHits[0][0]
-    y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
-    z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
-    Y, Z = np.meshgrid(y_range, z_range)
-    X = np.full(Y.shape, ecalRecHits[0][0])
-
-    plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+    if (len(ecal_end_z) > 0):
+        x = ecalRecHits[0][0]
+        y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
+        z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
+        Y, Z = np.meshgrid(y_range, z_range)
+        X = np.full(Y.shape, ecalRecHits[0][0])
     
-    for recHit in ecalRecHits:
-        center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
-        radius = 3.87
-        theta = np.linspace(0, 2 * np.pi, 100)
-        circle_x = center_x + radius * np.cos(theta)
-        circle_y = center_y + radius * np.sin(theta)
-        circle_z = np.full_like(circle_x, center_z)
-        ax.plot(circle_z, circle_x, circle_y, c='purple')
+        plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+    
+        for recHit in ecalRecHits:
+            center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
+            radius = 3.87
+            theta = np.linspace(0, 2 * np.pi, 100)
+            circle_x = center_x + radius * np.cos(theta)
+            circle_y = center_y + radius * np.sin(theta)
+            circle_z = np.full_like(circle_x, center_z)
+            ax.plot(circle_z, circle_x, circle_y, c='purple')
 
     # Labels and title
     ax.set_xlabel('z [mm]')
@@ -169,41 +183,44 @@ def trackPlotter(tree, event_number, tag, save):
 
     ax.legend(fontsize=10)
     
-    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}.png')
+    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_{save_tag}.png')
 
 #    UNCOMMENT THESE LINES IF YOU WANT A ZOOMED IN PLOT (i.e. just recoil points)
-#    ax.set_xlim(0, 50)
-#
-#    x_low_lim = -10
-#    x_up_lim = -5
-#    y_low_lim = 14
-#    y_up_lim = 17
-#    
-#    x_target = 0.0
-#    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
-#    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
-#    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
-#    X_target = np.full(Y_target.shape, 0.0)
-#    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
-#
-#    ax.set_ylim(x_low_lim, x_up_lim)
-#    ax.set_zlim(y_low_lim, y_up_lim)
-#    plane.set_visible(False)
-#
-#    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
+    ax.set_xlim(0, 50)
+
+    x_low_lim = 5
+    x_up_lim = 15
+    y_low_lim = 0
+    y_up_lim = 10
+    
+    x_target = 0.0
+    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
+    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
+    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
+    X_target = np.full(Y_target.shape, 0.0)
+    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
+
+    ax.set_ylim(x_low_lim, x_up_lim)
+    ax.set_zlim(y_low_lim, y_up_lim)
+    plane.set_visible(False)
+
+    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
     
 def main():
     tree = r.TChain("LDMX_Events")
-    tree.Add('events_5000_rLDMXV1.root')
+    tree.Add('events_1_rLDMX_v1_yZERO_new3Dpoints.root')
 
     nentries = tree.GetEntries()
     print("nentries = ", nentries)
     
     tag = 'rLDMX_v1'
-    save_loc = 'event_displays/rLDMX_v1'
-    event_number = 10
+    save_loc = 'plots/event_displays/'
+    event_number = 26
+    save_tag = 'yZERO_new3Dpoints'
 
-    trackPlotter(tree, event_number, tag, save_loc)
+#    random_numbers = random.sample(range(0, 101), 10)
+#    for number in random_numbers:
+    trackPlotter(tree, event_number, tag, save_loc, save_tag)
 
 if __name__ == "__main__":
     main()

--- a/EventDisplay/python/rLDMX_EventDisplay.py
+++ b/EventDisplay/python/rLDMX_EventDisplay.py
@@ -27,9 +27,10 @@ def addBranch(tree, ldmx_class, branch_name):
 
     return branch
     
-def trackPlotter(tree, event_number, tag, save):
+def trackPlotter(tree, event_number, tag, save, save_tag):
     
     recoilSimHits = addBranch(tree, 'SimTrackerHit', 'RecoilSimHits_{}'.format(tag))
+    targetSP = addBranch(tree, 'SimTrackerHit', 'TargetScoringPlaneHits_{}'.format(tag))
     ecalRecHit = addBranch(tree, 'EcalHit', 'EcalRecHits_{}'.format(tag))
     digiRecoil = addBranch(tree, 'Measurement', 'DigiRecoilSimHits_{}'.format(tag))
     recoilTruth = addBranch(tree, 'StraightTrack', 'LinearRecoilTruthTracks_{}'.format(tag))
@@ -61,6 +62,10 @@ def trackPlotter(tree, event_number, tag, save):
     ecal_end_NOISE_y = []
     ecal_end_NOISE_z = []
     
+    targetSP_x = []
+    targetSP_y = []
+    targetSP_z = []
+    
     trackParams = []
     truthTrackParams = []
 
@@ -68,6 +73,12 @@ def trackPlotter(tree, event_number, tag, save):
         recoilSim_z.append(particle.getPosition()[2])
         recoilSim_x.append(particle.getPosition()[0])
         recoilSim_y.append(particle.getPosition()[1])
+        
+    for sp_particle in targetSP:
+        if (sp_particle.getPosition()[2] > 0):
+            targetSP_z.append(sp_particle.getPosition()[2])
+            targetSP_x.append(sp_particle.getPosition()[0])
+            targetSP_y.append(sp_particle.getPosition()[1])
         
     for x_digi in digiRecoil:
         zpos_digi_tot.append(x_digi.getGlobalPosition()[0])
@@ -102,14 +113,18 @@ def trackPlotter(tree, event_number, tag, save):
     ecalRecHits = np.column_stack((ecal_end_z, ecal_end_x, ecal_end_y))
     ecalRecHits_noise = np.column_stack((ecal_end_NOISE_z, ecal_end_NOISE_x, ecal_end_NOISE_y))
     recoilSim = np.column_stack((recoilSim_z, recoilSim_x, recoilSim_y))
+    targetSP_hits = np.column_stack((targetSP_z, targetSP_x, targetSP_y))
     first_sensor_pos = np.column_stack((first_sensor_z, first_sensor_x, first_sensor_y))
     second_sensor_pos = np.column_stack((second_sensor_z, second_sensor_x, second_sensor_y))
     
     fig = plt.figure(figsize=(8, 8))
     ax = fig.add_subplot(111, projection='3d')
 
+    #These values come from uncertainty propogation in the function that reconstructs
+    #the 3D sensor point from the axial-stereo combo. See Tracking/LinearSeedFinder.cxx
+    #for the function definitions
     x_sensor_uncertainty = 0.006 #mm
-    y_sensor_uncertainty = 20./np.sqrt(12) # mm
+    y_sensor_uncertainty = 0.085 # mm
     
     for zi, xi, yi in zip(first_sensor_pos[:,0], first_sensor_pos[:,1], first_sensor_pos[:,2]):
         ax.plot([zi, zi], [xi - x_sensor_uncertainty, xi + x_sensor_uncertainty], [yi, yi], color='black',linewidth=2)  # x error
@@ -122,6 +137,7 @@ def trackPlotter(tree, event_number, tag, save):
     ax.scatter(digiPoints[:,0], digiPoints[:,1], digiPoints[:,2], c='b', marker='o', label='DigiRecoil SimHit', s=25)
     ax.scatter(ecalRecHits[:, 0], ecalRecHits[:, 1], ecalRecHits[:, 2], c='purple', label='ECalRecHit', s=50, alpha=0.5)
     ax.scatter(recoilSim[:, 0], recoilSim[:, 1], recoilSim[:, 2], marker='o', c='gray', label='RecoilSimHits', s=100, alpha=0.25)
+    ax.scatter(targetSP_hits[:, 0], targetSP_hits[:, 1], targetSP_hits[:, 2], marker='o', c='yellow', label='Target SP Hits', s=50, alpha=0.5)
     ax.scatter(first_sensor_pos[:,0], first_sensor_pos[:,1], first_sensor_pos[:,2], marker='o', c='red', label='First Sensor Point', s=30, alpha=0.75)
     ax.scatter(second_sensor_pos[:,0], second_sensor_pos[:,1], second_sensor_pos[:,2], marker='o', c='orange', label='Second Sensor Point', s=30, alpha=0.75)
     
@@ -138,22 +154,23 @@ def trackPlotter(tree, event_number, tag, save):
         for truthTrack in truthTrackParams:
             ax.plot([0.0, ecalRecHits[0][0]], [truthTrack[1], truthTrack[0]*ecalRecHits[0][0]+truthTrack[1]], [truthTrack[3], truthTrack[2]*ecalRecHits[0][0]+truthTrack[3]], color='blue', label=f'Truth Track, d_RecHit = {truthTrack[4]:.2f} mm, chi2 = {truthTrack[5]:.3f}')
     
-    x = ecalRecHits[0][0]
-    y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
-    z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
-    Y, Z = np.meshgrid(y_range, z_range)
-    X = np.full(Y.shape, ecalRecHits[0][0])
-
-    plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+    if (len(ecal_end_z) > 0):
+        x = ecalRecHits[0][0]
+        y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
+        z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
+        Y, Z = np.meshgrid(y_range, z_range)
+        X = np.full(Y.shape, ecalRecHits[0][0])
     
-    for recHit in ecalRecHits:
-        center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
-        radius = 3.87
-        theta = np.linspace(0, 2 * np.pi, 100)
-        circle_x = center_x + radius * np.cos(theta)
-        circle_y = center_y + radius * np.sin(theta)
-        circle_z = np.full_like(circle_x, center_z)
-        ax.plot(circle_z, circle_x, circle_y, c='purple')
+        plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+    
+        for recHit in ecalRecHits:
+            center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
+            radius = 3.87
+            theta = np.linspace(0, 2 * np.pi, 100)
+            circle_x = center_x + radius * np.cos(theta)
+            circle_y = center_y + radius * np.sin(theta)
+            circle_z = np.full_like(circle_x, center_z)
+            ax.plot(circle_z, circle_x, circle_y, c='purple')
 
     # Labels and title
     ax.set_xlabel('z [mm]')
@@ -169,41 +186,44 @@ def trackPlotter(tree, event_number, tag, save):
 
     ax.legend(fontsize=10)
     
-    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}.png')
+    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_{save_tag}.png')
 
 #    UNCOMMENT THESE LINES IF YOU WANT A ZOOMED IN PLOT (i.e. just recoil points)
-#    ax.set_xlim(0, 50)
-#
-#    x_low_lim = -10
-#    x_up_lim = -5
-#    y_low_lim = 14
-#    y_up_lim = 17
-#    
-#    x_target = 0.0
-#    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
-#    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
-#    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
-#    X_target = np.full(Y_target.shape, 0.0)
-#    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
-#
-#    ax.set_ylim(x_low_lim, x_up_lim)
-#    ax.set_zlim(y_low_lim, y_up_lim)
-#    plane.set_visible(False)
-#
-#    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
+    ax.set_xlim(0, 50)
+
+    x_low_lim = 5
+    x_up_lim = 15
+    y_low_lim = 0
+    y_up_lim = 10
+    
+    x_target = 0.0
+    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
+    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
+    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
+    X_target = np.full(Y_target.shape, 0.0)
+    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
+
+    ax.set_ylim(x_low_lim, x_up_lim)
+    ax.set_zlim(y_low_lim, y_up_lim)
+    plane.set_visible(False)
+
+    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
     
 def main():
     tree = r.TChain("LDMX_Events")
-    tree.Add('events_5000_rLDMXV1.root')
+    tree.Add('events_1_rLDMX_v1_yZERO_new3Dpoints.root')
 
     nentries = tree.GetEntries()
     print("nentries = ", nentries)
     
     tag = 'rLDMX_v1'
-    save_loc = 'event_displays/rLDMX_v1'
-    event_number = 10
+    save_loc = 'plots/event_displays/'
+    event_number = 26
+    save_tag = 'yZERO_new3Dpoints'
 
-    trackPlotter(tree, event_number, tag, save_loc)
+#    random_numbers = random.sample(range(0, 101), 10)
+#    for number in random_numbers:
+    trackPlotter(tree, event_number, tag, save_loc, save_tag)
 
 if __name__ == "__main__":
     main()

--- a/EventDisplay/python/rLDMX_EventDisplay.py
+++ b/EventDisplay/python/rLDMX_EventDisplay.py
@@ -154,23 +154,22 @@ def trackPlotter(tree, event_number, tag, save, save_tag):
         for truthTrack in truthTrackParams:
             ax.plot([0.0, ecalRecHits[0][0]], [truthTrack[1], truthTrack[0]*ecalRecHits[0][0]+truthTrack[1]], [truthTrack[3], truthTrack[2]*ecalRecHits[0][0]+truthTrack[3]], color='blue', label=f'Truth Track, d_RecHit = {truthTrack[4]:.2f} mm, chi2 = {truthTrack[5]:.3f}')
     
-    if (len(ecal_end_z) > 0):
-        x = ecalRecHits[0][0]
-        y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
-        z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
-        Y, Z = np.meshgrid(y_range, z_range)
-        X = np.full(Y.shape, ecalRecHits[0][0])
-    
-        plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
-    
-        for recHit in ecalRecHits:
-            center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
-            radius = 3.87
-            theta = np.linspace(0, 2 * np.pi, 100)
-            circle_x = center_x + radius * np.cos(theta)
-            circle_y = center_y + radius * np.sin(theta)
-            circle_z = np.full_like(circle_x, center_z)
-            ax.plot(circle_z, circle_x, circle_y, c='purple')
+    x = ecalRecHits[0][0]
+    y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
+    z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
+    Y, Z = np.meshgrid(y_range, z_range)
+    X = np.full(Y.shape, ecalRecHits[0][0])
+        
+    plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+        
+    for recHit in ecalRecHits:
+        center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
+        radius = 3.87
+        theta = np.linspace(0, 2 * np.pi, 100)
+        circle_x = center_x + radius * np.cos(theta)
+        circle_y = center_y + radius * np.sin(theta)
+        circle_z = np.full_like(circle_x, center_z)
+        ax.plot(circle_z, circle_x, circle_y, c='purple')
 
     # Labels and title
     ax.set_xlabel('z [mm]')
@@ -189,29 +188,29 @@ def trackPlotter(tree, event_number, tag, save, save_tag):
     plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_{save_tag}.png')
 
 #    UNCOMMENT THESE LINES IF YOU WANT A ZOOMED IN PLOT (i.e. just recoil points)
-    ax.set_xlim(0, 50)
-
-    x_low_lim = 5
-    x_up_lim = 15
-    y_low_lim = 0
-    y_up_lim = 10
-    
-    x_target = 0.0
-    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
-    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
-    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
-    X_target = np.full(Y_target.shape, 0.0)
-    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
-
-    ax.set_ylim(x_low_lim, x_up_lim)
-    ax.set_zlim(y_low_lim, y_up_lim)
-    plane.set_visible(False)
-
-    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
+#    ax.set_xlim(0, 50)
+#
+#    x_low_lim = -6
+#    x_up_lim = -4
+#    y_low_lim = -18.5
+#    y_up_lim = -17
+#
+#    x_target = 0.0
+#    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
+#    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
+#    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
+#    X_target = np.full(Y_target.shape, 0.0)
+#    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
+#
+#    ax.set_ylim(x_low_lim, x_up_lim)
+#    ax.set_zlim(y_low_lim, y_up_lim)
+#    plane.set_visible(False)
+#
+#    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
     
 def main():
     tree = r.TChain("LDMX_Events")
-    tree.Add('events_1_rLDMX_v1_yZERO_new3Dpoints.root')
+    tree.Add('events_5000_rLDMX_v1_yZERO_new3Dpoints.root')
 
     nentries = tree.GetEntries()
     print("nentries = ", nentries)

--- a/EventDisplay/python/rLDMX_EventDisplay.py
+++ b/EventDisplay/python/rLDMX_EventDisplay.py
@@ -151,23 +151,22 @@ def trackPlotter(tree, event_number, tag, save, save_tag):
         for truthTrack in truthTrackParams:
             ax.plot([0.0, ecalRecHits[0][0]], [truthTrack[1], truthTrack[0]*ecalRecHits[0][0]+truthTrack[1]], [truthTrack[3], truthTrack[2]*ecalRecHits[0][0]+truthTrack[3]], color='blue', label=f'Truth Track, d_RecHit = {truthTrack[4]:.2f} mm, chi2 = {truthTrack[5]:.3f}')
     
-    if (len(ecal_end_z) > 0):
-        x = ecalRecHits[0][0]
-        y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
-        z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
-        Y, Z = np.meshgrid(y_range, z_range)
-        X = np.full(Y.shape, ecalRecHits[0][0])
-    
-        plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
-    
-        for recHit in ecalRecHits:
-            center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
-            radius = 3.87
-            theta = np.linspace(0, 2 * np.pi, 100)
-            circle_x = center_x + radius * np.cos(theta)
-            circle_y = center_y + radius * np.sin(theta)
-            circle_z = np.full_like(circle_x, center_z)
-            ax.plot(circle_z, circle_x, circle_y, c='purple')
+    x = ecalRecHits[0][0]
+    y_range = np.linspace(min(ecalRecHits[:,1]) - 5, max(ecalRecHits[:,1]) + 5, 50)
+    z_range = np.linspace(min(ecalRecHits[:,2]) - 5, max(ecalRecHits[:,2]) + 5, 50)
+    Y, Z = np.meshgrid(y_range, z_range)
+    X = np.full(Y.shape, ecalRecHits[0][0])
+        
+    plane = ax.plot_surface(X, Y, Z, color='red', alpha=0.1, edgecolor='none')
+        
+    for recHit in ecalRecHits:
+        center_z, center_x, center_y = recHit[0], recHit[1], recHit[2]
+        radius = 3.87
+        theta = np.linspace(0, 2 * np.pi, 100)
+        circle_x = center_x + radius * np.cos(theta)
+        circle_y = center_y + radius * np.sin(theta)
+        circle_z = np.full_like(circle_x, center_z)
+        ax.plot(circle_z, circle_x, circle_y, c='purple')
 
     # Labels and title
     ax.set_xlabel('z [mm]')
@@ -186,29 +185,29 @@ def trackPlotter(tree, event_number, tag, save, save_tag):
     plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_{save_tag}.png')
 
 #    UNCOMMENT THESE LINES IF YOU WANT A ZOOMED IN PLOT (i.e. just recoil points)
-    ax.set_xlim(0, 50)
-
-    x_low_lim = 5
-    x_up_lim = 15
-    y_low_lim = 0
-    y_up_lim = 10
-    
-    x_target = 0.0
-    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
-    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
-    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
-    X_target = np.full(Y_target.shape, 0.0)
-    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
-
-    ax.set_ylim(x_low_lim, x_up_lim)
-    ax.set_zlim(y_low_lim, y_up_lim)
-    plane.set_visible(False)
-
-    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
+#    ax.set_xlim(0, 50)
+#
+#    x_low_lim = -6
+#    x_up_lim = -4
+#    y_low_lim = -18.5
+#    y_up_lim = -17
+#
+#    x_target = 0.0
+#    y_target_range = np.linspace(x_low_lim, x_up_lim, 50)
+#    z_target_range = np.linspace(y_low_lim, y_up_lim, 50)
+#    Y_target, Z_target = np.meshgrid(y_target_range, z_target_range)
+#    X_target = np.full(Y_target.shape, 0.0)
+#    target_plane = ax.plot_surface(X_target, Y_target, Z_target, color='purple', alpha=0.1, edgecolor='none')
+#
+#    ax.set_ylim(x_low_lim, x_up_lim)
+#    ax.set_zlim(y_low_lim, y_up_lim)
+#    plane.set_visible(False)
+#
+#    plt.savefig(f'{save}/{tag}_eventDisplay_eventID_{event_number}_ZOOM.png')
     
 def main():
     tree = r.TChain("LDMX_Events")
-    tree.Add('events_1_rLDMX_v1_yZERO_new3Dpoints.root')
+    tree.Add('events_5000_rLDMX_v1_yZERO_new3Dpoints.root')
 
     nentries = tree.GetEntries()
     print("nentries = ", nentries)

--- a/Tracking/include/Tracking/Event/Measurement.h
+++ b/Tracking/include/Tracking/Event/Measurement.h
@@ -111,7 +111,7 @@ class Measurement {
   /// Add a trackId to the internal vector
   void addTrackId(int trkId) { trackIds_.push_back(trkId); };
   /// @return the sim particle IDs that compose the measurement
-  std::vector<unsigned int> getTrackIds() { return trackIds_; };
+  std::vector<unsigned int> getTrackIds() const { return trackIds_; };
 
   ///  @return The energy deposited in the sensor where the measurement took
   ///  place.

--- a/Tracking/include/Tracking/Reco/LinearSeedFinder.h
+++ b/Tracking/include/Tracking/Reco/LinearSeedFinder.h
@@ -69,19 +69,6 @@ class LinearSeedFinder : public TrackingGeometryUser {
           recoil_two,
       const std::array<double, 3> ecal_one);
 
-  // Function to combine Recoil layer points into "real" sensor points
-  std::pair<std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                   std::optional<ldmx::Measurement>>>,
-            std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                   std::optional<ldmx::Measurement>>>>
-  combineMultiGlobalHits(const std::vector<ldmx::Measurement> &hit_collection);
-
-  // Function to do weighted averaging when combining Recoil layer points
-  std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                         std::optional<ldmx::Measurement>>>
-  midPointCalculation(const std::vector<ldmx::Measurement> &layer1,
-                      const std::vector<ldmx::Measurement> &layer2);
-
   // Fitting function: fit a straight line in 3D using 3 points (1 degree of
   // freedom)
   std::tuple<double, double, double, double, std::vector<double>> fit3DLine(
@@ -92,6 +79,12 @@ class LinearSeedFinder : public TrackingGeometryUser {
   // Helper function: calculate distance between 2 3D points
   double calculateDistance(const std::array<double, 3> &point1,
                            const std::array<double, 3> &point2);
+    
+  // Do 3D hit reconstruction using an axial measurement and a stereo measurement according to geometric projections
+  Acts::Vector3 simple3DHitV2(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface, const ldmx::SimTrackerHit& hitOnTarget,  std::vector<ldmx::SimTrackerHit> pair_sim_hits);
+    
+  //Makes all combinations of sensor measurements to use in the seeding
+  std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> processMeasurements(const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>& measurements, const geo::TrackersTrackingGeometry& tg);
 
   // Calculate chi2 of the fit
   double globalChiSquare(const std::array<double, 3> &first_sensor,
@@ -102,14 +95,12 @@ class LinearSeedFinder : public TrackingGeometryUser {
   // Function to find the number of unique layers hit (to determine if we have
   // enough points to fit)
   int uniqueLayersHit(const std::vector<ldmx::Measurement> &digi_points);
-    
-    std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> processMeasurements(const std::vector<ldmx::Measurement>& measurements, const geo::TrackersTrackingGeometry& tg);
-    std::array<double, 3> convertToLdmxStdArray(const Acts::Vector3& vec);
-    std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> getSurfaceVectors(const Acts::Surface& surface);
-    Acts::Vector3 compute3DHit(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface);
-    double dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
-    Acts::Vector3 stripCenter(const Acts::Vector3& strip_origin, double u, const Acts::Vector3& strip_uhat);
-    double nonZeroDotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
+
+  //Helper functions:
+  std::array<double, 3> convertToLdmxStdArray(const Acts::Vector3& vec);
+  std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> getSurfaceVectors(const Acts::Surface& surface);
+  double dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
+  std::array<double, 3> getPointAtZ(std::array<double, 3> target, std::array<double, 3> measurement, double z_target);
     
   double processing_time_{0.};
   long n_events_{0};
@@ -133,7 +124,7 @@ class LinearSeedFinder : public TrackingGeometryUser {
   double layer34_midpoint_{27.5};
   double ecal_first_layer_z_threshold_{250.0};
 
-  std::vector<double> recoil_uncertainty_{0.006, 5.7735};
+  std::vector<double> recoil_uncertainty_{0.006, 0.085};
 
   // Check failures
   long n_missing_{0};

--- a/Tracking/include/Tracking/Reco/LinearSeedFinder.h
+++ b/Tracking/include/Tracking/Reco/LinearSeedFinder.h
@@ -79,12 +79,26 @@ class LinearSeedFinder : public TrackingGeometryUser {
   // Helper function: calculate distance between 2 3D points
   double calculateDistance(const std::array<double, 3> &point1,
                            const std::array<double, 3> &point2);
-    
-  // Do 3D hit reconstruction using an axial measurement and a stereo measurement according to geometric projections
-  Acts::Vector3 simple3DHitV2(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface, const ldmx::SimTrackerHit& hitOnTarget,  std::vector<ldmx::SimTrackerHit> pair_sim_hits);
-    
-  //Makes all combinations of sensor measurements to use in the seeding
-  std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> processMeasurements(const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>& measurements, const geo::TrackersTrackingGeometry& tg);
+
+  // Do 3D hit reconstruction using an axial measurement and a stereo
+  // measurement according to geometric projections
+  Acts::Vector3 simple3DHitV2(const ldmx::Measurement &axial,
+                              const Acts::Surface &axial_surface,
+                              const ldmx::Measurement &stereo,
+                              const Acts::Surface &stereo_surface,
+                              const ldmx::SimTrackerHit &hitOnTarget,
+                              std::vector<ldmx::SimTrackerHit> pair_sim_hits);
+
+  // Makes all combinations of sensor measurements to use in the seeding
+  std::vector<std::tuple<
+      std::array<double, 3>,
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>,
+      std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit,
+                               ldmx::SimTrackerHit>>>>
+  processMeasurements(
+      const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit,
+                                   ldmx::SimTrackerHit>> &measurements,
+      const geo::TrackersTrackingGeometry &tg);
 
   // Calculate chi2 of the fit
   double globalChiSquare(const std::array<double, 3> &first_sensor,
@@ -96,12 +110,15 @@ class LinearSeedFinder : public TrackingGeometryUser {
   // enough points to fit)
   int uniqueLayersHit(const std::vector<ldmx::Measurement> &digi_points);
 
-  //Helper functions:
-  std::array<double, 3> convertToLdmxStdArray(const Acts::Vector3& vec);
-  std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> getSurfaceVectors(const Acts::Surface& surface);
-  double dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
-  std::array<double, 3> getPointAtZ(std::array<double, 3> target, std::array<double, 3> measurement, double z_target);
-    
+  // Helper functions:
+  std::array<double, 3> convertToLdmxStdArray(const Acts::Vector3 &vec);
+  std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> getSurfaceVectors(
+      const Acts::Surface &surface);
+  double dotProduct(const Acts::Vector3 &v1, const Acts::Vector3 &v2);
+  std::array<double, 3> getPointAtZ(std::array<double, 3> target,
+                                    std::array<double, 3> measurement,
+                                    double z_target);
+
   double processing_time_{0.};
   long n_events_{0};
   unsigned int n_seeds_{0};

--- a/Tracking/include/Tracking/Reco/LinearSeedFinder.h
+++ b/Tracking/include/Tracking/Reco/LinearSeedFinder.h
@@ -102,7 +102,15 @@ class LinearSeedFinder : public TrackingGeometryUser {
   // Function to find the number of unique layers hit (to determine if we have
   // enough points to fit)
   int uniqueLayersHit(const std::vector<ldmx::Measurement> &digi_points);
-
+    
+    std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> processMeasurements(const std::vector<ldmx::Measurement>& measurements, const geo::TrackersTrackingGeometry& tg);
+    std::array<double, 3> convertToLdmxStdArray(const Acts::Vector3& vec);
+    std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> getSurfaceVectors(const Acts::Surface& surface);
+    Acts::Vector3 compute3DHit(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface);
+    double dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
+    Acts::Vector3 stripCenter(const Acts::Vector3& strip_origin, double u, const Acts::Vector3& strip_uhat);
+    double nonZeroDotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2);
+    
   double processing_time_{0.};
   long n_events_{0};
   unsigned int n_seeds_{0};

--- a/Tracking/python/reducedTracking.py
+++ b/Tracking/python/reducedTracking.py
@@ -46,10 +46,10 @@ class LinearSeedFinder(Producer):
         self.layer34_midpoint = 27.5
     
     def buildHistograms(self) :
-        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_ALL","Sensor1 Measured x - Sim Stereo1 x [mm]",200,-50,50)
-        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_ALL","Sensor1 Measured y - Sim Stereo1 y [mm]",200,-50,50)
-        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_ALL","Sensor2 Measured x - Sim Stereo2 x [mm]",200,-50,50)
-        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_ALL","Sensor2 Measured y - Sim Stereo2 y [mm]",200,-50,50)
+        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_ALL","Sensor1 Measured x - Sim Stereo1 x [mm]",100,-0.1,0.1)
+        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_ALL","Sensor1 Measured y - Sim Stereo1 y [mm]",100,-2,2)
+        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_ALL","Sensor2 Measured x - Sim Stereo2 x [mm]",100,-0.1,0.1)
+        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_ALL","Sensor2 Measured y - Sim Stereo2 y [mm]",100,-2,2)
         self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_same_trackID","Sensor1 Measured x - Sim Stereo1 x [mm]",100,-0.1,0.1)
         self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_same_trackID","Sensor1 Measured y - Sim Stereo1 y [mm]",100,-2,2)
         self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_same_trackID","Sensor2 Measured x - Sim Stereo2 x [mm]",100,-0.1,0.1)

--- a/Tracking/python/reducedTracking.py
+++ b/Tracking/python/reducedTracking.py
@@ -44,16 +44,6 @@ class LinearSeedFinder(Producer):
         self.layer12_midpoint = 12.5
         self.layer23_midpoint = 20.0
         self.layer34_midpoint = 27.5
-    
-    def buildHistograms(self) :
-        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_ALL","Sensor1 Measured x - Sim Stereo1 x [mm]",100,-0.1,0.1)
-        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_ALL","Sensor1 Measured y - Sim Stereo1 y [mm]",100,-2,2)
-        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_ALL","Sensor2 Measured x - Sim Stereo2 x [mm]",100,-0.1,0.1)
-        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_ALL","Sensor2 Measured y - Sim Stereo2 y [mm]",100,-2,2)
-        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_same_trackID","Sensor1 Measured x - Sim Stereo1 x [mm]",100,-0.1,0.1)
-        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_same_trackID","Sensor1 Measured y - Sim Stereo1 y [mm]",100,-2,2)
-        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_same_trackID","Sensor2 Measured x - Sim Stereo2 x [mm]",100,-0.1,0.1)
-        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_same_trackID","Sensor2 Measured y - Sim Stereo2 y [mm]",100,-2,2)
         
 class LinearTrackFinder(Producer):
     """ Producer to find Seeds for the reduced geometry track finding

--- a/Tracking/python/reducedTracking.py
+++ b/Tracking/python/reducedTracking.py
@@ -37,13 +37,23 @@ class LinearSeedFinder(Producer):
         self.input_hits_collection = 'DigiRecoilSimHits'
         self.input_rec_hits_collection = 'EcalRecHits'
         self.out_seed_collection = 'LinearRecoilSeedTracks'
-        self.recoil_uncertainty = [0.006, 20./(12**(0.5))]
+        self.recoil_uncertainty = [0.006, 0.085]
         self.ecal_uncertainty = 3.87
         self.ecal_first_layer_z_threshold = 250.0
         self.ecal_distance_threshold = 15.0
         self.layer12_midpoint = 12.5
         self.layer23_midpoint = 20.0
         self.layer34_midpoint = 27.5
+    
+    def buildHistograms(self) :
+        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_ALL","Sensor1 Measured x - Sim Stereo1 x [mm]",200,-50,50)
+        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_ALL","Sensor1 Measured y - Sim Stereo1 y [mm]",200,-50,50)
+        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_ALL","Sensor2 Measured x - Sim Stereo2 x [mm]",200,-50,50)
+        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_ALL","Sensor2 Measured y - Sim Stereo2 y [mm]",200,-50,50)
+        self.build1DHistogram("sensor1_measured_x-sim_stereo_layer1_x_same_trackID","Sensor1 Measured x - Sim Stereo1 x [mm]",100,-0.1,0.1)
+        self.build1DHistogram("sensor1_measured_y-sim_stereo_layer1_y_same_trackID","Sensor1 Measured y - Sim Stereo1 y [mm]",100,-2,2)
+        self.build1DHistogram("sensor2_measured_x-sim_stereo_layer2_x_same_trackID","Sensor2 Measured x - Sim Stereo2 x [mm]",100,-0.1,0.1)
+        self.build1DHistogram("sensor2_measured_y-sim_stereo_layer2_y_same_trackID","Sensor2 Measured y - Sim Stereo2 y [mm]",100,-2,2)
         
 class LinearTrackFinder(Producer):
     """ Producer to find Seeds for the reduced geometry track finding

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -29,7 +29,7 @@ void LinearSeedFinder::configure(framework::config::Parameters& parameters) {
 
   // the uncertainty is sigma_x = 6 microns and sigma_y = 20./sqrt(12)
   recoil_uncertainty_ = parameters.getParameter<std::vector<double>>(
-      "recoil_uncertainty", {0.006, 5.7735});
+      "recoil_uncertainty", {0.006, 0.085});
   ecal_uncertainty_ =
       parameters.getParameter<double>("ecal_uncertainty", {3.87});
   ecal_distance_threshold_ =
@@ -43,100 +43,184 @@ void LinearSeedFinder::configure(framework::config::Parameters& parameters) {
 }
 
 void LinearSeedFinder::produce(framework::Event& event) {
-  auto start = std::chrono::high_resolution_clock::now();
-  std::vector<ldmx::StraightTrack> straight_seed_tracks;
-  n_events_++;
-  auto tg{geometry()};
-
-  const std::vector<ldmx::Measurement> recoil_hits =
-      event.getCollection<ldmx::Measurement>(input_hits_collection_,
-                                             input_pass_name_);
-  const std::vector<ldmx::EcalHit> ecal_rec_hit =
-      event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
-                                         input_pass_name_);
-
-  std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
-
-  // Find RecHits at first layer of ECal
-  for (const auto& x_ecal : ecal_rec_hit) {
-    if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
-      first_layer_ecal_rec_hits.push_back(
-          {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
-    }  // if first layer of Ecal
-  }  // for positions in ecalRecHit
-
-  // Check if we would fit empty seeds, if so: end tracking
-  if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
-      (uniqueLayersHit(recoil_hits) < 2)) {
-    n_missing_++;
-    n_seeds_ += straight_seed_tracks.size();
-    event.add(out_seed_collection_, straight_seed_tracks);
-    return;
-  }
-
-  // Setup truth map
-  std::map<int, ldmx::SimParticle> particle_map;
-  if (event.exists("SimParticles")) {
-    particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
-    truth_matching_tool_->setup(particle_map, recoil_hits);
-  }
+    auto start = std::chrono::high_resolution_clock::now();
+    std::vector<ldmx::StraightTrack> straight_seed_tracks;
+    n_events_++;
+    auto tg{geometry()};
     
-    std::vector<ldmx::Measurement> first_two_layers;
-    for (const auto& point : recoil_hits) {
-      if (point.getGlobalPosition()[0] < layer12_midpoint_)
-        first_two_layers.push_back(point);
-      else if (point.getGlobalPosition()[0] < layer23_midpoint_)
-        first_two_layers.push_back(point);
-      else
-        continue;
+    const std::vector<ldmx::Measurement> recoil_hits =
+    event.getCollection<ldmx::Measurement>(input_hits_collection_,
+                                           input_pass_name_);
+    const std::vector<ldmx::EcalHit> ecal_rec_hit =
+    event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
+                                       input_pass_name_);
+    
+    std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
+    
+    // Find RecHits at first layer of ECal
+    for (const auto& x_ecal : ecal_rec_hit) {
+        if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
+            first_layer_ecal_rec_hits.push_back(
+                                                {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
+        }  // if first layer of Ecal
+    }    // for positions in ecalRecHit
+    
+    // Check if we would fit empty seeds, if so: end tracking
+    if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
+        (uniqueLayersHit(recoil_hits) < 2)) {
+        n_missing_++;
+        n_seeds_ += straight_seed_tracks.size();
+        event.add(out_seed_collection_, straight_seed_tracks);
+        return;
     }
-
-
-    auto firstSensorCombos = processMeasurements(first_two_layers, tg);
-      for (const auto& combo : firstSensorCombos) {
-          auto [combo_3d_points, first_layer, second_layer] = combo;
-          
-          ldmx_log(debug) << "The combined 3D hit is: (" << combo_3d_points[0] << ", "
-          << combo_3d_points[1] << ", " << combo_3d_points[2] << ")\n";
-          ldmx_log(debug) << "which is made out of layer1= (" << first_layer.getGlobalPosition()[0] << ", "
-          << first_layer.getGlobalPosition()[1] << ", " << first_layer.getGlobalPosition()[2] << ")\n";
-          ldmx_log(debug) << "and is made out of layer2= (" << second_layer.getGlobalPosition()[0] << ", "
-          << second_layer.getGlobalPosition()[1] << ", " << second_layer.getGlobalPosition()[2] << ")\n";
-          
-          const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits",
-                                                                                                            input_pass_name_);
-          
-          ldmx_log(debug) << "The first recoil layer trackID is: (" << first_layer.getTrackIds()[0] << ")\n";
-          ldmx_log(debug) << "The second recoil layer trackID is: (" << second_layer.getTrackIds()[0] << ")\n";
-
-          for (const auto& hit : recoil_sim_hits) {
-              ldmx_log(debug) << "The hit trackID is: (" << hit.getTrackID() << ")\n";
-              if (hit.getTrackID() == first_layer.getTrackIds()[0]) {
-                  ldmx_log(debug) << "The global position of the SimParticle with matching trackID to the measurement is: (" << hit.getPosition()[0] << ", " << hit.getPosition()[1] << ", " << hit.getPosition()[2] << ")\n";
-              }
-          }
-          
-      }
-
-// weighted averaging: layer1+layer2 = sensor1, layer3+layer4 = sensor2
-  // this gives all possible combinations of two tracker points for fitting
-  auto [first_sensor, second_sensor] = combineMultiGlobalHits(recoil_hits);
-
-  for (const auto& first_point : first_sensor) {
-    for (const auto& second_point : second_sensor) {
-      for (const auto& rec_hit : first_layer_ecal_rec_hits) {
-        // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom
-        // for linear fit
-        ldmx::StraightTrack seed_track =
-            SeedTracker(first_point, second_point, rec_hit);
-
-        // Seed passed RecHit distance check
-        if (seed_track.getChi2() > 0.0) {
-          straight_seed_tracks.push_back(seed_track);
-        }  // if chi2 > 0
-      }  // for rec_hits
-    }  // for second recoil tracker
-  }  // for first recoil tracker
+    
+    // Setup truth map
+    std::map<int, ldmx::SimParticle> particle_map;
+    if (event.exists("SimParticles")) {
+        particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
+        truth_matching_tool_->setup(particle_map, recoil_hits);
+    }
+    
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> first_two_layers;
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> second_two_layers;
+    
+    const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits", input_pass_name_);
+    const std::vector<ldmx::SimTrackerHit> scoring_hits = event.getCollection<ldmx::SimTrackerHit>("TargetScoringPlaneHits",input_pass_name_);
+    
+    // Index all sim hits by track ID
+    std::unordered_map<int, std::vector<const ldmx::SimTrackerHit*>> sim_hits_by_track_id;
+    for (const auto& hit : recoil_sim_hits) {
+        sim_hits_by_track_id[hit.getTrackID()].push_back(&hit);
+    } //for sim hits
+    
+    // Index scoring hits by track ID (one positive scoring plane hit per trackID)
+    std::unordered_map<int, const ldmx::SimTrackerHit*> scoring_hit_map;
+    for (const auto& sp_hit : scoring_hits) {
+        if (sp_hit.getPosition()[2] > 0)
+            scoring_hit_map[sp_hit.getTrackID()] = &sp_hit;
+    } //for sp hits
+    
+    for (const auto& point : recoil_hits) {
+        // x is in tracking coordinates, z is in ldmx coordinates
+        float x = point.getGlobalPosition()[0];
+        int track_id = point.getTrackIds()[0];
+        
+        //get the key value = track_id
+        auto sim_range_it = sim_hits_by_track_id.find(track_id);
+        if (sim_range_it == sim_hits_by_track_id.end())
+            continue;
+        
+        //access map value at track_id
+        const auto& sim_hits = sim_range_it->second;
+        
+        for (const auto* sim_hit : sim_hits) {
+            float z = sim_hit->getPosition()[2];
+            
+            if (x < layer12_midpoint_) {
+                if (z < layer12_midpoint_) {
+                    auto sp_it = scoring_hit_map.find(track_id);
+                    if (sp_it != scoring_hit_map.end()) {
+                        first_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+                        break;
+                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
+                } //associate 1st layer sim hit
+            } //check if recoil hit is 1st layer
+            else if (x < layer23_midpoint_) {
+                if (z > layer12_midpoint_ && z < layer23_midpoint_) {
+                    first_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
+                    break;
+                } //associate 2nd layer sim hit
+            } //check if recoil hit is 2nd layer
+            else if (x < layer34_midpoint_) {
+                if (z > layer23_midpoint_ && z < layer34_midpoint_) {
+                    auto sp_it = scoring_hit_map.find(track_id);
+                    if (sp_it != scoring_hit_map.end()) {
+                        second_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+                        break;
+                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
+                } //associate 3rd layer sim hits
+            } //check if recoil hit is 3rd layer
+            else {
+                if (z > layer34_midpoint_) {
+                    second_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
+                    break;
+                } // associate 4th layer sim hits
+            } // check if recoil hits is 4th layer
+            
+        } //loop through simhits
+    } //loop through recoil hits
+    
+    //Reconstruct 3D sensor points on which to do fitting
+    auto first_sensor_combos = processMeasurements(first_two_layers, tg);
+    auto second_sensor_combos = processMeasurements(second_two_layers, tg);
+        
+    // These histograms are being used to evaluate the performance of the hit reconstruction
+    // Since they rely on the sim hit associated to the layer, we output the histograms here instead of the DQM
+    // These can be commented out (and the declaration in reducedTracking.py removed) if they are not wanted
+    // HISTOGRAM START //
+    for (const auto& [combo_3d_point, first_layer, second_layer] : first_sensor_combos) {
+        if (second_layer.has_value()) {
+            // Unpack the first and second layer measurements
+            const auto& [meas1, hit1, scoring1] = first_layer;
+            const auto& [meas2, hit2, scoring2] = *second_layer;
+            
+            histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
+            histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
+            
+            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+                histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
+                histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
+            } //if trackIDs match, save the difference
+        } //if
+    } //for
+    
+    for (const auto& [combo_3d_point, first_layer, second_layer] : second_sensor_combos) {
+        if (second_layer.has_value()) {
+            // Unpack the first and second layer measurements
+            const auto& [meas1, hit1, scoring1] = first_layer;
+            const auto& [meas2, hit2, scoring2] = *second_layer;
+            
+            histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
+            histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
+            
+            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+                histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
+                histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
+            } //if trackIDs match, save the difference
+        } //if
+    } //for
+    // HISTOGRAM END //
+    
+    for (const auto& [first_combo_3d_point, first_layer_one, first_layer_two] : first_sensor_combos) {
+        std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> first_sensor_point;
+        
+        if (first_layer_two.has_value()) {
+            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::get<ldmx::Measurement>(*first_layer_two)};
+        } //check whether we did reconstruction or...
+        else {
+            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::nullopt};
+        } //...we are taking only one layer as the measurement (axial or stereo)
+        
+        for (const auto& [second_combo_3d_point, second_layer_one, second_layer_two] : second_sensor_combos) {
+            std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> second_sensor_point;
+            if (second_layer_two.has_value()) {
+                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::get<ldmx::Measurement>(*second_layer_two)};
+            } //check whether we did reconstruction or...
+            else {
+                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::nullopt};
+            } //...we are taking only one layer as the measurement (axial or stereo)
+            
+            for (const auto& rec_hit : first_layer_ecal_rec_hits) {
+                // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom for linear fit
+                ldmx::StraightTrack seed_track = SeedTracker(first_sensor_point, second_sensor_point, rec_hit);
+                
+                // Seed passed RecHit distance check, add it
+                if (seed_track.getChi2() > 0.0) {
+                    straight_seed_tracks.push_back(seed_track);
+                }  // if chi2 > 0
+            }    // for rec_hits
+        }      // for second recoil tracker
+    }        // for first recoil tracker
 
   n_seeds_ += straight_seed_tracks.size();
   event.add(out_seed_collection_, straight_seed_tracks);
@@ -244,114 +328,79 @@ void LinearSeedFinder::onProcessEnd() {
 
 }  // onProcessEnd
 
-std::pair<std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                 std::optional<ldmx::Measurement>>>,
-          std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                 std::optional<ldmx::Measurement>>>>
-LinearSeedFinder::combineMultiGlobalHits(
-    const std::vector<ldmx::Measurement>& hit_collection) {
-  std::vector<ldmx::Measurement> layer1, layer2, layer3, layer4;
+std::array<double, 3> LinearSeedFinder::getPointAtZ(std::array<double, 3> target, std::array<double, 3> measurement, double z_target) {
+    double slope_x = (measurement[1] - target[0]) / (measurement[0] - target[2]);
+    double slope_y = (measurement[2] - target[1]) / (measurement[0] - target[2]);
 
-  // Split hits into layers based on z position
-  // TODO: can we access layer information directly from ldmx::Measurement??
-  for (const auto& point : hit_collection) {
-    if (point.getGlobalPosition()[0] < layer12_midpoint_)
-      layer1.push_back(point);
-    else if (point.getGlobalPosition()[0] < layer23_midpoint_)
-      layer2.push_back(point);
-    else if (point.getGlobalPosition()[0] < layer34_midpoint_)
-      layer3.push_back(point);
-    else
-      layer4.push_back(point);
-  }
+    double intercept_x = target[0] - slope_x * target[2];
+    double intercept_y = target[1] - slope_y * target[2];
 
-  std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                         std::optional<ldmx::Measurement>>>
-      first_sensor_merged_hits, second_sensor_merged_hits;
+    double x_target = slope_x * z_target + intercept_x;
+    double y_target = slope_y * z_target + intercept_y;
 
-  if (layer1.empty()) {
-    for (const auto& point : layer2) {
-      first_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer2
-  }  // if layer1 empty
-  else if (layer2.empty()) {
-    for (const auto& point : layer1) {
-      first_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer1
-  }  // if layer2 empty
-  else {
-    first_sensor_merged_hits = midPointCalculation(layer1, layer2);
-  }  // do weighted average of two layers
+    return {z_target, x_target, y_target};
+}
 
-  if (layer3.empty()) {
-    for (const auto& point : layer4) {
-      second_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer4
-  }  // if layer3 empty
-  else if (layer4.empty()) {
-    for (const auto& point : layer3) {
-      second_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
+std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> LinearSeedFinder::processMeasurements(const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>& measurements, const geo::TrackersTrackingGeometry& tg) {
+    
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> axial_measurements;
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> stereo_measurements;
+    std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> points_with_measurement;
+    Acts::Vector3 dummy{0., 0., 0.};
+    
+    // Separate measurements into axial and stereo based on layerID
+    for (const auto& [measurement, sim_hit, scoring_hit] : measurements) {
+        if (measurement.getLayerID() % 2 == 0) {
+            axial_measurements.emplace_back(measurement, sim_hit, scoring_hit);
+        } else {
+            stereo_measurements.emplace_back(measurement, sim_hit, scoring_hit);
+        }
     }
-  }  // if layer4 empty
-  // do weighted average of two layers
-  else {
-    second_sensor_merged_hits = midPointCalculation(layer3, layer4);
-  }
 
-  return {first_sensor_merged_hits, second_sensor_merged_hits};
-}  // combineMultiGlobalHits
+    // If there are measurements in both axial and stereo layer:
+    // Iterate over axial and stereo measurements to compute 3D points
+    if (!axial_measurements.empty() && !stereo_measurements.empty()) {
+        for (const auto& axial : axial_measurements) {
+            const auto& [axial_meas, axial_hit, axial_sp] = axial;
 
-std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> LinearSeedFinder::processMeasurements(const std::vector<ldmx::Measurement>& measurements, const geo::TrackersTrackingGeometry& tg) {
-    
-    std::vector<ldmx::Measurement> axialMeasurements;
-    std::vector<ldmx::Measurement> stereoMeasurements;
-    std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> points_with_measurement;
-    
-    for (const auto& meas : measurements) {
-        if (meas.getLayerID() % 2 == 0) {
-            axialMeasurements.push_back(meas);
-        } // even layers are axial, from looking at Measurement.h
-        else {
-            stereoMeasurements.push_back(meas);
-        } // odd layers are stereo, from looking at Meaasurement.h
-    } // for measurements
-    
-    for (const auto& axial : axialMeasurements) {
-        for (const auto& stereo : stereoMeasurements) {
+            for (const auto& stereo : stereo_measurements) {
+                const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+
+                const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
+                const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
+
+                if (!axial_surface || !stereo_surface) continue;
+
+                std::vector<ldmx::SimTrackerHit> sim_hits = {axial_hit, stereo_hit};
+                Acts::Vector3 space_point = simple3DHitV2(axial_meas, *axial_surface, stereo_meas, *stereo_surface, axial_sp, sim_hits);
+
+                points_with_measurement.push_back({convertToLdmxStdArray(space_point), axial, stereo});
+            }
+        }
+    } else if (!axial_measurements.empty()) {
+        // if there are only axial measurements, take them to be our sensor points
+        for (const auto& axial : axial_measurements) {
+            const auto& [axial_meas, axial_hit, axial_sp] = axial;
+            const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
             
-            // Get surfaces from ACTS
-            const Acts::Surface* axial_surface = tg.getSurface(axial.getLayerID());
-            const Acts::Surface* stereo_surface = tg.getSurface(stereo.getLayerID());
+            Acts::Vector3 axial_meas_hit = axial_surface->localToGlobal(geometry_context(), Acts::Vector2(axial_meas.getLocalPosition()[0], 0.0), dummy);
+
+            points_with_measurement.push_back({convertToLdmxStdArray(axial_meas_hit), axial, std::nullopt});
+        }
+    } else if (!stereo_measurements.empty()) {
+        for (const auto& stereo : stereo_measurements) {
+            const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+            const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
             
-            if (!axial_surface || !stereo_surface) continue;  // Skip invalid surfaces
+            Acts::Vector3 stereo_meas_hit = stereo_surface->localToGlobal(geometry_context(), Acts::Vector2(stereo_meas.getLocalPosition()[0], 0.0), dummy);
             
-            // Compute 3D space point
-            Acts::Vector3 spacePoint = compute3DHit(axial, *axial_surface, stereo, *stereo_surface);
-            
-            points_with_measurement.push_back({convertToLdmxStdArray(spacePoint), axial, stereo});
-        } // for stereo
-    } // for axial
-    
+            points_with_measurement.push_back({convertToLdmxStdArray(stereo_meas_hit), stereo, std::nullopt});
+        }
+    }
     return points_with_measurement;
 }
 
-//I think ACTS saves its arrays like (x, y, z)
+//ACTS saves its arrays like (x, y, z)
 std::array<double, 3> LinearSeedFinder::convertToLdmxStdArray(const Acts::Vector3& vec) {
     return {vec.x(), vec.y(), vec.z()};
 }
@@ -365,30 +414,41 @@ std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> LinearSeedFinder::getSur
     return {u.normalized(), v.normalized(), w};
 }
 
-Acts::Vector3 LinearSeedFinder::compute3DHit(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface) {
+//  estimate the 3d position of the particle as it passes through a stereo/axial pair
+//  currently this uses the sim hits from the target and the axial sensor to calculate
+//  the angle of the particle, which is needed to project the two sensors to the same z
+//  For real data, we could use the position at the target for the tagger and the axial
+//  u position of the measured hit (we only project in x, which, in MC, is identically x)
+//  assumptions:   axial u-direction is identically global-x (tracking-global y)
+//                 sensors' w-directions are aligned with beam (global-z, tracking-global x)
+Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface,  const ldmx::SimTrackerHit& target_sp,  std::vector<ldmx::SimTrackerHit> pair_sim_hits) {
+    
+    Acts::Vector3 dummy{0., 0., 0.};
+    Acts::Vector3 hitOnTarget{target_sp.getPosition()[0], target_sp.getPosition()[1], target_sp.getPosition()[2]}; //x,y,z
+        
+    Acts::Vector3 axial_true_global{pair_sim_hits[0].getPosition()[0], pair_sim_hits[0].getPosition()[1], pair_sim_hits[0].getPosition()[2]};
+    //stereo_true_global is unused
+    Acts::Vector3 stereo_true_global{pair_sim_hits[1].getPosition()[0], pair_sim_hits[1].getPosition()[1], pair_sim_hits[1].getPosition()[2]};
+    
+    Acts::Vector3 simpart_path = axial_true_global-hitOnTarget;
+    Acts::Vector3 simpart_unit = simpart_path.normalized();
+        
+    // Get global positions for strip origins  ....  actually these are in tracking coordinates!
+    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
+    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
+    
+    //the tracking-global vector difference between stereo and axial sensor centers
+    Acts::Vector3  deltaSensors=stereo_origin-axial_origin;
+    
+    //calculate the displacement in tracking global x (need to generalize) by going from tracking x=axial to x=stereo
+    double dx_proj=(simpart_unit[0]/simpart_unit[2])*deltaSensors[0];// this looks weird because simpart_unit is in global-global and delta sensors is in tracking-global
     
     // Compute unit vectors for both hits
     auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
     auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
-
-    ldmx_log(debug) << "############################################################" << "\n";
-    ldmx_log(debug) << "The axial unit vectors are: " << "\n";
-    ldmx_log(debug) << "u: " << axial_u[0] << ", " << axial_u[1] << ", " << axial_u[2] << "\n";
-    ldmx_log(debug) << "v: " << axial_v[0] << ", " << axial_v[1] << ", " << axial_v[2] << "\n";
-    ldmx_log(debug) << "w: " << axial_w[0] << ", " << axial_w[1] << ", " << axial_w[2] << "\n";
-
-    ldmx_log(debug) << "The stereo unit vectors are: " << "\n";
-    ldmx_log(debug) << "u: " << stereo_u[0] << ", " << stereo_u[1] << ", " << stereo_u[2] << "\n";
-    ldmx_log(debug) << "v: " << stereo_v[0] << ", " << stereo_v[1] << ", " << stereo_v[2] << "\n";
-    ldmx_log(debug) << "w: " << stereo_w[0] << ", " << stereo_w[1] << ", " << stereo_w[2] << "\n";
-
-    // Get global positions for strip origins
-    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
-    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
-    
-    ldmx_log(debug) << "The axial global origins are: " << axial_origin[0] << ", " << axial_origin[1] << ", " << axial_origin[2] << "\n";
-    ldmx_log(debug) << "The stereo global origins are: " << stereo_origin[0] << ", " << stereo_origin[1] << ", " << stereo_origin[2] << "\n";
-    
+    double salpha = dotProduct(axial_v, stereo_u);
+        
+    // Get sensor local measured coordinates
     // Get local position components
     auto [axial_u_value, axial_v_value] = axial.getLocalPosition();
     auto [stereo_u_value, stereo_v_value] = stereo.getLocalPosition();
@@ -397,95 +457,26 @@ Acts::Vector3 LinearSeedFinder::compute3DHit(const ldmx::Measurement& axial, con
     axial_v_value = 0.0;
     stereo_v_value = 0.0;
     
-    ldmx_log(debug) << "The axial local positions are: " << axial_u_value << ", " << axial_v_value << "\n";
-    ldmx_log(debug) << "The stereo local positions are: " << stereo_u_value << ", " << stereo_v_value << "\n";
+    //use the dx_proj as the displacement in u of the axial measurement
+    //it's axial_u_value - dx_proj because u is in the -x direction
+    // this calculation is in the axial frame
+    double v_intercept_useproj=-((axial_u_value-dx_proj)-stereo_u_value)/salpha;
+    double u_intercept_useproj=axial_u_value-dx_proj;
     
-    Acts::Vector3 dummy{0., 0., 0.};
-    Acts::Vector3 axial_global = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(axial_u_value, axial_v_value), dummy);
-    Acts::Vector3 stereo_global = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(stereo_u_value, stereo_v_value), dummy);
+    //convert to tracking global
+    Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
+    Acts::Vector3 dummy_stereo_proj = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
     
-    ldmx_log(debug) << "The axial localToGlobal (i.e. global position) are: " << axial_global[0] << ", " << axial_global[1] << ", " << axial_global[2] << "\n";
-    ldmx_log(debug) << "The stereo localToGlobal (i.e. global position) are: " << stereo_global[0] << ", " << stereo_global[1] << ", " << stereo_global[2] << "\n";
-    
-    // From here we follow the logic of the HPS code
-    double gamma = dotProduct(stereo_origin, stereo_w) / nonZeroDotProduct(axial_origin, axial_w);
-    ldmx_log(debug) << "The value of gamma is: " << gamma << "\n";
-    
-    //This should be equivalent to the sin of the stereo angle, according to HPS
-    double salpha = dotProduct(axial_v, stereo_u);
-    ldmx_log(debug) << "The value of salpha is: " << salpha << "\n";
-
-    Acts::Vector3 p1 = stripCenter(axial_origin, axial_u_value, axial_u); //axial_u = axial unit vector in u
-    ldmx_log(debug) << "The p1 vector is: [" << p1[0] << ", " << p1[1] << ", " << p1[2] << "] \n";
-
-    Acts::Vector3 p2 = stripCenter(stereo_origin, stereo_u_value, stereo_u); //stereo_u = stereo unit vector in u
-    ldmx_log(debug) << "The p2 vector is: [" << p2[0] << ", " << p2[1] << ", " << p2[2] << "] \n";
-
-    Acts::Vector3 dp = p2 - p1;
-    ldmx_log(debug) << "The dp vector is: [" << dp[0] << ", " << dp[1] << ", " << dp[2] << "] \n";
-
-    double v1 = dotProduct(dp, stereo_u) / (gamma*salpha);
-    ldmx_log(debug) << "The value of v1 is: " << v1 << "\n";
-
-    if (v1 < -50.0) { v1 = -50.0; }
-    else if (v1 > 50.0) { v1 = 50.0; }
-    
-    Acts::Vector3 r1 = p1 + v1 * axial_v; //axial_v = axial unit vector in v
-    ldmx_log(debug) << "The r1 vector is: [" << r1[0] << ", " << r1[1] << ", " << r1[2] << "] \n";
-    
-    Acts::Vector3 final_position = (0.5 * (1 + gamma)) * r1;
-    ldmx_log(debug) << "The final position is: [" << final_position[0] << ", " << final_position[1] << ", " << final_position[2] << "] \n";
-    ldmx_log(debug) << "########################## end ##################################" << "\n";
-
-    return final_position;
+    //we want the reconstructed hit to be at the z of the stereo layer
+    Acts::Vector3 reconstructed_hit{dummy_stereo_proj[0], axst_global_useproj[1], axst_global_useproj[2]};
+    ldmx_log(debug) << "The particle projected axst measured position is (compare with stereo sim position): " << reconstructed_hit[0] << ", " << reconstructed_hit[1] << ", " << reconstructed_hit[2] << "\n";
+        
+    return reconstructed_hit;
 }
 
 double LinearSeedFinder::dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
     return v1.dot(v2);
 }
-
-Acts::Vector3 LinearSeedFinder::stripCenter(const Acts::Vector3& strip_origin, double u, const Acts::Vector3& strip_uhat) {
-    return strip_origin + u * strip_uhat;
-}
-
-double LinearSeedFinder::nonZeroDotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
-    double cth = v1.dot(v2);
-    double eps = 1e-6;
-    if (std::abs(cth) < eps) {
-        cth = (cth < 0.0) ? -eps : eps;
-    }
-    return cth;
-}
-
-
-std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                       std::optional<ldmx::Measurement>>>
-LinearSeedFinder::midPointCalculation(
-    const std::vector<ldmx::Measurement>& layer1,
-    const std::vector<ldmx::Measurement>& layer2) {
-  std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                         std::optional<ldmx::Measurement>>>
-      merged_hits;
-
-  for (const auto& point1 : layer1) {
-    for (const auto& point2 : layer2) {
-      double z_avg =
-          (point1.getGlobalPosition()[0] + point2.getGlobalPosition()[0]) /
-          (2.0);
-      double x_avg =
-          (point1.getGlobalPosition()[1] + point2.getGlobalPosition()[1]) /
-          (2.0);
-      // Until we make axial/stereo combinations, we don't know anything about
-      // the y value
-      double y_avg = 0.0;
-
-      merged_hits.push_back(std::make_tuple(
-          std::array<double, 3>{z_avg, x_avg, y_avg}, point1, point2));
-
-    }  // for layer2
-  }  // for layer1
-  return merged_hits;
-}  // midPointCalculation
 
 std::tuple<double, double, double, double, std::vector<double>>
 LinearSeedFinder::fit3DLine(const std::array<double, 3>& first_recoil,

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -165,54 +165,6 @@ void LinearSeedFinder::produce(framework::Event& event) {
   auto first_sensor_combos = processMeasurements(first_two_layers, tg);
   auto second_sensor_combos = processMeasurements(second_two_layers, tg);
 
-  // These histograms are being used to evaluate the performance of the hit
-  // reconstruction Since they rely on the sim hit associated to the layer, we
-  // output the histograms here instead of the DQM These can be commented out
-  // (and the declaration in reducedTracking.py removed) if they are not wanted
-  // HISTOGRAM START //
-  for (const auto& [combo_3d_point, first_layer, second_layer] :
-       first_sensor_combos) {
-    if (second_layer.has_value()) {
-      // Unpack the first and second layer measurements
-      const auto& [meas1, hit1, scoring1] = first_layer;
-      const auto& [meas2, hit2, scoring2] = *second_layer;
-
-      histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_ALL",
-                       combo_3d_point[1] - hit2.getPosition()[0]);
-      histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_ALL",
-                       combo_3d_point[2] - hit2.getPosition()[1]);
-
-      if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
-        histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_same_trackID",
-                         combo_3d_point[1] - hit2.getPosition()[0]);
-        histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_same_trackID",
-                         combo_3d_point[2] - hit2.getPosition()[1]);
-      }  // if trackIDs match, save the difference
-    }  // if
-  }  // for
-
-  for (const auto& [combo_3d_point, first_layer, second_layer] :
-       second_sensor_combos) {
-    if (second_layer.has_value()) {
-      // Unpack the first and second layer measurements
-      const auto& [meas1, hit1, scoring1] = first_layer;
-      const auto& [meas2, hit2, scoring2] = *second_layer;
-
-      histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_ALL",
-                       combo_3d_point[1] - hit2.getPosition()[0]);
-      histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_ALL",
-                       combo_3d_point[2] - hit2.getPosition()[1]);
-
-      if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
-        histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_same_trackID",
-                         combo_3d_point[1] - hit2.getPosition()[0]);
-        histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_same_trackID",
-                         combo_3d_point[2] - hit2.getPosition()[1]);
-      }  // if trackIDs match, save the difference
-    }  // if
-  }  // for
-  // HISTOGRAM END //
-
   for (const auto& [first_combo_3d_point, first_layer_one, first_layer_two] :
        first_sensor_combos) {
     std::tuple<std::array<double, 3>, ldmx::Measurement,

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -46,6 +46,7 @@ void LinearSeedFinder::produce(framework::Event& event) {
   auto start = std::chrono::high_resolution_clock::now();
   std::vector<ldmx::StraightTrack> straight_seed_tracks;
   n_events_++;
+  auto tg{geometry()};
 
   const std::vector<ldmx::Measurement> recoil_hits =
       event.getCollection<ldmx::Measurement>(input_hits_collection_,
@@ -79,8 +80,45 @@ void LinearSeedFinder::produce(framework::Event& event) {
     particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
     truth_matching_tool_->setup(particle_map, recoil_hits);
   }
+    
+    std::vector<ldmx::Measurement> first_two_layers;
+    for (const auto& point : recoil_hits) {
+      if (point.getGlobalPosition()[0] < layer12_midpoint_)
+        first_two_layers.push_back(point);
+      else if (point.getGlobalPosition()[0] < layer23_midpoint_)
+        first_two_layers.push_back(point);
+      else
+        continue;
+    }
 
-  // weighted averaging: layer1+layer2 = sensor1, layer3+layer4 = sensor2
+
+    auto firstSensorCombos = processMeasurements(first_two_layers, tg);
+      for (const auto& combo : firstSensorCombos) {
+          auto [combo_3d_points, first_layer, second_layer] = combo;
+          
+          ldmx_log(debug) << "The combined 3D hit is: (" << combo_3d_points[0] << ", "
+          << combo_3d_points[1] << ", " << combo_3d_points[2] << ")\n";
+          ldmx_log(debug) << "which is made out of layer1= (" << first_layer.getGlobalPosition()[0] << ", "
+          << first_layer.getGlobalPosition()[1] << ", " << first_layer.getGlobalPosition()[2] << ")\n";
+          ldmx_log(debug) << "and is made out of layer2= (" << second_layer.getGlobalPosition()[0] << ", "
+          << second_layer.getGlobalPosition()[1] << ", " << second_layer.getGlobalPosition()[2] << ")\n";
+          
+          const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits",
+                                                                                                            input_pass_name_);
+          
+          ldmx_log(debug) << "The first recoil layer trackID is: (" << first_layer.getTrackIds()[0] << ")\n";
+          ldmx_log(debug) << "The second recoil layer trackID is: (" << second_layer.getTrackIds()[0] << ")\n";
+
+          for (const auto& hit : recoil_sim_hits) {
+              ldmx_log(debug) << "The hit trackID is: (" << hit.getTrackID() << ")\n";
+              if (hit.getTrackID() == first_layer.getTrackIds()[0]) {
+                  ldmx_log(debug) << "The global position of the SimParticle with matching trackID to the measurement is: (" << hit.getPosition()[0] << ", " << hit.getPosition()[1] << ", " << hit.getPosition()[2] << ")\n";
+              }
+          }
+          
+      }
+
+// weighted averaging: layer1+layer2 = sensor1, layer3+layer4 = sensor2
   // this gives all possible combinations of two tracker points for fitting
   auto [first_sensor, second_sensor] = combineMultiGlobalHits(recoil_hits);
 
@@ -278,6 +316,147 @@ LinearSeedFinder::combineMultiGlobalHits(
 
   return {first_sensor_merged_hits, second_sensor_merged_hits};
 }  // combineMultiGlobalHits
+
+std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> LinearSeedFinder::processMeasurements(const std::vector<ldmx::Measurement>& measurements, const geo::TrackersTrackingGeometry& tg) {
+    
+    std::vector<ldmx::Measurement> axialMeasurements;
+    std::vector<ldmx::Measurement> stereoMeasurements;
+    std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> points_with_measurement;
+    
+    for (const auto& meas : measurements) {
+        if (meas.getLayerID() % 2 == 0) {
+            axialMeasurements.push_back(meas);
+        } // even layers are axial, from looking at Measurement.h
+        else {
+            stereoMeasurements.push_back(meas);
+        } // odd layers are stereo, from looking at Meaasurement.h
+    } // for measurements
+    
+    for (const auto& axial : axialMeasurements) {
+        for (const auto& stereo : stereoMeasurements) {
+            
+            // Get surfaces from ACTS
+            const Acts::Surface* axial_surface = tg.getSurface(axial.getLayerID());
+            const Acts::Surface* stereo_surface = tg.getSurface(stereo.getLayerID());
+            
+            if (!axial_surface || !stereo_surface) continue;  // Skip invalid surfaces
+            
+            // Compute 3D space point
+            Acts::Vector3 spacePoint = compute3DHit(axial, *axial_surface, stereo, *stereo_surface);
+            
+            points_with_measurement.push_back({convertToLdmxStdArray(spacePoint), axial, stereo});
+        } // for stereo
+    } // for axial
+    
+    return points_with_measurement;
+}
+
+//I think ACTS saves its arrays like (x, y, z)
+std::array<double, 3> LinearSeedFinder::convertToLdmxStdArray(const Acts::Vector3& vec) {
+    return {vec.x(), vec.y(), vec.z()};
+}
+
+//Helper function to calculate unit vector by taking advantage of the localToGlobal transformation
+std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> LinearSeedFinder::getSurfaceVectors(const Acts::Surface& surface) {
+    Acts::Vector3 dummy{0., 0., 0.};
+    Acts::Vector3 u = surface.localToGlobal(geometry_context(), Acts::Vector2(1, 0), dummy) - surface.center(geometry_context());
+    Acts::Vector3 v = surface.localToGlobal(geometry_context(), Acts::Vector2(0, 1), dummy) - surface.center(geometry_context());
+    Acts::Vector3 w = u.cross(v).normalized();
+    return {u.normalized(), v.normalized(), w};
+}
+
+Acts::Vector3 LinearSeedFinder::compute3DHit(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface) {
+    
+    // Compute unit vectors for both hits
+    auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
+    auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
+
+    ldmx_log(debug) << "############################################################" << "\n";
+    ldmx_log(debug) << "The axial unit vectors are: " << "\n";
+    ldmx_log(debug) << "u: " << axial_u[0] << ", " << axial_u[1] << ", " << axial_u[2] << "\n";
+    ldmx_log(debug) << "v: " << axial_v[0] << ", " << axial_v[1] << ", " << axial_v[2] << "\n";
+    ldmx_log(debug) << "w: " << axial_w[0] << ", " << axial_w[1] << ", " << axial_w[2] << "\n";
+
+    ldmx_log(debug) << "The stereo unit vectors are: " << "\n";
+    ldmx_log(debug) << "u: " << stereo_u[0] << ", " << stereo_u[1] << ", " << stereo_u[2] << "\n";
+    ldmx_log(debug) << "v: " << stereo_v[0] << ", " << stereo_v[1] << ", " << stereo_v[2] << "\n";
+    ldmx_log(debug) << "w: " << stereo_w[0] << ", " << stereo_w[1] << ", " << stereo_w[2] << "\n";
+
+    // Get global positions for strip origins
+    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
+    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
+    
+    ldmx_log(debug) << "The axial global origins are: " << axial_origin[0] << ", " << axial_origin[1] << ", " << axial_origin[2] << "\n";
+    ldmx_log(debug) << "The stereo global origins are: " << stereo_origin[0] << ", " << stereo_origin[1] << ", " << stereo_origin[2] << "\n";
+    
+    // Get local position components
+    auto [axial_u_value, axial_v_value] = axial.getLocalPosition();
+    auto [stereo_u_value, stereo_v_value] = stereo.getLocalPosition();
+    
+    // Manual correction, since v should always be 0 (insensitive direction)
+    axial_v_value = 0.0;
+    stereo_v_value = 0.0;
+    
+    ldmx_log(debug) << "The axial local positions are: " << axial_u_value << ", " << axial_v_value << "\n";
+    ldmx_log(debug) << "The stereo local positions are: " << stereo_u_value << ", " << stereo_v_value << "\n";
+    
+    Acts::Vector3 dummy{0., 0., 0.};
+    Acts::Vector3 axial_global = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(axial_u_value, axial_v_value), dummy);
+    Acts::Vector3 stereo_global = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(stereo_u_value, stereo_v_value), dummy);
+    
+    ldmx_log(debug) << "The axial localToGlobal (i.e. global position) are: " << axial_global[0] << ", " << axial_global[1] << ", " << axial_global[2] << "\n";
+    ldmx_log(debug) << "The stereo localToGlobal (i.e. global position) are: " << stereo_global[0] << ", " << stereo_global[1] << ", " << stereo_global[2] << "\n";
+    
+    // From here we follow the logic of the HPS code
+    double gamma = dotProduct(stereo_origin, stereo_w) / nonZeroDotProduct(axial_origin, axial_w);
+    ldmx_log(debug) << "The value of gamma is: " << gamma << "\n";
+    
+    //This should be equivalent to the sin of the stereo angle, according to HPS
+    double salpha = dotProduct(axial_v, stereo_u);
+    ldmx_log(debug) << "The value of salpha is: " << salpha << "\n";
+
+    Acts::Vector3 p1 = stripCenter(axial_origin, axial_u_value, axial_u); //axial_u = axial unit vector in u
+    ldmx_log(debug) << "The p1 vector is: [" << p1[0] << ", " << p1[1] << ", " << p1[2] << "] \n";
+
+    Acts::Vector3 p2 = stripCenter(stereo_origin, stereo_u_value, stereo_u); //stereo_u = stereo unit vector in u
+    ldmx_log(debug) << "The p2 vector is: [" << p2[0] << ", " << p2[1] << ", " << p2[2] << "] \n";
+
+    Acts::Vector3 dp = p2 - p1;
+    ldmx_log(debug) << "The dp vector is: [" << dp[0] << ", " << dp[1] << ", " << dp[2] << "] \n";
+
+    double v1 = dotProduct(dp, stereo_u) / (gamma*salpha);
+    ldmx_log(debug) << "The value of v1 is: " << v1 << "\n";
+
+    if (v1 < -50.0) { v1 = -50.0; }
+    else if (v1 > 50.0) { v1 = 50.0; }
+    
+    Acts::Vector3 r1 = p1 + v1 * axial_v; //axial_v = axial unit vector in v
+    ldmx_log(debug) << "The r1 vector is: [" << r1[0] << ", " << r1[1] << ", " << r1[2] << "] \n";
+    
+    Acts::Vector3 final_position = (0.5 * (1 + gamma)) * r1;
+    ldmx_log(debug) << "The final position is: [" << final_position[0] << ", " << final_position[1] << ", " << final_position[2] << "] \n";
+    ldmx_log(debug) << "########################## end ##################################" << "\n";
+
+    return final_position;
+}
+
+double LinearSeedFinder::dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
+    return v1.dot(v2);
+}
+
+Acts::Vector3 LinearSeedFinder::stripCenter(const Acts::Vector3& strip_origin, double u, const Acts::Vector3& strip_uhat) {
+    return strip_origin + u * strip_uhat;
+}
+
+double LinearSeedFinder::nonZeroDotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
+    double cth = v1.dot(v2);
+    double eps = 1e-6;
+    if (std::abs(cth) < eps) {
+        cth = (cth < 0.0) ? -eps : eps;
+    }
+    return cth;
+}
+
 
 std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
                        std::optional<ldmx::Measurement>>>

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -447,6 +447,7 @@ Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, co
     auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
     auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
     double salpha = dotProduct(axial_v, stereo_u);
+    double cosalpha = dotProduct(axial_u, stereo_u);
         
     // Get sensor local measured coordinates
     // Get local position components
@@ -460,15 +461,16 @@ Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, co
     //use the dx_proj as the displacement in u of the axial measurement
     //it's axial_u_value - dx_proj because u is in the -x direction
     // this calculation is in the axial frame
-    double v_intercept_useproj=-((axial_u_value-dx_proj)-stereo_u_value)/salpha;
-    double u_intercept_useproj=axial_u_value-dx_proj;
+    double v_intercept_useproj=(stereo_u_value - (axial_u_value-dx_proj)*cosalpha)/salpha;
+    double u_intercept_useproj=axial_u_value;
     
     //convert to tracking global
     Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
     Acts::Vector3 dummy_stereo_proj = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
     
-    //we want the reconstructed hit to be at the z of the stereo layer
+   //we want the reconstructed hit to be at the z of the stereo layer
     Acts::Vector3 reconstructed_hit{dummy_stereo_proj[0], axst_global_useproj[1], axst_global_useproj[2]};
+    
     ldmx_log(debug) << "The particle projected axst measured position is (compare with stereo sim position): " << reconstructed_hit[0] << ", " << reconstructed_hit[1] << ", " << reconstructed_hit[2] << "\n";
         
     return reconstructed_hit;

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -43,184 +43,222 @@ void LinearSeedFinder::configure(framework::config::Parameters& parameters) {
 }
 
 void LinearSeedFinder::produce(framework::Event& event) {
-    auto start = std::chrono::high_resolution_clock::now();
-    std::vector<ldmx::StraightTrack> straight_seed_tracks;
-    n_events_++;
-    auto tg{geometry()};
-    
-    const std::vector<ldmx::Measurement> recoil_hits =
-    event.getCollection<ldmx::Measurement>(input_hits_collection_,
-                                           input_pass_name_);
-    const std::vector<ldmx::EcalHit> ecal_rec_hit =
-    event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
-                                       input_pass_name_);
-    
-    std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
-    
-    // Find RecHits at first layer of ECal
-    for (const auto& x_ecal : ecal_rec_hit) {
-        if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
-            first_layer_ecal_rec_hits.push_back(
-                                                {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
-        }  // if first layer of Ecal
-    }    // for positions in ecalRecHit
-    
-    // Check if we would fit empty seeds, if so: end tracking
-    if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
-        (uniqueLayersHit(recoil_hits) < 2)) {
-        n_missing_++;
-        n_seeds_ += straight_seed_tracks.size();
-        event.add(out_seed_collection_, straight_seed_tracks);
-        return;
-    }
-    
-    // Setup truth map
-    std::map<int, ldmx::SimParticle> particle_map;
-    if (event.exists("SimParticles")) {
-        particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
-        truth_matching_tool_->setup(particle_map, recoil_hits);
-    }
-    
-    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> first_two_layers;
-    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> second_two_layers;
-    
-    const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits", input_pass_name_);
-    const std::vector<ldmx::SimTrackerHit> scoring_hits = event.getCollection<ldmx::SimTrackerHit>("TargetScoringPlaneHits",input_pass_name_);
-    
-    // Index all sim hits by track ID
-    std::unordered_map<int, std::vector<const ldmx::SimTrackerHit*>> sim_hits_by_track_id;
-    for (const auto& hit : recoil_sim_hits) {
-        sim_hits_by_track_id[hit.getTrackID()].push_back(&hit);
-    } //for sim hits
-    
-    // Index scoring hits by track ID (one positive scoring plane hit per trackID)
-    std::unordered_map<int, const ldmx::SimTrackerHit*> scoring_hit_map;
-    for (const auto& sp_hit : scoring_hits) {
-        if (sp_hit.getPosition()[2] > 0)
-            scoring_hit_map[sp_hit.getTrackID()] = &sp_hit;
-    } //for sp hits
-    
-    for (const auto& point : recoil_hits) {
-        // x is in tracking coordinates, z is in ldmx coordinates
-        float x = point.getGlobalPosition()[0];
-        int track_id = point.getTrackIds()[0];
-        
-        //get the key value = track_id
-        auto sim_range_it = sim_hits_by_track_id.find(track_id);
-        if (sim_range_it == sim_hits_by_track_id.end())
-            continue;
-        
-        //access map value at track_id
-        const auto& sim_hits = sim_range_it->second;
-        
-        for (const auto* sim_hit : sim_hits) {
-            float z = sim_hit->getPosition()[2];
-            
-            if (x < layer12_midpoint_) {
-                if (z < layer12_midpoint_) {
-                    auto sp_it = scoring_hit_map.find(track_id);
-                    if (sp_it != scoring_hit_map.end()) {
-                        first_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
-                        break;
-                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
-                } //associate 1st layer sim hit
-            } //check if recoil hit is 1st layer
-            else if (x < layer23_midpoint_) {
-                if (z > layer12_midpoint_ && z < layer23_midpoint_) {
-                    first_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
-                    break;
-                } //associate 2nd layer sim hit
-            } //check if recoil hit is 2nd layer
-            else if (x < layer34_midpoint_) {
-                if (z > layer23_midpoint_ && z < layer34_midpoint_) {
-                    auto sp_it = scoring_hit_map.find(track_id);
-                    if (sp_it != scoring_hit_map.end()) {
-                        second_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
-                        break;
-                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
-                } //associate 3rd layer sim hits
-            } //check if recoil hit is 3rd layer
-            else {
-                if (z > layer34_midpoint_) {
-                    second_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
-                    break;
-                } // associate 4th layer sim hits
-            } // check if recoil hits is 4th layer
-            
-        } //loop through simhits
-    } //loop through recoil hits
-    
-    //Reconstruct 3D sensor points on which to do fitting
-    auto first_sensor_combos = processMeasurements(first_two_layers, tg);
-    auto second_sensor_combos = processMeasurements(second_two_layers, tg);
-        
-    // These histograms are being used to evaluate the performance of the hit reconstruction
-    // Since they rely on the sim hit associated to the layer, we output the histograms here instead of the DQM
-    // These can be commented out (and the declaration in reducedTracking.py removed) if they are not wanted
-    // HISTOGRAM START //
-    for (const auto& [combo_3d_point, first_layer, second_layer] : first_sensor_combos) {
-        if (second_layer.has_value()) {
-            // Unpack the first and second layer measurements
-            const auto& [meas1, hit1, scoring1] = first_layer;
-            const auto& [meas2, hit2, scoring2] = *second_layer;
-            
-            histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
-            histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
-            
-            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
-                histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
-                histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
-            } //if trackIDs match, save the difference
-        } //if
-    } //for
-    
-    for (const auto& [combo_3d_point, first_layer, second_layer] : second_sensor_combos) {
-        if (second_layer.has_value()) {
-            // Unpack the first and second layer measurements
-            const auto& [meas1, hit1, scoring1] = first_layer;
-            const auto& [meas2, hit2, scoring2] = *second_layer;
-            
-            histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
-            histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
-            
-            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
-                histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
-                histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
-            } //if trackIDs match, save the difference
-        } //if
-    } //for
-    // HISTOGRAM END //
-    
-    for (const auto& [first_combo_3d_point, first_layer_one, first_layer_two] : first_sensor_combos) {
-        std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> first_sensor_point;
-        
-        if (first_layer_two.has_value()) {
-            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::get<ldmx::Measurement>(*first_layer_two)};
-        } //check whether we did reconstruction or...
-        else {
-            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::nullopt};
-        } //...we are taking only one layer as the measurement (axial or stereo)
-        
-        for (const auto& [second_combo_3d_point, second_layer_one, second_layer_two] : second_sensor_combos) {
-            std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> second_sensor_point;
-            if (second_layer_two.has_value()) {
-                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::get<ldmx::Measurement>(*second_layer_two)};
-            } //check whether we did reconstruction or...
-            else {
-                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::nullopt};
-            } //...we are taking only one layer as the measurement (axial or stereo)
-            
-            for (const auto& rec_hit : first_layer_ecal_rec_hits) {
-                // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom for linear fit
-                ldmx::StraightTrack seed_track = SeedTracker(first_sensor_point, second_sensor_point, rec_hit);
-                
-                // Seed passed RecHit distance check, add it
-                if (seed_track.getChi2() > 0.0) {
-                    straight_seed_tracks.push_back(seed_track);
-                }  // if chi2 > 0
-            }    // for rec_hits
-        }      // for second recoil tracker
-    }        // for first recoil tracker
+  auto start = std::chrono::high_resolution_clock::now();
+  std::vector<ldmx::StraightTrack> straight_seed_tracks;
+  n_events_++;
+  auto tg{geometry()};
+
+  const std::vector<ldmx::Measurement> recoil_hits =
+      event.getCollection<ldmx::Measurement>(input_hits_collection_,
+                                             input_pass_name_);
+  const std::vector<ldmx::EcalHit> ecal_rec_hit =
+      event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
+                                         input_pass_name_);
+
+  std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
+
+  // Find RecHits at first layer of ECal
+  for (const auto& x_ecal : ecal_rec_hit) {
+    if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
+      first_layer_ecal_rec_hits.push_back(
+          {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
+    }  // if first layer of Ecal
+  }  // for positions in ecalRecHit
+
+  // Check if we would fit empty seeds, if so: end tracking
+  if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
+      (uniqueLayersHit(recoil_hits) < 2)) {
+    n_missing_++;
+    n_seeds_ += straight_seed_tracks.size();
+    event.add(out_seed_collection_, straight_seed_tracks);
+    return;
+  }
+
+  // Setup truth map
+  std::map<int, ldmx::SimParticle> particle_map;
+  if (event.exists("SimParticles")) {
+    particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
+    truth_matching_tool_->setup(particle_map, recoil_hits);
+  }
+
+  std::vector<
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>
+      first_two_layers;
+  std::vector<
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>
+      second_two_layers;
+
+  const std::vector<ldmx::SimTrackerHit> recoil_sim_hits =
+      event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits",
+                                               input_pass_name_);
+  const std::vector<ldmx::SimTrackerHit> scoring_hits =
+      event.getCollection<ldmx::SimTrackerHit>("TargetScoringPlaneHits",
+                                               input_pass_name_);
+
+  // Index all sim hits by track ID
+  std::unordered_map<int, std::vector<const ldmx::SimTrackerHit*>>
+      sim_hits_by_track_id;
+  for (const auto& hit : recoil_sim_hits) {
+    sim_hits_by_track_id[hit.getTrackID()].push_back(&hit);
+  }  // for sim hits
+
+  // Index scoring hits by track ID (one positive scoring plane hit per trackID)
+  std::unordered_map<int, const ldmx::SimTrackerHit*> scoring_hit_map;
+  for (const auto& sp_hit : scoring_hits) {
+    if (sp_hit.getPosition()[2] > 0)
+      scoring_hit_map[sp_hit.getTrackID()] = &sp_hit;
+  }  // for sp hits
+
+  for (const auto& point : recoil_hits) {
+    // x is in tracking coordinates, z is in ldmx coordinates
+    float x = point.getGlobalPosition()[0];
+    int track_id = point.getTrackIds()[0];
+
+    // get the key value = track_id
+    auto sim_range_it = sim_hits_by_track_id.find(track_id);
+    if (sim_range_it == sim_hits_by_track_id.end()) continue;
+
+    // access map value at track_id
+    const auto& sim_hits = sim_range_it->second;
+
+    for (const auto* sim_hit : sim_hits) {
+      float z = sim_hit->getPosition()[2];
+
+      if (x < layer12_midpoint_) {
+        if (z < layer12_midpoint_) {
+          auto sp_it = scoring_hit_map.find(track_id);
+          if (sp_it != scoring_hit_map.end()) {
+            first_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+            break;
+          }  // add the associated scoring plane hit (will be needed for 3D
+             // reconstruction)
+        }  // associate 1st layer sim hit
+      }  // check if recoil hit is 1st layer
+      else if (x < layer23_midpoint_) {
+        if (z > layer12_midpoint_ && z < layer23_midpoint_) {
+          first_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
+          break;
+        }  // associate 2nd layer sim hit
+      }  // check if recoil hit is 2nd layer
+      else if (x < layer34_midpoint_) {
+        if (z > layer23_midpoint_ && z < layer34_midpoint_) {
+          auto sp_it = scoring_hit_map.find(track_id);
+          if (sp_it != scoring_hit_map.end()) {
+            second_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+            break;
+          }  // add the associated scoring plane hit (will be needed for 3D
+             // reconstruction)
+        }  // associate 3rd layer sim hits
+      }  // check if recoil hit is 3rd layer
+      else {
+        if (z > layer34_midpoint_) {
+          second_two_layers.emplace_back(point, *sim_hit,
+                                         ldmx::SimTrackerHit());
+          break;
+        }  // associate 4th layer sim hits
+      }  // check if recoil hits is 4th layer
+
+    }  // loop through simhits
+  }  // loop through recoil hits
+
+  // Reconstruct 3D sensor points on which to do fitting
+  auto first_sensor_combos = processMeasurements(first_two_layers, tg);
+  auto second_sensor_combos = processMeasurements(second_two_layers, tg);
+
+  // These histograms are being used to evaluate the performance of the hit
+  // reconstruction Since they rely on the sim hit associated to the layer, we
+  // output the histograms here instead of the DQM These can be commented out
+  // (and the declaration in reducedTracking.py removed) if they are not wanted
+  // HISTOGRAM START //
+  for (const auto& [combo_3d_point, first_layer, second_layer] :
+       first_sensor_combos) {
+    if (second_layer.has_value()) {
+      // Unpack the first and second layer measurements
+      const auto& [meas1, hit1, scoring1] = first_layer;
+      const auto& [meas2, hit2, scoring2] = *second_layer;
+
+      histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_ALL",
+                       combo_3d_point[1] - hit2.getPosition()[0]);
+      histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_ALL",
+                       combo_3d_point[2] - hit2.getPosition()[1]);
+
+      if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+        histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_same_trackID",
+                         combo_3d_point[1] - hit2.getPosition()[0]);
+        histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_same_trackID",
+                         combo_3d_point[2] - hit2.getPosition()[1]);
+      }  // if trackIDs match, save the difference
+    }  // if
+  }  // for
+
+  for (const auto& [combo_3d_point, first_layer, second_layer] :
+       second_sensor_combos) {
+    if (second_layer.has_value()) {
+      // Unpack the first and second layer measurements
+      const auto& [meas1, hit1, scoring1] = first_layer;
+      const auto& [meas2, hit2, scoring2] = *second_layer;
+
+      histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_ALL",
+                       combo_3d_point[1] - hit2.getPosition()[0]);
+      histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_ALL",
+                       combo_3d_point[2] - hit2.getPosition()[1]);
+
+      if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+        histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_same_trackID",
+                         combo_3d_point[1] - hit2.getPosition()[0]);
+        histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_same_trackID",
+                         combo_3d_point[2] - hit2.getPosition()[1]);
+      }  // if trackIDs match, save the difference
+    }  // if
+  }  // for
+  // HISTOGRAM END //
+
+  for (const auto& [first_combo_3d_point, first_layer_one, first_layer_two] :
+       first_sensor_combos) {
+    std::tuple<std::array<double, 3>, ldmx::Measurement,
+               std::optional<ldmx::Measurement>>
+        first_sensor_point;
+
+    if (first_layer_two.has_value()) {
+      first_sensor_point = {first_combo_3d_point,
+                            std::get<ldmx::Measurement>(first_layer_one),
+                            std::get<ldmx::Measurement>(*first_layer_two)};
+    }  // check whether we did reconstruction or...
+    else {
+      first_sensor_point = {first_combo_3d_point,
+                            std::get<ldmx::Measurement>(first_layer_one),
+                            std::nullopt};
+    }  //...we are taking only one layer as the measurement (axial or stereo)
+
+    for (const auto& [second_combo_3d_point, second_layer_one,
+                      second_layer_two] : second_sensor_combos) {
+      std::tuple<std::array<double, 3>, ldmx::Measurement,
+                 std::optional<ldmx::Measurement>>
+          second_sensor_point;
+      if (second_layer_two.has_value()) {
+        second_sensor_point = {second_combo_3d_point,
+                               std::get<ldmx::Measurement>(second_layer_one),
+                               std::get<ldmx::Measurement>(*second_layer_two)};
+      }  // check whether we did reconstruction or...
+      else {
+        second_sensor_point = {second_combo_3d_point,
+                               std::get<ldmx::Measurement>(second_layer_one),
+                               std::nullopt};
+      }  //...we are taking only one layer as the measurement (axial or stereo)
+
+      for (const auto& rec_hit : first_layer_ecal_rec_hits) {
+        // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom
+        // for linear fit
+        ldmx::StraightTrack seed_track =
+            SeedTracker(first_sensor_point, second_sensor_point, rec_hit);
+
+        // Seed passed RecHit distance check, add it
+        if (seed_track.getChi2() > 0.0) {
+          straight_seed_tracks.push_back(seed_track);
+        }  // if chi2 > 0
+      }  // for rec_hits
+    }  // for second recoil tracker
+  }  // for first recoil tracker
 
   n_seeds_ += straight_seed_tracks.size();
   event.add(out_seed_collection_, straight_seed_tracks);
@@ -328,156 +366,221 @@ void LinearSeedFinder::onProcessEnd() {
 
 }  // onProcessEnd
 
-std::array<double, 3> LinearSeedFinder::getPointAtZ(std::array<double, 3> target, std::array<double, 3> measurement, double z_target) {
-    double slope_x = (measurement[1] - target[0]) / (measurement[0] - target[2]);
-    double slope_y = (measurement[2] - target[1]) / (measurement[0] - target[2]);
+std::array<double, 3> LinearSeedFinder::getPointAtZ(
+    std::array<double, 3> target, std::array<double, 3> measurement,
+    double z_target) {
+  double slope_x = (measurement[1] - target[0]) / (measurement[0] - target[2]);
+  double slope_y = (measurement[2] - target[1]) / (measurement[0] - target[2]);
 
-    double intercept_x = target[0] - slope_x * target[2];
-    double intercept_y = target[1] - slope_y * target[2];
+  double intercept_x = target[0] - slope_x * target[2];
+  double intercept_y = target[1] - slope_y * target[2];
 
-    double x_target = slope_x * z_target + intercept_x;
-    double y_target = slope_y * z_target + intercept_y;
+  double x_target = slope_x * z_target + intercept_x;
+  double y_target = slope_y * z_target + intercept_y;
 
-    return {z_target, x_target, y_target};
+  return {z_target, x_target, y_target};
 }
 
-std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> LinearSeedFinder::processMeasurements(const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>& measurements, const geo::TrackersTrackingGeometry& tg) {
-    
-    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> axial_measurements;
-    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> stereo_measurements;
-    std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> points_with_measurement;
-    Acts::Vector3 dummy{0., 0., 0.};
-    
-    // Separate measurements into axial and stereo based on layerID
-    for (const auto& [measurement, sim_hit, scoring_hit] : measurements) {
-        if (measurement.getLayerID() % 2 == 0) {
-            axial_measurements.emplace_back(measurement, sim_hit, scoring_hit);
-        } else {
-            stereo_measurements.emplace_back(measurement, sim_hit, scoring_hit);
-        }
+std::vector<std::tuple<
+    std::array<double, 3>,
+    std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>,
+    std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit,
+                             ldmx::SimTrackerHit>>>>
+LinearSeedFinder::processMeasurements(
+    const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit,
+                                 ldmx::SimTrackerHit>>& measurements,
+    const geo::TrackersTrackingGeometry& tg) {
+  std::vector<
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>
+      axial_measurements;
+  std::vector<
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>
+      stereo_measurements;
+  std::vector<std::tuple<
+      std::array<double, 3>,
+      std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>,
+      std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit,
+                               ldmx::SimTrackerHit>>>>
+      points_with_measurement;
+  Acts::Vector3 dummy{0., 0., 0.};
+
+  // Separate measurements into axial and stereo based on layerID
+  for (const auto& [measurement, sim_hit, scoring_hit] : measurements) {
+    if (measurement.getLayerID() % 2 == 0) {
+      axial_measurements.emplace_back(measurement, sim_hit, scoring_hit);
+    } else {
+      stereo_measurements.emplace_back(measurement, sim_hit, scoring_hit);
     }
+  }
 
-    // If there are measurements in both axial and stereo layer:
-    // Iterate over axial and stereo measurements to compute 3D points
-    if (!axial_measurements.empty() && !stereo_measurements.empty()) {
-        for (const auto& axial : axial_measurements) {
-            const auto& [axial_meas, axial_hit, axial_sp] = axial;
+  // If there are measurements in both axial and stereo layer:
+  // Iterate over axial and stereo measurements to compute 3D points
+  if (!axial_measurements.empty() && !stereo_measurements.empty()) {
+    for (const auto& axial : axial_measurements) {
+      const auto& [axial_meas, axial_hit, axial_sp] = axial;
 
-            for (const auto& stereo : stereo_measurements) {
-                const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+      for (const auto& stereo : stereo_measurements) {
+        const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
 
-                const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
-                const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
+        const Acts::Surface* axial_surface =
+            tg.getSurface(axial_meas.getLayerID());
+        const Acts::Surface* stereo_surface =
+            tg.getSurface(stereo_meas.getLayerID());
 
-                if (!axial_surface || !stereo_surface) continue;
+        if (!axial_surface || !stereo_surface) continue;
 
-                std::vector<ldmx::SimTrackerHit> sim_hits = {axial_hit, stereo_hit};
-                Acts::Vector3 space_point = simple3DHitV2(axial_meas, *axial_surface, stereo_meas, *stereo_surface, axial_sp, sim_hits);
+        std::vector<ldmx::SimTrackerHit> sim_hits = {axial_hit, stereo_hit};
+        Acts::Vector3 space_point =
+            simple3DHitV2(axial_meas, *axial_surface, stereo_meas,
+                          *stereo_surface, axial_sp, sim_hits);
 
-                points_with_measurement.push_back({convertToLdmxStdArray(space_point), axial, stereo});
-            }
-        }
-    } else if (!axial_measurements.empty()) {
-        // if there are only axial measurements, take them to be our sensor points
-        for (const auto& axial : axial_measurements) {
-            const auto& [axial_meas, axial_hit, axial_sp] = axial;
-            const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
-            
-            Acts::Vector3 axial_meas_hit = axial_surface->localToGlobal(geometry_context(), Acts::Vector2(axial_meas.getLocalPosition()[0], 0.0), dummy);
-
-            points_with_measurement.push_back({convertToLdmxStdArray(axial_meas_hit), axial, std::nullopt});
-        }
-    } else if (!stereo_measurements.empty()) {
-        for (const auto& stereo : stereo_measurements) {
-            const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
-            const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
-            
-            Acts::Vector3 stereo_meas_hit = stereo_surface->localToGlobal(geometry_context(), Acts::Vector2(stereo_meas.getLocalPosition()[0], 0.0), dummy);
-            
-            points_with_measurement.push_back({convertToLdmxStdArray(stereo_meas_hit), stereo, std::nullopt});
-        }
+        points_with_measurement.push_back(
+            {convertToLdmxStdArray(space_point), axial, stereo});
+      }
     }
-    return points_with_measurement;
+  } else if (!axial_measurements.empty()) {
+    // if there are only axial measurements, take them to be our sensor points
+    for (const auto& axial : axial_measurements) {
+      const auto& [axial_meas, axial_hit, axial_sp] = axial;
+      const Acts::Surface* axial_surface =
+          tg.getSurface(axial_meas.getLayerID());
+
+      Acts::Vector3 axial_meas_hit = axial_surface->localToGlobal(
+          geometry_context(),
+          Acts::Vector2(axial_meas.getLocalPosition()[0], 0.0), dummy);
+
+      points_with_measurement.push_back(
+          {convertToLdmxStdArray(axial_meas_hit), axial, std::nullopt});
+    }
+  } else if (!stereo_measurements.empty()) {
+    for (const auto& stereo : stereo_measurements) {
+      const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+      const Acts::Surface* stereo_surface =
+          tg.getSurface(stereo_meas.getLayerID());
+
+      Acts::Vector3 stereo_meas_hit = stereo_surface->localToGlobal(
+          geometry_context(),
+          Acts::Vector2(stereo_meas.getLocalPosition()[0], 0.0), dummy);
+
+      points_with_measurement.push_back(
+          {convertToLdmxStdArray(stereo_meas_hit), stereo, std::nullopt});
+    }
+  }
+  return points_with_measurement;
 }
 
-//ACTS saves its arrays like (x, y, z)
-std::array<double, 3> LinearSeedFinder::convertToLdmxStdArray(const Acts::Vector3& vec) {
-    return {vec.x(), vec.y(), vec.z()};
+// ACTS saves its arrays like (x, y, z)
+std::array<double, 3> LinearSeedFinder::convertToLdmxStdArray(
+    const Acts::Vector3& vec) {
+  return {vec.x(), vec.y(), vec.z()};
 }
 
-//Helper function to calculate unit vector by taking advantage of the localToGlobal transformation
-std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> LinearSeedFinder::getSurfaceVectors(const Acts::Surface& surface) {
-    Acts::Vector3 dummy{0., 0., 0.};
-    Acts::Vector3 u = surface.localToGlobal(geometry_context(), Acts::Vector2(1, 0), dummy) - surface.center(geometry_context());
-    Acts::Vector3 v = surface.localToGlobal(geometry_context(), Acts::Vector2(0, 1), dummy) - surface.center(geometry_context());
-    Acts::Vector3 w = u.cross(v).normalized();
-    return {u.normalized(), v.normalized(), w};
+// Helper function to calculate unit vector by taking advantage of the
+// localToGlobal transformation
+std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3>
+LinearSeedFinder::getSurfaceVectors(const Acts::Surface& surface) {
+  Acts::Vector3 dummy{0., 0., 0.};
+  Acts::Vector3 u =
+      surface.localToGlobal(geometry_context(), Acts::Vector2(1, 0), dummy) -
+      surface.center(geometry_context());
+  Acts::Vector3 v =
+      surface.localToGlobal(geometry_context(), Acts::Vector2(0, 1), dummy) -
+      surface.center(geometry_context());
+  Acts::Vector3 w = u.cross(v).normalized();
+  return {u.normalized(), v.normalized(), w};
 }
 
-//  estimate the 3d position of the particle as it passes through a stereo/axial pair
-//  currently this uses the sim hits from the target and the axial sensor to calculate
-//  the angle of the particle, which is needed to project the two sensors to the same z
-//  For real data, we could use the position at the target for the tagger and the axial
-//  u position of the measured hit (we only project in x, which, in MC, is identically x)
-//  assumptions:   axial u-direction is identically global-x (tracking-global y)
-//                 sensors' w-directions are aligned with beam (global-z, tracking-global x)
-Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface,  const ldmx::SimTrackerHit& target_sp,  std::vector<ldmx::SimTrackerHit> pair_sim_hits) {
-    
-    Acts::Vector3 dummy{0., 0., 0.};
-    Acts::Vector3 hitOnTarget{target_sp.getPosition()[0], target_sp.getPosition()[1], target_sp.getPosition()[2]}; //x,y,z
-        
-    Acts::Vector3 axial_true_global{pair_sim_hits[0].getPosition()[0], pair_sim_hits[0].getPosition()[1], pair_sim_hits[0].getPosition()[2]};
-    //stereo_true_global is unused
-    Acts::Vector3 stereo_true_global{pair_sim_hits[1].getPosition()[0], pair_sim_hits[1].getPosition()[1], pair_sim_hits[1].getPosition()[2]};
-    
-    Acts::Vector3 simpart_path = axial_true_global-hitOnTarget;
-    Acts::Vector3 simpart_unit = simpart_path.normalized();
-        
-    // Get global positions for strip origins  ....  actually these are in tracking coordinates!
-    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
-    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
-    
-    //the tracking-global vector difference between stereo and axial sensor centers
-    Acts::Vector3  deltaSensors=stereo_origin-axial_origin;
-    
-    //calculate the displacement in tracking global x (need to generalize) by going from tracking x=axial to x=stereo
-    double dx_proj=(simpart_unit[0]/simpart_unit[2])*deltaSensors[0];// this looks weird because simpart_unit is in global-global and delta sensors is in tracking-global
-    
-    // Compute unit vectors for both hits
-    auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
-    auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
-    double salpha = dotProduct(axial_v, stereo_u);
-    double cosalpha = dotProduct(axial_u, stereo_u);
-        
-    // Get sensor local measured coordinates
-    // Get local position components
-    auto [axial_u_value, axial_v_value] = axial.getLocalPosition();
-    auto [stereo_u_value, stereo_v_value] = stereo.getLocalPosition();
-    
-    // Manual correction, since v should always be 0 (insensitive direction)
-    axial_v_value = 0.0;
-    stereo_v_value = 0.0;
-    
-    //use the dx_proj as the displacement in u of the axial measurement
-    //it's axial_u_value - dx_proj because u is in the -x direction
-    // this calculation is in the axial frame
-    double v_intercept_useproj=(stereo_u_value - (axial_u_value-dx_proj)*cosalpha)/salpha;
-    double u_intercept_useproj=axial_u_value-dx_proj;
-    
-    //convert to tracking global
-    Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
-    Acts::Vector3 dummy_stereo_proj = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
-    
-   //we want the reconstructed hit to be at the z of the stereo layer
-    Acts::Vector3 reconstructed_hit{dummy_stereo_proj[0], axst_global_useproj[1], axst_global_useproj[2]};
-    
-    ldmx_log(debug) << "The particle projected axst measured position is (compare with stereo sim position): " << reconstructed_hit[0] << ", " << reconstructed_hit[1] << ", " << reconstructed_hit[2] << "\n";
-        
-    return reconstructed_hit;
+//  estimate the 3d position of the particle as it passes through a stereo/axial
+//  pair currently this uses the sim hits from the target and the axial sensor
+//  to calculate the angle of the particle, which is needed to project the two
+//  sensors to the same z For real data, we could use the position at the target
+//  for the tagger and the axial u position of the measured hit (we only project
+//  in x, which, in MC, is identically x) assumptions:   axial u-direction is
+//  identically global-x (tracking-global y)
+//                 sensors' w-directions are aligned with beam (global-z,
+//                 tracking-global x)
+Acts::Vector3 LinearSeedFinder::simple3DHitV2(
+    const ldmx::Measurement& axial, const Acts::Surface& axial_surface,
+    const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface,
+    const ldmx::SimTrackerHit& target_sp,
+    std::vector<ldmx::SimTrackerHit> pair_sim_hits) {
+  Acts::Vector3 dummy{0., 0., 0.};
+  Acts::Vector3 hitOnTarget{target_sp.getPosition()[0],
+                            target_sp.getPosition()[1],
+                            target_sp.getPosition()[2]};  // x,y,z
+
+  Acts::Vector3 axial_true_global{pair_sim_hits[0].getPosition()[0],
+                                  pair_sim_hits[0].getPosition()[1],
+                                  pair_sim_hits[0].getPosition()[2]};
+  // stereo_true_global is unused
+  Acts::Vector3 stereo_true_global{pair_sim_hits[1].getPosition()[0],
+                                   pair_sim_hits[1].getPosition()[1],
+                                   pair_sim_hits[1].getPosition()[2]};
+
+  Acts::Vector3 simpart_path = axial_true_global - hitOnTarget;
+  Acts::Vector3 simpart_unit = simpart_path.normalized();
+
+  // Get global positions for strip origins  ....  actually these are in
+  // tracking coordinates!
+  Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
+  Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
+
+  // the tracking-global vector difference between stereo and axial sensor
+  // centers
+  Acts::Vector3 deltaSensors = stereo_origin - axial_origin;
+
+  // calculate the displacement in tracking global x (need to generalize) by
+  // going from tracking x=axial to x=stereo
+  double dx_proj =
+      (simpart_unit[0] / simpart_unit[2]) *
+      deltaSensors[0];  // this looks weird because simpart_unit is in
+                        // global-global and delta sensors is in tracking-global
+
+  // Compute unit vectors for both hits
+  auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
+  auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
+  double salpha = dotProduct(axial_v, stereo_u);
+  double cosalpha = dotProduct(axial_u, stereo_u);
+
+  // Get sensor local measured coordinates
+  // Get local position components
+  auto [axial_u_value, axial_v_value] = axial.getLocalPosition();
+  auto [stereo_u_value, stereo_v_value] = stereo.getLocalPosition();
+
+  // Manual correction, since v should always be 0 (insensitive direction)
+  axial_v_value = 0.0;
+  stereo_v_value = 0.0;
+
+  // use the dx_proj as the displacement in u of the axial measurement
+  // it's axial_u_value - dx_proj because u is in the -x direction
+  //  this calculation is in the axial frame
+  double v_intercept_useproj =
+      (stereo_u_value - (axial_u_value - dx_proj) * cosalpha) / salpha;
+  double u_intercept_useproj = axial_u_value - dx_proj;
+
+  // convert to tracking global
+  Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(
+      geometry_context(),
+      Acts::Vector2(u_intercept_useproj, v_intercept_useproj), dummy);
+  Acts::Vector3 dummy_stereo_proj = stereo_surface.localToGlobal(
+      geometry_context(),
+      Acts::Vector2(u_intercept_useproj, v_intercept_useproj), dummy);
+
+  // we want the reconstructed hit to be at the z of the stereo layer
+  Acts::Vector3 reconstructed_hit{dummy_stereo_proj[0], axst_global_useproj[1],
+                                  axst_global_useproj[2]};
+
+  ldmx_log(debug) << "The particle projected axst measured position is "
+                     "(compare with stereo sim position): "
+                  << reconstructed_hit[0] << ", " << reconstructed_hit[1]
+                  << ", " << reconstructed_hit[2] << "\n";
+
+  return reconstructed_hit;
 }
 
-double LinearSeedFinder::dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
-    return v1.dot(v2);
+double LinearSeedFinder::dotProduct(const Acts::Vector3& v1,
+                                    const Acts::Vector3& v2) {
+  return v1.dot(v2);
 }
 
 std::tuple<double, double, double, double, std::vector<double>>

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -462,7 +462,7 @@ Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, co
     //it's axial_u_value - dx_proj because u is in the -x direction
     // this calculation is in the axial frame
     double v_intercept_useproj=(stereo_u_value - (axial_u_value-dx_proj)*cosalpha)/salpha;
-    double u_intercept_useproj=axial_u_value;
+    double u_intercept_useproj=axial_u_value-dx_proj;
     
     //convert to tracking global
     Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);

--- a/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
+++ b/Tracking/src/Tracking/Reco/LinearSeedFinder.cxx
@@ -29,7 +29,7 @@ void LinearSeedFinder::configure(framework::config::Parameters& parameters) {
 
   // the uncertainty is sigma_x = 6 microns and sigma_y = 20./sqrt(12)
   recoil_uncertainty_ = parameters.getParameter<std::vector<double>>(
-      "recoil_uncertainty", {0.006, 5.7735});
+      "recoil_uncertainty", {0.006, 0.085});
   ecal_uncertainty_ =
       parameters.getParameter<double>("ecal_uncertainty", {3.87});
   ecal_distance_threshold_ =
@@ -43,112 +43,196 @@ void LinearSeedFinder::configure(framework::config::Parameters& parameters) {
 }
 
 void LinearSeedFinder::produce(framework::Event& event) {
-  auto start = std::chrono::high_resolution_clock::now();
-  std::vector<ldmx::StraightTrack> straight_seed_tracks;
-  n_events_++;
-  auto tg{geometry()};
-
-  const std::vector<ldmx::Measurement> recoil_hits =
-      event.getCollection<ldmx::Measurement>(input_hits_collection_,
-                                             input_pass_name_);
-  const std::vector<ldmx::EcalHit> ecal_rec_hit =
-      event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
-                                         input_pass_name_);
-
-  std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
-
-  // Find RecHits at first layer of ECal
-  for (const auto& x_ecal : ecal_rec_hit) {
-    if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
-      first_layer_ecal_rec_hits.push_back(
-          {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
-    }  // if first layer of Ecal
-  }    // for positions in ecalRecHit
-
-  // Check if we would fit empty seeds, if so: end tracking
-  if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
-      (uniqueLayersHit(recoil_hits) < 2)) {
-    n_missing_++;
+    auto start = std::chrono::high_resolution_clock::now();
+    std::vector<ldmx::StraightTrack> straight_seed_tracks;
+    n_events_++;
+    auto tg{geometry()};
+    
+    const std::vector<ldmx::Measurement> recoil_hits =
+    event.getCollection<ldmx::Measurement>(input_hits_collection_,
+                                           input_pass_name_);
+    const std::vector<ldmx::EcalHit> ecal_rec_hit =
+    event.getCollection<ldmx::EcalHit>(input_rec_hits_collection_,
+                                       input_pass_name_);
+    
+    std::vector<std::array<double, 3>> first_layer_ecal_rec_hits;
+    
+    // Find RecHits at first layer of ECal
+    for (const auto& x_ecal : ecal_rec_hit) {
+        if (x_ecal.getZPos() < ecal_first_layer_z_threshold_) {
+            first_layer_ecal_rec_hits.push_back(
+                                                {x_ecal.getZPos(), x_ecal.getXPos(), x_ecal.getYPos()});
+        }  // if first layer of Ecal
+    }    // for positions in ecalRecHit
+    
+    // Check if we would fit empty seeds, if so: end tracking
+    if ((recoil_hits.size() < 2) || (first_layer_ecal_rec_hits.empty()) ||
+        (uniqueLayersHit(recoil_hits) < 2)) {
+        n_missing_++;
+        n_seeds_ += straight_seed_tracks.size();
+        event.add(out_seed_collection_, straight_seed_tracks);
+        return;
+    }
+    
+    // Setup truth map
+    std::map<int, ldmx::SimParticle> particle_map;
+    if (event.exists("SimParticles")) {
+        particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
+        truth_matching_tool_->setup(particle_map, recoil_hits);
+    }
+    
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> first_two_layers;
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> second_two_layers;
+    
+    const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits", input_pass_name_);
+    const std::vector<ldmx::SimTrackerHit> scoring_hits = event.getCollection<ldmx::SimTrackerHit>("TargetScoringPlaneHits",input_pass_name_);
+    
+    // Index all sim hits by track ID
+    std::unordered_map<int, std::vector<const ldmx::SimTrackerHit*>> sim_hits_by_track_id;
+    for (const auto& hit : recoil_sim_hits) {
+        sim_hits_by_track_id[hit.getTrackID()].push_back(&hit);
+    } //for sim hits
+    
+    // Index scoring hits by track ID (one positive scoring plane hit per trackID)
+    std::unordered_map<int, const ldmx::SimTrackerHit*> scoring_hit_map;
+    for (const auto& sp_hit : scoring_hits) {
+        if (sp_hit.getPosition()[2] > 0)
+            scoring_hit_map[sp_hit.getTrackID()] = &sp_hit;
+    } //for sp hits
+    
+    for (const auto& point : recoil_hits) {
+        // x is in tracking coordinates, z is in ldmx coordinates
+        float x = point.getGlobalPosition()[0];
+        int track_id = point.getTrackIds()[0];
+        
+        //get the key value = track_id
+        auto sim_range_it = sim_hits_by_track_id.find(track_id);
+        if (sim_range_it == sim_hits_by_track_id.end())
+            continue;
+        
+        //access map value at track_id
+        const auto& sim_hits = sim_range_it->second;
+        
+        for (const auto* sim_hit : sim_hits) {
+            float z = sim_hit->getPosition()[2];
+            
+            if (x < layer12_midpoint_) {
+                if (z < layer12_midpoint_) {
+                    auto sp_it = scoring_hit_map.find(track_id);
+                    if (sp_it != scoring_hit_map.end()) {
+                        first_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+                        break;
+                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
+                } //associate 1st layer sim hit
+            } //check if recoil hit is 1st layer
+            else if (x < layer23_midpoint_) {
+                if (z > layer12_midpoint_ && z < layer23_midpoint_) {
+                    first_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
+                    break;
+                } //associate 2nd layer sim hit
+            } //check if recoil hit is 2nd layer
+            else if (x < layer34_midpoint_) {
+                if (z > layer23_midpoint_ && z < layer34_midpoint_) {
+                    auto sp_it = scoring_hit_map.find(track_id);
+                    if (sp_it != scoring_hit_map.end()) {
+                        second_two_layers.emplace_back(point, *sim_hit, *sp_it->second);
+                        break;
+                    } // add the associated scoring plane hit (will be needed for 3D reconstruction)
+                } //associate 3rd layer sim hits
+            } //check if recoil hit is 3rd layer
+            else {
+                if (z > layer34_midpoint_) {
+                    second_two_layers.emplace_back(point, *sim_hit, ldmx::SimTrackerHit());
+                    break;
+                } // associate 4th layer sim hits
+            } // check if recoil hits is 4th layer
+            
+        } //loop through simhits
+    } //loop through recoil hits
+    
+    //Reconstruct 3D sensor points on which to do fitting
+    auto first_sensor_combos = processMeasurements(first_two_layers, tg);
+    auto second_sensor_combos = processMeasurements(second_two_layers, tg);
+        
+    // These histograms are being used to evaluate the performance of the hit reconstruction
+    // Since they rely on the sim hit associated to the layer, we output the histograms here instead of the DQM
+    // These can be commented out (and the declaration in reducedTracking.py removed) if they are not wanted
+    // HISTOGRAM START //
+    for (const auto& [combo_3d_point, first_layer, second_layer] : first_sensor_combos) {
+        if (second_layer.has_value()) {
+            // Unpack the first and second layer measurements
+            const auto& [meas1, hit1, scoring1] = first_layer;
+            const auto& [meas2, hit2, scoring2] = *second_layer;
+            
+            histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
+            histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
+            
+            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+                histograms_.fill("sensor1_measured_x-sim_stereo_layer1_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
+                histograms_.fill("sensor1_measured_y-sim_stereo_layer1_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
+            } //if trackIDs match, save the difference
+        } //if
+    } //for
+    
+    for (const auto& [combo_3d_point, first_layer, second_layer] : second_sensor_combos) {
+        if (second_layer.has_value()) {
+            // Unpack the first and second layer measurements
+            const auto& [meas1, hit1, scoring1] = first_layer;
+            const auto& [meas2, hit2, scoring2] = *second_layer;
+            
+            histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_ALL", combo_3d_point[1] - hit2.getPosition()[0]);
+            histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_ALL", combo_3d_point[2] - hit2.getPosition()[1]);
+            
+            if (meas1.getTrackIds()[0] == meas2.getTrackIds()[0]) {
+                histograms_.fill("sensor2_measured_x-sim_stereo_layer2_x_same_trackID", combo_3d_point[1] - hit2.getPosition()[0]);
+                histograms_.fill("sensor2_measured_y-sim_stereo_layer2_y_same_trackID", combo_3d_point[2] - hit2.getPosition()[1]);
+            } //if trackIDs match, save the difference
+        } //if
+    } //for
+    // HISTOGRAM END //
+    
+    for (const auto& [first_combo_3d_point, first_layer_one, first_layer_two] : first_sensor_combos) {
+        std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> first_sensor_point;
+        
+        if (first_layer_two.has_value()) {
+            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::get<ldmx::Measurement>(*first_layer_two)};
+        } //check whether we did reconstruction or...
+        else {
+            first_sensor_point = {first_combo_3d_point, std::get<ldmx::Measurement>(first_layer_one), std::nullopt};
+        } //...we are taking only one layer as the measurement (axial or stereo)
+        
+        for (const auto& [second_combo_3d_point, second_layer_one, second_layer_two] : second_sensor_combos) {
+            std::tuple<std::array<double, 3>, ldmx::Measurement, std::optional<ldmx::Measurement>> second_sensor_point;
+            if (second_layer_two.has_value()) {
+                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::get<ldmx::Measurement>(*second_layer_two)};
+            } //check whether we did reconstruction or...
+            else {
+                second_sensor_point = {second_combo_3d_point, std::get<ldmx::Measurement>(second_layer_one), std::nullopt};
+            } //...we are taking only one layer as the measurement (axial or stereo)
+            
+            for (const auto& rec_hit : first_layer_ecal_rec_hits) {
+                // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom for linear fit
+                ldmx::StraightTrack seed_track = SeedTracker(first_sensor_point, second_sensor_point, rec_hit);
+                
+                // Seed passed RecHit distance check, add it
+                if (seed_track.getChi2() > 0.0) {
+                    straight_seed_tracks.push_back(seed_track);
+                }  // if chi2 > 0
+            }    // for rec_hits
+        }      // for second recoil tracker
+    }        // for first recoil tracker
+    
     n_seeds_ += straight_seed_tracks.size();
     event.add(out_seed_collection_, straight_seed_tracks);
-    return;
-  }
-
-  // Setup truth map
-  std::map<int, ldmx::SimParticle> particle_map;
-  if (event.exists("SimParticles")) {
-    particle_map = event.getMap<int, ldmx::SimParticle>("SimParticles");
-    truth_matching_tool_->setup(particle_map, recoil_hits);
-  }
     
-    std::vector<ldmx::Measurement> first_two_layers;
-    for (const auto& point : recoil_hits) {
-      if (point.getGlobalPosition()[0] < layer12_midpoint_)
-        first_two_layers.push_back(point);
-      else if (point.getGlobalPosition()[0] < layer23_midpoint_)
-        first_two_layers.push_back(point);
-      else
-        continue;
-    }
-
-
-    auto firstSensorCombos = processMeasurements(first_two_layers, tg);
-      for (const auto& combo : firstSensorCombos) {
-          auto [combo_3d_points, first_layer, second_layer] = combo;
-          
-          ldmx_log(debug) << "The combined 3D hit is: (" << combo_3d_points[0] << ", "
-          << combo_3d_points[1] << ", " << combo_3d_points[2] << ")\n";
-          ldmx_log(debug) << "which is made out of layer1= (" << first_layer.getGlobalPosition()[0] << ", "
-          << first_layer.getGlobalPosition()[1] << ", " << first_layer.getGlobalPosition()[2] << ")\n";
-          ldmx_log(debug) << "and is made out of layer2= (" << second_layer.getGlobalPosition()[0] << ", "
-          << second_layer.getGlobalPosition()[1] << ", " << second_layer.getGlobalPosition()[2] << ")\n";
-          
-          const std::vector<ldmx::SimTrackerHit> recoil_sim_hits = event.getCollection<ldmx::SimTrackerHit>("RecoilSimHits",
-                                                                                                            input_pass_name_);
-          
-          ldmx_log(debug) << "The first recoil layer trackID is: (" << first_layer.getTrackIds()[0] << ")\n";
-          ldmx_log(debug) << "The second recoil layer trackID is: (" << second_layer.getTrackIds()[0] << ")\n";
-
-          for (const auto& hit : recoil_sim_hits) {
-              ldmx_log(debug) << "The hit trackID is: (" << hit.getTrackID() << ")\n";
-              if (hit.getTrackID() == first_layer.getTrackIds()[0]) {
-                  ldmx_log(debug) << "The global position of the SimParticle with matching trackID to the measurement is: (" << hit.getPosition()[0] << ", " << hit.getPosition()[1] << ", " << hit.getPosition()[2] << ")\n";
-              }
-          }
-          
-      }
-
-// weighted averaging: layer1+layer2 = sensor1, layer3+layer4 = sensor2
-  // this gives all possible combinations of two tracker points for fitting
-  auto [first_sensor, second_sensor] = combineMultiGlobalHits(recoil_hits);
-
-  for (const auto& first_point : first_sensor) {
-    for (const auto& second_point : second_sensor) {
-      for (const auto& rec_hit : first_layer_ecal_rec_hits) {
-        // Do fitting on 2 sensor + 1 recHit combinations = 1 degree of freedom
-        // for linear fit
-        ldmx::StraightTrack seed_track =
-            SeedTracker(first_point, second_point, rec_hit);
-
-        // Seed passed RecHit distance check
-        if (seed_track.getChi2() > 0.0) {
-          straight_seed_tracks.push_back(seed_track);
-        }  // if chi2 > 0
-      }    // for rec_hits
-    }      // for second recoil tracker
-  }        // for first recoil tracker
-
-  n_seeds_ += straight_seed_tracks.size();
-  event.add(out_seed_collection_, straight_seed_tracks);
-
-  auto end = std::chrono::high_resolution_clock::now();
-
-  auto diff = end - start;
-  processing_time_ += std::chrono::duration<double, std::milli>(diff).count();
-
-  first_layer_ecal_rec_hits.clear();
-  straight_seed_tracks.clear();
-
+    auto end = std::chrono::high_resolution_clock::now();
+    
+    auto diff = end - start;
+    processing_time_ += std::chrono::duration<double, std::milli>(diff).count();
+    
+    first_layer_ecal_rec_hits.clear();
+    straight_seed_tracks.clear();
+    
 }  // produce
 
 ldmx::StraightTrack LinearSeedFinder::SeedTracker(
@@ -244,114 +328,79 @@ void LinearSeedFinder::onProcessEnd() {
 
 }  // onProcessEnd
 
-std::pair<std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                 std::optional<ldmx::Measurement>>>,
-          std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                                 std::optional<ldmx::Measurement>>>>
-LinearSeedFinder::combineMultiGlobalHits(
-    const std::vector<ldmx::Measurement>& hit_collection) {
-  std::vector<ldmx::Measurement> layer1, layer2, layer3, layer4;
+std::array<double, 3> LinearSeedFinder::getPointAtZ(std::array<double, 3> target, std::array<double, 3> measurement, double z_target) {
+    double slope_x = (measurement[1] - target[0]) / (measurement[0] - target[2]);
+    double slope_y = (measurement[2] - target[1]) / (measurement[0] - target[2]);
 
-  // Split hits into layers based on z position
-  // TODO: can we access layer information directly from ldmx::Measurement??
-  for (const auto& point : hit_collection) {
-    if (point.getGlobalPosition()[0] < layer12_midpoint_)
-      layer1.push_back(point);
-    else if (point.getGlobalPosition()[0] < layer23_midpoint_)
-      layer2.push_back(point);
-    else if (point.getGlobalPosition()[0] < layer34_midpoint_)
-      layer3.push_back(point);
-    else
-      layer4.push_back(point);
-  }
+    double intercept_x = target[0] - slope_x * target[2];
+    double intercept_y = target[1] - slope_y * target[2];
 
-  std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                         std::optional<ldmx::Measurement>>>
-      first_sensor_merged_hits, second_sensor_merged_hits;
+    double x_target = slope_x * z_target + intercept_x;
+    double y_target = slope_y * z_target + intercept_y;
 
-  if (layer1.empty()) {
-    for (const auto& point : layer2) {
-      first_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer2
-  }    // if layer1 empty
-  else if (layer2.empty()) {
-    for (const auto& point : layer1) {
-      first_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer1
-  }    // if layer2 empty
-  else {
-    first_sensor_merged_hits = midPointCalculation(layer1, layer2);
-  }  // do weighted average of two layers
+    return {z_target, x_target, y_target};
+}
 
-  if (layer3.empty()) {
-    for (const auto& point : layer4) {
-      second_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
-    }  // only look at layer4
-  }    // if layer3 empty
-  else if (layer4.empty()) {
-    for (const auto& point : layer3) {
-      second_sensor_merged_hits.push_back(
-          std::make_tuple(std::array<double, 3>{point.getGlobalPosition()[0],
-                                                point.getGlobalPosition()[1],
-                                                point.getGlobalPosition()[2]},
-                          point, std::nullopt));
+std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> LinearSeedFinder::processMeasurements(const std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>& measurements, const geo::TrackersTrackingGeometry& tg) {
+    
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> axial_measurements;
+    std::vector<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>> stereo_measurements;
+    std::vector<std::tuple<std::array<double, 3>, std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>, std::optional<std::tuple<ldmx::Measurement, ldmx::SimTrackerHit, ldmx::SimTrackerHit>>>> points_with_measurement;
+    Acts::Vector3 dummy{0., 0., 0.};
+    
+    // Separate measurements into axial and stereo based on layerID
+    for (const auto& [measurement, sim_hit, scoring_hit] : measurements) {
+        if (measurement.getLayerID() % 2 == 0) {
+            axial_measurements.emplace_back(measurement, sim_hit, scoring_hit);
+        } else {
+            stereo_measurements.emplace_back(measurement, sim_hit, scoring_hit);
+        }
     }
-  }  // if layer4 empty
-  // do weighted average of two layers
-  else {
-    second_sensor_merged_hits = midPointCalculation(layer3, layer4);
-  }
 
-  return {first_sensor_merged_hits, second_sensor_merged_hits};
-}  // combineMultiGlobalHits
+    // If there are measurements in both axial and stereo layer:
+    // Iterate over axial and stereo measurements to compute 3D points
+    if (!axial_measurements.empty() && !stereo_measurements.empty()) {
+        for (const auto& axial : axial_measurements) {
+            const auto& [axial_meas, axial_hit, axial_sp] = axial;
 
-std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> LinearSeedFinder::processMeasurements(const std::vector<ldmx::Measurement>& measurements, const geo::TrackersTrackingGeometry& tg) {
-    
-    std::vector<ldmx::Measurement> axialMeasurements;
-    std::vector<ldmx::Measurement> stereoMeasurements;
-    std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement, ldmx::Measurement>> points_with_measurement;
-    
-    for (const auto& meas : measurements) {
-        if (meas.getLayerID() % 2 == 0) {
-            axialMeasurements.push_back(meas);
-        } // even layers are axial, from looking at Measurement.h
-        else {
-            stereoMeasurements.push_back(meas);
-        } // odd layers are stereo, from looking at Meaasurement.h
-    } // for measurements
-    
-    for (const auto& axial : axialMeasurements) {
-        for (const auto& stereo : stereoMeasurements) {
+            for (const auto& stereo : stereo_measurements) {
+                const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+
+                const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
+                const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
+
+                if (!axial_surface || !stereo_surface) continue;
+
+                std::vector<ldmx::SimTrackerHit> sim_hits = {axial_hit, stereo_hit};
+                Acts::Vector3 space_point = simple3DHitV2(axial_meas, *axial_surface, stereo_meas, *stereo_surface, axial_sp, sim_hits);
+
+                points_with_measurement.push_back({convertToLdmxStdArray(space_point), axial, stereo});
+            }
+        }
+    } else if (!axial_measurements.empty()) {
+        // if there are only axial measurements, take them to be our sensor points
+        for (const auto& axial : axial_measurements) {
+            const auto& [axial_meas, axial_hit, axial_sp] = axial;
+            const Acts::Surface* axial_surface = tg.getSurface(axial_meas.getLayerID());
             
-            // Get surfaces from ACTS
-            const Acts::Surface* axial_surface = tg.getSurface(axial.getLayerID());
-            const Acts::Surface* stereo_surface = tg.getSurface(stereo.getLayerID());
+            Acts::Vector3 axial_meas_hit = axial_surface->localToGlobal(geometry_context(), Acts::Vector2(axial_meas.getLocalPosition()[0], 0.0), dummy);
+
+            points_with_measurement.push_back({convertToLdmxStdArray(axial_meas_hit), axial, std::nullopt});
+        }
+    } else if (!stereo_measurements.empty()) {
+        for (const auto& stereo : stereo_measurements) {
+            const auto& [stereo_meas, stereo_hit, stereo_sp] = stereo;
+            const Acts::Surface* stereo_surface = tg.getSurface(stereo_meas.getLayerID());
             
-            if (!axial_surface || !stereo_surface) continue;  // Skip invalid surfaces
+            Acts::Vector3 stereo_meas_hit = stereo_surface->localToGlobal(geometry_context(), Acts::Vector2(stereo_meas.getLocalPosition()[0], 0.0), dummy);
             
-            // Compute 3D space point
-            Acts::Vector3 spacePoint = compute3DHit(axial, *axial_surface, stereo, *stereo_surface);
-            
-            points_with_measurement.push_back({convertToLdmxStdArray(spacePoint), axial, stereo});
-        } // for stereo
-    } // for axial
-    
+            points_with_measurement.push_back({convertToLdmxStdArray(stereo_meas_hit), stereo, std::nullopt});
+        }
+    }
     return points_with_measurement;
 }
 
-//I think ACTS saves its arrays like (x, y, z)
+//ACTS saves its arrays like (x, y, z)
 std::array<double, 3> LinearSeedFinder::convertToLdmxStdArray(const Acts::Vector3& vec) {
     return {vec.x(), vec.y(), vec.z()};
 }
@@ -365,30 +414,41 @@ std::tuple<Acts::Vector3, Acts::Vector3, Acts::Vector3> LinearSeedFinder::getSur
     return {u.normalized(), v.normalized(), w};
 }
 
-Acts::Vector3 LinearSeedFinder::compute3DHit(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface) {
+//  estimate the 3d position of the particle as it passes through a stereo/axial pair
+//  currently this uses the sim hits from the target and the axial sensor to calculate
+//  the angle of the particle, which is needed to project the two sensors to the same z
+//  For real data, we could use the position at the target for the tagger and the axial
+//  u position of the measured hit (we only project in x, which, in MC, is identically x)
+//  assumptions:   axial u-direction is identically global-x (tracking-global y)
+//                 sensors' w-directions are aligned with beam (global-z, tracking-global x)
+Acts::Vector3 LinearSeedFinder::simple3DHitV2(const ldmx::Measurement& axial, const Acts::Surface& axial_surface, const ldmx::Measurement& stereo, const Acts::Surface& stereo_surface,  const ldmx::SimTrackerHit& target_sp,  std::vector<ldmx::SimTrackerHit> pair_sim_hits) {
+    
+    Acts::Vector3 dummy{0., 0., 0.};
+    Acts::Vector3 hitOnTarget{target_sp.getPosition()[0], target_sp.getPosition()[1], target_sp.getPosition()[2]}; //x,y,z
+        
+    Acts::Vector3 axial_true_global{pair_sim_hits[0].getPosition()[0], pair_sim_hits[0].getPosition()[1], pair_sim_hits[0].getPosition()[2]};
+    //stereo_true_global is unused
+    Acts::Vector3 stereo_true_global{pair_sim_hits[1].getPosition()[0], pair_sim_hits[1].getPosition()[1], pair_sim_hits[1].getPosition()[2]};
+    
+    Acts::Vector3 simpart_path = axial_true_global-hitOnTarget;
+    Acts::Vector3 simpart_unit = simpart_path.normalized();
+        
+    // Get global positions for strip origins  ....  actually these are in tracking coordinates!
+    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
+    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
+    
+    //the tracking-global vector difference between stereo and axial sensor centers
+    Acts::Vector3  deltaSensors=stereo_origin-axial_origin;
+    
+    //calculate the displacement in tracking global x (need to generalize) by going from tracking x=axial to x=stereo
+    double dx_proj=(simpart_unit[0]/simpart_unit[2])*deltaSensors[0];// this looks weird because simpart_unit is in global-global and delta sensors is in tracking-global
     
     // Compute unit vectors for both hits
     auto [axial_u, axial_v, axial_w] = getSurfaceVectors(axial_surface);
     auto [stereo_u, stereo_v, stereo_w] = getSurfaceVectors(stereo_surface);
-
-    ldmx_log(debug) << "############################################################" << "\n";
-    ldmx_log(debug) << "The axial unit vectors are: " << "\n";
-    ldmx_log(debug) << "u: " << axial_u[0] << ", " << axial_u[1] << ", " << axial_u[2] << "\n";
-    ldmx_log(debug) << "v: " << axial_v[0] << ", " << axial_v[1] << ", " << axial_v[2] << "\n";
-    ldmx_log(debug) << "w: " << axial_w[0] << ", " << axial_w[1] << ", " << axial_w[2] << "\n";
-
-    ldmx_log(debug) << "The stereo unit vectors are: " << "\n";
-    ldmx_log(debug) << "u: " << stereo_u[0] << ", " << stereo_u[1] << ", " << stereo_u[2] << "\n";
-    ldmx_log(debug) << "v: " << stereo_v[0] << ", " << stereo_v[1] << ", " << stereo_v[2] << "\n";
-    ldmx_log(debug) << "w: " << stereo_w[0] << ", " << stereo_w[1] << ", " << stereo_w[2] << "\n";
-
-    // Get global positions for strip origins
-    Acts::Vector3 axial_origin = axial_surface.center(geometry_context());
-    Acts::Vector3 stereo_origin = stereo_surface.center(geometry_context());
-    
-    ldmx_log(debug) << "The axial global origins are: " << axial_origin[0] << ", " << axial_origin[1] << ", " << axial_origin[2] << "\n";
-    ldmx_log(debug) << "The stereo global origins are: " << stereo_origin[0] << ", " << stereo_origin[1] << ", " << stereo_origin[2] << "\n";
-    
+    double salpha = dotProduct(axial_v, stereo_u);
+        
+    // Get sensor local measured coordinates
     // Get local position components
     auto [axial_u_value, axial_v_value] = axial.getLocalPosition();
     auto [stereo_u_value, stereo_v_value] = stereo.getLocalPosition();
@@ -397,95 +457,26 @@ Acts::Vector3 LinearSeedFinder::compute3DHit(const ldmx::Measurement& axial, con
     axial_v_value = 0.0;
     stereo_v_value = 0.0;
     
-    ldmx_log(debug) << "The axial local positions are: " << axial_u_value << ", " << axial_v_value << "\n";
-    ldmx_log(debug) << "The stereo local positions are: " << stereo_u_value << ", " << stereo_v_value << "\n";
+    //use the dx_proj as the displacement in u of the axial measurement
+    //it's axial_u_value - dx_proj because u is in the -x direction
+    // this calculation is in the axial frame
+    double v_intercept_useproj=-((axial_u_value-dx_proj)-stereo_u_value)/salpha;
+    double u_intercept_useproj=axial_u_value-dx_proj;
     
-    Acts::Vector3 dummy{0., 0., 0.};
-    Acts::Vector3 axial_global = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(axial_u_value, axial_v_value), dummy);
-    Acts::Vector3 stereo_global = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(stereo_u_value, stereo_v_value), dummy);
+    //convert to tracking global
+    Acts::Vector3 axst_global_useproj = axial_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
+    Acts::Vector3 dummy_stereo_proj = stereo_surface.localToGlobal(geometry_context(), Acts::Vector2(u_intercept_useproj,v_intercept_useproj), dummy);
     
-    ldmx_log(debug) << "The axial localToGlobal (i.e. global position) are: " << axial_global[0] << ", " << axial_global[1] << ", " << axial_global[2] << "\n";
-    ldmx_log(debug) << "The stereo localToGlobal (i.e. global position) are: " << stereo_global[0] << ", " << stereo_global[1] << ", " << stereo_global[2] << "\n";
-    
-    // From here we follow the logic of the HPS code
-    double gamma = dotProduct(stereo_origin, stereo_w) / nonZeroDotProduct(axial_origin, axial_w);
-    ldmx_log(debug) << "The value of gamma is: " << gamma << "\n";
-    
-    //This should be equivalent to the sin of the stereo angle, according to HPS
-    double salpha = dotProduct(axial_v, stereo_u);
-    ldmx_log(debug) << "The value of salpha is: " << salpha << "\n";
-
-    Acts::Vector3 p1 = stripCenter(axial_origin, axial_u_value, axial_u); //axial_u = axial unit vector in u
-    ldmx_log(debug) << "The p1 vector is: [" << p1[0] << ", " << p1[1] << ", " << p1[2] << "] \n";
-
-    Acts::Vector3 p2 = stripCenter(stereo_origin, stereo_u_value, stereo_u); //stereo_u = stereo unit vector in u
-    ldmx_log(debug) << "The p2 vector is: [" << p2[0] << ", " << p2[1] << ", " << p2[2] << "] \n";
-
-    Acts::Vector3 dp = p2 - p1;
-    ldmx_log(debug) << "The dp vector is: [" << dp[0] << ", " << dp[1] << ", " << dp[2] << "] \n";
-
-    double v1 = dotProduct(dp, stereo_u) / (gamma*salpha);
-    ldmx_log(debug) << "The value of v1 is: " << v1 << "\n";
-
-    if (v1 < -50.0) { v1 = -50.0; }
-    else if (v1 > 50.0) { v1 = 50.0; }
-    
-    Acts::Vector3 r1 = p1 + v1 * axial_v; //axial_v = axial unit vector in v
-    ldmx_log(debug) << "The r1 vector is: [" << r1[0] << ", " << r1[1] << ", " << r1[2] << "] \n";
-    
-    Acts::Vector3 final_position = (0.5 * (1 + gamma)) * r1;
-    ldmx_log(debug) << "The final position is: [" << final_position[0] << ", " << final_position[1] << ", " << final_position[2] << "] \n";
-    ldmx_log(debug) << "########################## end ##################################" << "\n";
-
-    return final_position;
+    //we want the reconstructed hit to be at the z of the stereo layer
+    Acts::Vector3 reconstructed_hit{dummy_stereo_proj[0], axst_global_useproj[1], axst_global_useproj[2]};
+    ldmx_log(debug) << "The particle projected axst measured position is (compare with stereo sim position): " << reconstructed_hit[0] << ", " << reconstructed_hit[1] << ", " << reconstructed_hit[2] << "\n";
+        
+    return reconstructed_hit;
 }
 
 double LinearSeedFinder::dotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
     return v1.dot(v2);
 }
-
-Acts::Vector3 LinearSeedFinder::stripCenter(const Acts::Vector3& strip_origin, double u, const Acts::Vector3& strip_uhat) {
-    return strip_origin + u * strip_uhat;
-}
-
-double LinearSeedFinder::nonZeroDotProduct(const Acts::Vector3& v1, const Acts::Vector3& v2) {
-    double cth = v1.dot(v2);
-    double eps = 1e-6;
-    if (std::abs(cth) < eps) {
-        cth = (cth < 0.0) ? -eps : eps;
-    }
-    return cth;
-}
-
-
-std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                       std::optional<ldmx::Measurement>>>
-LinearSeedFinder::midPointCalculation(
-    const std::vector<ldmx::Measurement>& layer1,
-    const std::vector<ldmx::Measurement>& layer2) {
-  std::vector<std::tuple<std::array<double, 3>, ldmx::Measurement,
-                         std::optional<ldmx::Measurement>>>
-      merged_hits;
-
-  for (const auto& point1 : layer1) {
-    for (const auto& point2 : layer2) {
-      double z_avg =
-          (point1.getGlobalPosition()[0] + point2.getGlobalPosition()[0]) /
-          (2.0);
-      double x_avg =
-          (point1.getGlobalPosition()[1] + point2.getGlobalPosition()[1]) /
-          (2.0);
-      // Until we make axial/stereo combinations, we don't know anything about
-      // the y value
-      double y_avg = 0.0;
-
-      merged_hits.push_back(std::make_tuple(
-          std::array<double, 3>{z_avg, x_avg, y_avg}, point1, point2));
-
-    }  // for layer2
-  }    // for layer1
-  return merged_hits;
-}  // midPointCalculation
 
 std::tuple<double, double, double, double, std::vector<double>>
 LinearSeedFinder::fit3DLine(const std::array<double, 3>& first_recoil,


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1672 by adding a method to LinearSeedFinder.cxx that reconstructs 3D hits from all combinations of an axial and a stereo measurement. It also updates the uncertainties associated with the x and y coordinates of the reconstructed hit. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
Performance plots are shown in #1672.
