### PR TITLE
Fix typo in passname in CKF processor

### DIFF
--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -192,8 +192,6 @@ class CKFProcessor(Producer):
         self.out_trk_collection = 'Tracks'
         self.min_hits = 6
         self.outlier_pval_ = 3.84
-        
-        self.simParticles_passName = ''
         self.sim_particles_event_passname = ''
         self.input_pass_name = ''
         

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -215,7 +215,7 @@ void CKFProcessor::produce(framework::Event& event) {
   if (event.exists("SimParticles", sim_particles_event_passname_)) {
     ldmx_log(debug) << "Setting up track truth matching tool";
     particleMap = event.getMap<int, ldmx::SimParticle>("SimParticles",
-                                                       simParticles_passName_);
+                                                       sim_particles_event_passname_);
     truthMatchingTool = std::make_shared<tracking::sim::TruthMatchingTool>(
         particleMap, measurements);
   }
@@ -721,8 +721,6 @@ void CKFProcessor::configure(framework::config::Parameters& parameters) {
   seed_coll_name_ =
       parameters.getParameter<std::string>("seed_coll_name", "seedTracks");
 
-  simParticles_passName_ =
-      parameters.getParameter<std::string>("simParticles_passName");
   sim_particles_event_passname_ =
       parameters.getParameter<std::string>("sim_particles_event_passname");
 

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -214,8 +214,8 @@ void CKFProcessor::produce(framework::Event& event) {
 
   if (event.exists("SimParticles", sim_particles_event_passname_)) {
     ldmx_log(debug) << "Setting up track truth matching tool";
-    particleMap = event.getMap<int, ldmx::SimParticle>("SimParticles",
-                                                       sim_particles_event_passname_);
+    particleMap = event.getMap<int, ldmx::SimParticle>(
+        "SimParticles", sim_particles_event_passname_);
     truthMatchingTool = std::make_shared<tracking::sim::TruthMatchingTool>(
         particleMap, measurements);
   }


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
It's small so I didnt make an issue: the `if` was for `sim_particles_event_passname_` while the `get` was for `simParticles_passName_`

Otherwise belonged to the issue https://github.com/LDMX-Software/ldmx-sw/issues/1645

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
