### PR TITLE
use denv to run dark-brem-lib-gen

### DIFF
--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -11,10 +11,10 @@ start_group Produce Dark Brem Library
 curl -s https://tomeichlersmith.github.io/denv/install | sh
 # use docker so we don't have to tell podman to look at the docker.io registry
 export DENV_RUNNER=docker
-denv init ldmx/dark-brem-lib-gen:v5.1
+denv init ldmx/dark-brem-lib-gen:v5.1.0
 denv dark-brem-lib-gen \
   --run 1 \
-  --max_energy 8.0 \
+  --max-energy 8.0 \
   --apmass 0.01
 # cleanup denv
 rm -r .denv

--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -8,6 +8,7 @@
 ###############################################################################
 
 start_group Produce Dark Brem Library
+curl -s https://tomeichlersmith.github.io/denv/install | sh
 denv init ldmx/dark-brem-lib-gen:v5.1
 denv dark-brem-lib-gen \
   --run 1 \

--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -8,17 +8,11 @@
 ###############################################################################
 
 start_group Produce Dark Brem Library
-wget https://raw.githubusercontent.com/LDMX-Software/dark-brem-lib-gen/main/env.sh
-source env.sh
-# commented out lines are dbgen's defaults for reference
-dbgen use v5.0
-#dbgen cache ${HOME} <- only matters for apptainer/singularity
-#dbgen work /tmp
-#dbgen dest $PWD
-mkdir scratch
-dbgen work scratch
-dbgen run \
+denv init ldmx/dark-brem-lib-gen:v5.1
+denv dark-brem-lib-gen \
   --run 1 \
   --max_energy 8.0 \
   --apmass 0.01
+# cleanup denv
+rm -r .denv
 end_group

--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -9,6 +9,8 @@
 
 start_group Produce Dark Brem Library
 curl -s https://tomeichlersmith.github.io/denv/install | sh
+# use docker so we don't have to tell podman to look at the docker.io registry
+export DENV_RUNNER=docker
 denv init ldmx/dark-brem-lib-gen:v5.1
 denv dark-brem-lib-gen \
   --run 1 \


### PR DESCRIPTION
Following up from https://github.com/LDMX-Software/dark-brem-lib-gen/pull/24

### What are the issues that this addresses?
No issues, just pre-emptively avoiding an issue from arising.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [ ] I ran my developments and the following shows that they are successful. If the signal CI runs properly, we're all good.
