### PR TITLE
move test_table.csv to ci-data, use LDMX-Software/conditions-data

### DIFF
--- a/Conditions/test/TestConditions.cxx
+++ b/Conditions/test/TestConditions.cxx
@@ -265,7 +265,8 @@ TEST_CASE("Conditions", "[Conditions]") {
         "columns=[\"A\",\"Q\",\"V\"]\n"
         "cop=SimpleCSVTableProvider.SimpleCSVIntegerTableProvider(\"test_table_"
         "http\",columns)\n"
-        "cop.validForever(\"https://raw.githubusercontent.com/LDMX-Software/ci-data/refs/heads/main/conditions-test/test_table.csv\")\n";
+        "cop.validForever(\"https://raw.githubusercontent.com/LDMX-Software/"
+        "ci-data/refs/heads/main/conditions-test/test_table.csv\")\n";
 
     FILE* f = fopen("/tmp/test_cond.py", "w");
     fputs(cfgpy, f);
@@ -292,8 +293,10 @@ TEST_CASE("Conditions", "[Conditions]") {
         "columns=[\"PEDESTAL_ADC\"]\n"
         "cop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider(\"testbeam22_"
         "pedestals\",columns)\n"
-        "cop.conditions_baseURL='https://raw.githubusercontent.com/LDMX-Software/conditions-data/refs/heads/main/'\n"
-        "cop.entriesURL='${LDMX_CONDITION_BASEURL}/Hcal/testbeam04-2022/pedestals/index_v1_0_0.csv'\n";
+        "cop.conditions_baseURL='https://raw.githubusercontent.com/"
+        "LDMX-Software/conditions-data/refs/heads/main/'\n"
+        "cop.entriesURL='${LDMX_CONDITION_BASEURL}/Hcal/testbeam04-2022/"
+        "pedestals/index_v1_0_0.csv'\n";
 
     FILE* f = fopen("/tmp/test_cond.py", "w");
     fputs(cfgpy, f);

--- a/Conditions/test/TestConditions.cxx
+++ b/Conditions/test/TestConditions.cxx
@@ -265,8 +265,7 @@ TEST_CASE("Conditions", "[Conditions]") {
         "columns=[\"A\",\"Q\",\"V\"]\n"
         "cop=SimpleCSVTableProvider.SimpleCSVIntegerTableProvider(\"test_table_"
         "http\",columns)\n"
-        "cop.validForever(\"http://www-users.cse.umn.edu/~jmmans/"
-        "test_table.csv\")\n";
+        "cop.validForever(\"https://raw.githubusercontent.com/LDMX-Software/ci-data/refs/heads/main/conditions-test/test_table.csv\")\n";
 
     FILE* f = fopen("/tmp/test_cond.py", "w");
     fputs(cfgpy, f);
@@ -293,9 +292,8 @@ TEST_CASE("Conditions", "[Conditions]") {
         "columns=[\"PEDESTAL_ADC\"]\n"
         "cop=SimpleCSVTableProvider.SimpleCSVDoubleTableProvider(\"testbeam22_"
         "pedestals\",columns)\n"
-        "cop.conditions_baseURL='http://www-users.cse.umn.edu/~jmmans/ldmx/"
-        "condtest/'\n"
-        "cop.entriesURL='${LDMX_CONDITION_BASEURL}/testbeam22_pedestals.csv'\n";
+        "cop.conditions_baseURL='https://raw.githubusercontent.com/LDMX-Software/conditions-data/refs/heads/main/'\n"
+        "cop.entriesURL='${LDMX_CONDITION_BASEURL}/Hcal/testbeam04-2022/pedestals/index_v1_0_0.csv'\n";
 
     FILE* f = fopen("/tmp/test_cond.py", "w");
     fputs(cfgpy, f);


### PR DESCRIPTION
instead of having an extra copy of prior testbeam conditions, I'm just gong to direct the test to look at the repo where they are stored (https://github.com/LDMX-Software/conditions-data).

I've already copied test_table.csv into LDMX-Software/ci-data for test loading of a remote CSV file.

I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1774 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
