### PR TITLE
Allow NTupling of both data and simulated HCalDigis

### DIFF
--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -80,7 +80,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
 
   const ldmx::EventHeader* header =
       const_cast<framework::Event&>(event).getEventHeaderPtr();
-  bool is_simulation_ = not (header->isRealData());
+  bool is_simulation_ = not(header->isRealData());
 
   if (not is_simulation_) {
     if (already_aligned_) {
@@ -104,10 +104,10 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
   std::vector<bool> good_trailer;
 
   if (not is_simulation_) {
-    good_bxheader = event.getCollection<bool>(
-        input_name_ + "GoodLinkHeader", input_pass_);
-    good_trailer = event.getCollection<bool>(
-        input_name_ + "GoodLinkTrailer", input_pass_);
+    good_bxheader =
+        event.getCollection<bool>(input_name_ + "GoodLinkHeader", input_pass_);
+    good_trailer =
+        event.getCollection<bool>(input_name_ + "GoodLinkTrailer", input_pass_);
   }
 
   auto const& digis{

--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -80,7 +80,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
 
   const ldmx::EventHeader* header =
       const_cast<framework::Event&>(event).getEventHeaderPtr();
-  bool is_simulation_ = !(header->isRealData());
+  bool is_simulation_ = not (header->isRealData());
 
   if (not is_simulation_) {
     if (already_aligned_) {
@@ -104,9 +104,9 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
   std::vector<bool> good_trailer;
 
   if (not is_simulation_) {
-    good_bxheader = const_cast<framework::Event&>(event).getCollection<bool>(
+    good_bxheader = event.getCollection<bool>(
         input_name_ + "GoodLinkHeader", input_pass_);
-    good_trailer = const_cast<framework::Event&>(event).getCollection<bool>(
+    good_trailer = event.getCollection<bool>(
         input_name_ + "GoodLinkTrailer", input_pass_);
   }
 

--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -78,9 +78,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
 
   ldmxsw_event_ = event.getEventNumber();
 
-  const ldmx::EventHeader* header =
-      const_cast<framework::Event&>(event).getEventHeaderPtr();
-  bool is_simulation = not(header->isRealData());
+  bool is_simulation = not event.getEventHeader().isRealData();
 
   if (not is_simulation) {
     if (already_aligned_) {

--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -77,23 +77,42 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
       hcal::HcalDetectorMap::CONDITIONS_OBJECT_NAME)};
 
   ldmxsw_event_ = event.getEventNumber();
-  if (already_aligned_) {
-    aligned_ = event.getObject<bool>(input_name_ + "Aligned", input_pass_);
+
+  const ldmx::EventHeader* header =
+      const_cast<framework::Event&>(event).getEventHeaderPtr();
+  bool is_simulation_ = !(header->isRealData());
+
+  if (not is_simulation_) {
+    if (already_aligned_) {
+      aligned_ = event.getObject<bool>(input_name_ + "Aligned", input_pass_);
+    } else {
+      aligned_ = false;
+      version_ = event.getObject<int>(input_name_ + "Version", input_pass_);
+      pf_event_ = event.getObject<int>(input_name_ + "Number", input_pass_);
+      pf_ticks_ = event.getObject<int>(input_name_ + "Ticks", input_pass_);
+      pf_spill_ = event.getObject<int>(input_name_ + "Spill", input_pass_);
+    }
   } else {
-    aligned_ = false;
-    version_ = event.getObject<int>(input_name_ + "Version", input_pass_);
-    pf_event_ = event.getObject<int>(input_name_ + "Number", input_pass_);
-    pf_ticks_ = event.getObject<int>(input_name_ + "Ticks", input_pass_);
-    pf_spill_ = event.getObject<int>(input_name_ + "Spill", input_pass_);
+    aligned_ = true;
+    version_ = 0;
+    pf_event_ = ldmxsw_event_;
+    pf_ticks_ = 0;
+    pf_spill_ = 0;
   }
 
-  const auto& good_bxheader{
-      event.getCollection<bool>(input_name_ + "GoodLinkHeader", input_pass_)};
-  const auto& good_trailer{
-      event.getCollection<bool>(input_name_ + "GoodLinkTrailer", input_pass_)};
+  std::vector<bool> good_bxheader;
+  std::vector<bool> good_trailer;
+
+  if (not is_simulation_) {
+    good_bxheader = const_cast<framework::Event&>(event).getCollection<bool>(
+        input_name_ + "GoodLinkHeader", input_pass_);
+    good_trailer = const_cast<framework::Event&>(event).getCollection<bool>(
+        input_name_ + "GoodLinkTrailer", input_pass_);
+  }
 
   auto const& digis{
       event.getObject<ldmx::HgcrocDigiCollection>(input_name_, input_pass_)};
+
   for (std::size_t i_digi{0}; i_digi < digis.size(); i_digi++) {
     auto d{digis.getDigi(i_digi)};
     raw_id_ = static_cast<int>(d.id());
@@ -101,14 +120,22 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
       ldmx::HcalElectronicsID eid(d.id());
       fpga_ = eid.fiber();
       link_ = eid.elink();
-      good_link_ = (good_bxheader.at(link_) and good_trailer.at(link_));
+      if (!is_simulation_) {
+        good_link_ = (good_bxheader.at(link_) and good_trailer.at(link_));
+      } else {
+        good_link_ = true;
+      }
       channel_ = eid.channel();
       index_ = eid.index();
     } else {
       ldmx::HcalDigiID detid(d.id());
       ldmx::HcalElectronicsID eid = detmap.get(detid);
       int link = eid.elink();
-      good_link_ = (good_bxheader.at(link) and good_trailer.at(link));
+      if (!is_simulation_) {
+        good_link_ = (good_bxheader.at(link) and good_trailer.at(link));
+      } else {
+        good_link_ = true;
+      }
       section_ = detid.section();
       layer_ = detid.layer();
       strip_ = detid.strip();

--- a/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
+++ b/DQM/src/DQM/NtuplizeHgcrocDigiCollection.cxx
@@ -80,9 +80,9 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
 
   const ldmx::EventHeader* header =
       const_cast<framework::Event&>(event).getEventHeaderPtr();
-  bool is_simulation_ = not(header->isRealData());
+  bool is_simulation = not(header->isRealData());
 
-  if (not is_simulation_) {
+  if (not is_simulation) {
     if (already_aligned_) {
       aligned_ = event.getObject<bool>(input_name_ + "Aligned", input_pass_);
     } else {
@@ -103,7 +103,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
   std::vector<bool> good_bxheader;
   std::vector<bool> good_trailer;
 
-  if (not is_simulation_) {
+  if (not is_simulation) {
     good_bxheader =
         event.getCollection<bool>(input_name_ + "GoodLinkHeader", input_pass_);
     good_trailer =
@@ -120,7 +120,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
       ldmx::HcalElectronicsID eid(d.id());
       fpga_ = eid.fiber();
       link_ = eid.elink();
-      if (!is_simulation_) {
+      if (!is_simulation) {
         good_link_ = (good_bxheader.at(link_) and good_trailer.at(link_));
       } else {
         good_link_ = true;
@@ -131,7 +131,7 @@ void NtuplizeHgcrocDigiCollection::analyze(const framework::Event& event) {
       ldmx::HcalDigiID detid(d.id());
       ldmx::HcalElectronicsID eid = detmap.get(detid);
       int link = eid.elink();
-      if (!is_simulation_) {
+      if (!is_simulation) {
         good_link_ = (good_bxheader.at(link) and good_trailer.at(link));
       } else {
         good_link_ = true;

--- a/Framework/include/Framework/Event.h
+++ b/Framework/include/Framework/Event.h
@@ -59,7 +59,17 @@ class Event {
   ldmx::EventHeader &getEventHeader() { return eventHeader_; }
 
   /**
+   * Get the event header.
+   * @return A constant reference to the event header.
+   */
+  const ldmx::EventHeader &getEventHeader() const { return eventHeader_; }
+
+  /**
    * Get the event header as a pointer
+   *
+   * @note This is only helpful for the internal workings of the framework
+   * and should not be used by processors. Use getEventHeader instead.
+   *
    * @return A const pointer to the event header.
    */
   const ldmx::EventHeader *getEventHeaderPtr() { return &eventHeader_; }


### PR DESCRIPTION
Spill number/timing information and data quality measures are not produced by the simulation, and are only present in data from the 2022 test beam. With these changes, NtuplizeHgcrocDigiCollection checks whether we are dealing with a simulation, and then fakes some timing information and says that the link quality is perfect. 

Now, the correct solution would be to actually simulate the spill structure in MC, and store the data quality measures good_bxheader and good_trailer in a proper class. But, since this is so specific to the 2022 test beam, let's not complicate thing upstream in the simulation.  

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.

Now you can make NTuples out of simulated digis: 
![image](https://github.com/user-attachments/assets/697f871e-37e9-4441-a06c-0eb0332d65e1)
