### PR TITLE
make sample directory when copying new gold

### DIFF
--- a/.github/workflows/generate_pr_gold.yml
+++ b/.github/workflows/generate_pr_gold.yml
@@ -107,6 +107,7 @@ jobs:
           sample=$(basename ${sample_d})
           sample=${sample%%-new-gold}
           echo ${sample}
+          mkdir -p ci-data/${sample}
           mv ${sample_d}/hist.root ci-data/${sample}/gold.root
           mv ${sample_d}/output.log ci-data/${sample}/gold.log
         done


### PR DESCRIPTION
This allows for adding new CI samples by making sure that the destination directory exists before attempting to move the files.