### PR TITLE
Allows using tracking for ParticleNet inputs

### DIFF
--- a/Ecal/include/Ecal/EcalPnetVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalPnetVetoProcessor.h
@@ -16,6 +16,7 @@
 #include "Ecal/EcalVetoProcessor.h"
 #include "Ecal/Event/EcalHit.h"
 #include "Ecal/Event/EcalVetoResult.h"
+#include "Ecal/TrackPropagator.h"
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventProcessor.h"
 #include "SimCore/Event/SimTrackerHit.h"

--- a/Ecal/include/Ecal/EcalPnetVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalPnetVetoProcessor.h
@@ -13,7 +13,6 @@
 #include <numeric>
 
 #include "DetDescr/EcalGeometry.h"
-#include "Ecal/EcalVetoProcessor.h"
 #include "Ecal/Event/EcalHit.h"
 #include "Ecal/Event/EcalVetoResult.h"
 #include "Ecal/TrackPropagator.h"
@@ -21,7 +20,6 @@
 #include "Framework/EventProcessor.h"
 #include "SimCore/Event/SimTrackerHit.h"
 #include "Tools/ONNXRuntime.h"
-#include "Tracking/Event/Track.h"
 
 namespace ecal {
 
@@ -42,16 +40,16 @@ class EcalPnetVetoProcessor : public framework::Producer {
    * Make inputs to the DNN from ECAL RecHits.
    * @param ecalRecHits The EcalHit collection.
    */
-  void make_inputs(const ldmx::EcalGeometry& geom,
-                   const std::vector<ldmx::EcalHit>& ecalRecHits,
-                   const framework::Event& event);
+  void makeInputs(const ldmx::EcalGeometry& geom,
+                  const std::vector<ldmx::EcalHit>& ecalRecHits,
+                  std::array<double, 3> etraj, std::array<double, 3> enorm);
 
   /**
-   * Transfor logits to a probability
+   * Transform logits to a probability
    * @param logits: Vector of logits
-   * @returns
+   * @returns Vector of log softmax probabilities
    */
-  std::vector<float> log_softmax(const std::vector<float>& logits);
+  std::vector<float> logSoftmax(const std::vector<float>& logits);
 
  private:
   /** Maximum number of hits allowed in ECAL. Events with more hits will be

--- a/Ecal/include/Ecal/EcalPnetVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalPnetVetoProcessor.h
@@ -13,12 +13,14 @@
 #include <numeric>
 
 #include "DetDescr/EcalGeometry.h"
+#include "Ecal/EcalVetoProcessor.h"
 #include "Ecal/Event/EcalHit.h"
 #include "Ecal/Event/EcalVetoResult.h"
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventProcessor.h"
 #include "SimCore/Event/SimTrackerHit.h"
 #include "Tools/ONNXRuntime.h"
+#include "Tracking/Event/Track.h"
 
 namespace ecal {
 
@@ -41,7 +43,7 @@ class EcalPnetVetoProcessor : public framework::Producer {
    */
   void make_inputs(const ldmx::EcalGeometry& geom,
                    const std::vector<ldmx::EcalHit>& ecalRecHits,
-                   const std::vector<ldmx::SimTrackerHit>& ecalSPHits);
+                   const framework::Event& event);
 
   /**
    * Transfor logits to a probability
@@ -80,6 +82,9 @@ class EcalPnetVetoProcessor : public framework::Producer {
   std::string rec_coll_name_;
   std::string ecal_rec_hits_passname_;
   std::string ecal_sp_hits_passname_;
+  std::string track_pass_name_;
+  std::string track_collection_;
+  bool recoil_from_tracking_;
 };
 
 }  // namespace ecal

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -15,13 +15,13 @@
 #include "Ecal/Event/EcalHit.h"
 #include "Ecal/Event/EcalTrajectoryInfo.h"
 #include "Ecal/Event/EcalVetoResult.h"
+#include "Ecal/TrackPropagator.h"
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventProcessor.h"
 #include "SimCore/Event/SimParticle.h"
 #include "SimCore/Event/SimTrackerHit.h"
 #include "Tools/AnalysisUtils.h"
 #include "Tools/ONNXRuntime.h"
-#include "Tracking/Event/Track.h"
 
 // C++
 #include <stdlib.h>
@@ -33,7 +33,8 @@
 #include <map>
 #include <memory>
 
-// ROOT (for anle calculations)
+// ROOT (for angle calculations)
+// TODO: Should be moved to the XYZ vector class
 #include "TVector3.h"
 
 namespace ecal {
@@ -120,18 +121,6 @@ class EcalVetoProcessor : public framework::Producer {
    * @returns Minimum distance between h1 and the line
    */
   float distPtToLine(TVector3 h1, TVector3 p1, TVector3 p2);
-
-  /**
-   * Return a vector of parameters for a propagated recoil track
-   * @param[in] tracks The track collection
-   * @param[in] ts_type The track state type, i.e. tracks state at the ECAL face
-   * @param[in] ts_title The track state title, most likely "ecal"
-   * @returns Vector of parameters for a propagated recoil track
-   */
- public:
-  static std::vector<float> trackProp(const ldmx::Tracks& tracks,
-                                      ldmx::TrackStateType ts_type,
-                                      const std::string& ts_title);
 
  private:
   int nevents_{0};

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -128,9 +128,10 @@ class EcalVetoProcessor : public framework::Producer {
    * @param[in] ts_title The track state title, most likely "ecal"
    * @returns Vector of parameters for a propagated recoil track
    */
-  std::vector<float> trackProp(const ldmx::Tracks& tracks,
-                               ldmx::TrackStateType ts_type,
-                               const std::string& ts_title);
+ public:
+  static std::vector<float> trackProp(const ldmx::Tracks& tracks,
+                                      ldmx::TrackStateType ts_type,
+                                      const std::string& ts_title);
 
  private:
   int nevents_{0};

--- a/Ecal/include/Ecal/TrackPropagator.h
+++ b/Ecal/include/Ecal/TrackPropagator.h
@@ -1,0 +1,45 @@
+
+/**
+ * @file TrackPropagator.h
+ * @brief Class that propagates tracks to the ECAL face
+ * @author Tamas Vami (UCSB)
+ */
+
+#ifndef ECAL_TRACKPROPAGATOR_H_
+#define ECAL_TRACKPROPAGATOR_H_
+
+// LDMX
+#include "Tracking/Event/Track.h"
+
+// C++
+#include <cmath>
+
+namespace ecal {
+
+/**
+ * @class TrackPropagator
+ * @brief Class that propagates tracks to the ECAL face
+ */
+class TrackPropagator {
+ public:
+  TrackPropagator() = default;
+
+  virtual ~TrackPropagator() = default;
+
+ public:
+  /**
+   * Return a vector of parameters for a propagated recoil track
+   * @param[in] tracks The track collection
+   * @param[in] ts_type The track state type, i.e. tracks state at the ECAL face
+   * @param[in] ts_title The track state title, most likely "ecal"
+   * @returns Vector of parameters for a propagated recoil track
+   */
+
+  static std::vector<float> trackProp(const ldmx::Tracks& tracks,
+                                      ldmx::TrackStateType ts_type,
+                                      const std::string& ts_title);
+};
+
+}  // namespace ecal
+
+#endif

--- a/Ecal/include/Ecal/TrackPropagator.h
+++ b/Ecal/include/Ecal/TrackPropagator.h
@@ -17,28 +17,16 @@
 namespace ecal {
 
 /**
- * @class TrackPropagator
- * @brief Class that propagates tracks to the ECAL face
+ * Return a vector of parameters for a propagated recoil track
+ * @param[in] tracks The track collection
+ * @param[in] ts_type The track state type, i.e. tracks state at the ECAL face
+ * @param[in] ts_title The track state title, most likely "ecal"
+ * @returns Vector of parameters for a propagated recoil track
  */
-class TrackPropagator {
- public:
-  TrackPropagator() = default;
 
-  virtual ~TrackPropagator() = default;
-
- public:
-  /**
-   * Return a vector of parameters for a propagated recoil track
-   * @param[in] tracks The track collection
-   * @param[in] ts_type The track state type, i.e. tracks state at the ECAL face
-   * @param[in] ts_title The track state title, most likely "ecal"
-   * @returns Vector of parameters for a propagated recoil track
-   */
-
-  static std::vector<float> trackProp(const ldmx::Tracks& tracks,
-                                      ldmx::TrackStateType ts_type,
-                                      const std::string& ts_title);
-};
+std::vector<float> trackProp(const ldmx::Tracks& tracks,
+                             ldmx::TrackStateType ts_type,
+                             const std::string& ts_title);
 
 }  // namespace ecal
 

--- a/Ecal/python/vetos.py
+++ b/Ecal/python/vetos.py
@@ -63,12 +63,14 @@ class EcalPnetVetoProcessor(ldmxcfg.Producer) :
 
         from LDMX.Ecal.makePath import makeBDTPath
         self.model_path = makeBDTPath("particle_net_ecal_v10")
-        self.disc_cut = 0.74
+        self.disc_cut = 0.65
         self.collection_name = "EcalPnetVeto"
         self.rec_coll_name = "EcalRecHits"
         self.ecal_rec_hits_passname = ""
         self.ecal_sp_hits_passname = ""
-        
+        self.track_collection = "RecoilTracksClean"
+        self.track_pass_name = ""
+        self.recoil_from_tracking = True
         
 
 

--- a/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
@@ -96,7 +96,7 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
                                                           track_pass_name_)};
       ldmx::TrackStateType ts_at_ecal = ldmx::TrackStateType::AtECAL;
       auto recoil_track_states_ecal =
-          ecal::TrackPropagator::trackProp(recoil_tracks, ts_at_ecal, "ecal");
+          ecal::trackProp(recoil_tracks, ts_at_ecal, "ecal");
       if (!recoil_track_states_ecal.empty()) {
         std::array<double, 3> pos = {recoil_track_states_ecal[0],
                                      recoil_track_states_ecal[1],

--- a/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
@@ -29,12 +29,16 @@ void EcalPnetVetoProcessor::configure(
       parameters.getParameter<std::string>("ecal_rec_hits_passname");
   ecal_sp_hits_passname_ =
       parameters.getParameter<std::string>("ecal_sp_hits_passname");
+  track_pass_name_ =
+      parameters.getParameter<std::string>("track_pass_name", "");
+  track_collection_ = parameters.getParameter<std::string>("track_collection");
+  recoil_from_tracking_ = parameters.getParameter<bool>("recoil_from_tracking");
 }
 
 void EcalPnetVetoProcessor::produce(framework::Event& event) {
   ldmx::EcalVetoResult result;
-
-  // Get the Ecal Geometry
+  // ecal::EcalVetoProcessor proc;
+  //  Get the Ecal Geometry
   const auto& ecal_geometry = getCondition<ldmx::EcalGeometry>(
       ldmx::EcalGeometry::CONDITIONS_OBJECT_NAME);
 
@@ -44,20 +48,15 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
   auto nhits = std::count_if(
       ecal_rec_hits.begin(), ecal_rec_hits.end(),
       [](const ldmx::EcalHit& hit) { return hit.getEnergy() > 0; });
-  // Get the collection of EcalScroingPlane hits
-  auto const& spHits = event.getCollection<ldmx::SimTrackerHit>(
-      "EcalScoringPlaneHits", ecal_sp_hits_passname_);
 
+  // check number of hits
   ldmx_log(trace) << "nhits = " << nhits
                   << " max_num_hits_ = " << max_num_hits_;
-
   if (nhits < max_num_hits_) {
     // make inputs
-    make_inputs(ecal_geometry, ecal_rec_hits, spHits);
-
+    make_inputs(ecal_geometry, ecal_rec_hits, event);
     // run the DNN
     auto logits = rt_->run(input_names_, data_)[0];
-
     // make a log softmax of the logits then transform back
     // to a probability with an exponential
     auto prob = std::exp((log_softmax(logits)[1]));
@@ -83,35 +82,71 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
 void EcalPnetVetoProcessor::make_inputs(
     const ldmx::EcalGeometry& geom,
     const std::vector<ldmx::EcalHit>& ecal_rec_hits,
-    const std::vector<ldmx::SimTrackerHit>& ecal_sp_hits) {
+    const framework::Event& event) {
   // Compute electron trajectory
   std::array<double, 3> etraj_sp = {-999., -999., -999.};
   std::array<double, 3> enorm_sp = {-999., -999., -999.};
-
   const ldmx::SimTrackerHit* electron_hit = nullptr;
-  double electron_pz_max = -1.0;
-  for (auto const& hit : ecal_sp_hits) {
-    // Look at the electron only
-    if (hit.getPdgID() != 11) continue;
-    double electron_z = hit.getPosition()[2];
-    // Look at the SP in front of the ECAL
-    if (electron_z <= 239.0 || electron_z >= 240.0) continue;
-    double electron_pz = hit.getMomentum()[2];
-    // Find the highest pz electron
-    if (electron_pz > electron_pz_max) {
-      electron_pz_max = electron_pz;
-      electron_hit = &hit;
+  // Use Scoring Plane or Tracking
+  if (!recoil_from_tracking_ &&
+      event.exists("EcalScoringPlaneHits", ecal_sp_hits_passname_)) {
+    auto const& ecal_sp_hits = event.getCollection<ldmx::SimTrackerHit>(
+        "EcalScoringPlaneHits", ecal_sp_hits_passname_);
+    double electron_pz_max = -1.0;
+    for (auto const& hit : ecal_sp_hits) {
+      // Look at the electron only
+      if (hit.getPdgID() != 11) continue;
+      double electron_z = hit.getPosition()[2];
+      // Look at the SP in front of the ECAL
+      if (electron_z <= 239.0 || electron_z >= 240.0) continue;
+      double electron_pz = hit.getMomentum()[2];
+      // Find the highest pz electron
+      if (electron_pz > electron_pz_max) {
+        electron_pz_max = electron_pz;
+        electron_hit = &hit;
+      }
     }
-  }
-  if (electron_hit) {
-    ldmx_log(trace) << "Electron Found!";
-    auto pos = electron_hit->getPosition();
-    auto mom = electron_hit->getMomentum();
-    etraj_sp = {pos[0], pos[1], pos[2]};
-
-    double pz = mom[2];
-    if (pz != 0) {
-      enorm_sp = {mom[0] / pz, mom[1] / pz, 1.0};
+    if (electron_hit) {
+      // Get electron hit position/momentum at Ecal surface
+      ldmx_log(trace) << "Electron Found!";
+      auto pos = electron_hit->getPosition();
+      auto mom = electron_hit->getMomentum();
+      ldmx_log(info) << "SPpos=(" << pos[0] << "," << pos[1] << "," << pos[2]
+                     << ")";
+      ldmx_log(info) << "SPmom=(" << mom[0] << "," << mom[1] << "," << mom[2]
+                     << ")";
+      etraj_sp = {pos[0], pos[1], pos[2]};
+      double pz = mom[2];
+      if (pz != 0) {
+        // z-normalized momentum
+        enorm_sp = {mom[0] / pz, mom[1] / pz, 1.0};
+      }
+    }
+  } else {
+    // Use tracking to get electron hit position/momentum at Ecal surface
+    auto recoil_tracks{
+        event.getCollection<ldmx::Track>(track_collection_, track_pass_name_)};
+    ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
+    auto recoil_track_states_ecal =
+        ecal::EcalVetoProcessor::trackProp(recoil_tracks, ts_type, "ecal");
+    if (!recoil_track_states_ecal.empty()) {
+      std::array<double, 3> pos = {recoil_track_states_ecal[0],
+                                   recoil_track_states_ecal[1],
+                                   recoil_track_states_ecal[2]};
+      std::array<double, 3> mom = {(recoil_track_states_ecal[3]),
+                                   (recoil_track_states_ecal[4]),
+                                   (recoil_track_states_ecal[5])};
+      ldmx_log(info) << "Electron track pos=(" << pos[0] << "," << pos[1] << ","
+                     << pos[2] << ")";
+      ldmx_log(info) << "Electron track mom=(" << mom[0] << "," << mom[1] << ","
+                     << mom[2] << ")";
+      etraj_sp = pos;
+      double pz = mom[2];
+      if (pz != 0) {
+        enorm_sp = {mom[0] / pz, mom[1] / pz, 1.0};
+      }
+    } else {
+      ldmx_log(info) << "  No recoil track at ECAL";
     }
   }
 

--- a/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
@@ -47,16 +47,86 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
       [](const ldmx::EcalHit& hit) { return hit.getEnergy() > 0; });
 
   // check number of hits
-  ldmx_log(trace) << "nhits = " << nhits
+  ldmx_log(debug) << "nhits = " << nhits
                   << " max_num_hits_ = " << max_num_hits_;
   if (nhits < max_num_hits_) {
+    std::array<double, 3> etraj = {-999., -999., -999.};
+    std::array<double, 3> enorm = {-999., -999., -999.};
+    // Compute electron trajectory}
+    const ldmx::SimTrackerHit* electron_hit = nullptr;
+    // Use Scoring Plane or Tracking
+    if (!recoil_from_tracking_ &&
+        event.exists("EcalScoringPlaneHits", ecal_sp_hits_passname_)) {
+      auto const& ecal_sp_hits = event.getCollection<ldmx::SimTrackerHit>(
+          "EcalScoringPlaneHits", ecal_sp_hits_passname_);
+      double electron_pz_max = -1.0;
+      for (auto const& hit : ecal_sp_hits) {
+        // Look at the electron only
+        if (hit.getPdgID() != 11) continue;
+        double electron_z = hit.getPosition()[2];
+        // Look at the SP in front of the ECAL
+        if (electron_z <= 239.0 || electron_z >= 240.0) continue;
+        double electron_pz = hit.getMomentum()[2];
+        // Find the highest pz electron
+        if (electron_pz > electron_pz_max) {
+          electron_pz_max = electron_pz;
+          electron_hit = &hit;
+        }
+      }
+      // If we found an electron hit at the scoring plane
+      if (electron_hit) {
+        // Get electron hit position/momentum at Ecal surface
+        ldmx_log(debug) << "Electron Found in the Ecal SP!";
+        auto pos = electron_hit->getPosition();
+        auto mom = electron_hit->getMomentum();
+        ldmx_log(debug) << "ECAL SP pos=(" << pos[0] << "," << pos[1] << ","
+                        << pos[2] << ")";
+        ldmx_log(debug) << "ECAL SP mom=(" << mom[0] << "," << mom[1] << ","
+                        << mom[2] << ")";
+        etraj = {pos[0], pos[1], pos[2]};
+        double pz = mom[2];
+        if (pz != 0) {
+          // z-normalized momentum
+          enorm = {mom[0] / pz, mom[1] / pz, 1.0};
+        }
+      }
+    } else if (recoil_from_tracking_) {
+      // Use tracking to get electron hit position/momentum at Ecal surface
+      auto recoil_tracks{event.getCollection<ldmx::Track>(track_collection_,
+                                                          track_pass_name_)};
+      ldmx::TrackStateType ts_at_ecal = ldmx::TrackStateType::AtECAL;
+      auto recoil_track_states_ecal =
+          ecal::TrackPropagator::trackProp(recoil_tracks, ts_at_ecal, "ecal");
+      if (!recoil_track_states_ecal.empty()) {
+        std::array<double, 3> pos = {recoil_track_states_ecal[0],
+                                     recoil_track_states_ecal[1],
+                                     recoil_track_states_ecal[2]};
+        std::array<double, 3> mom = {(recoil_track_states_ecal[3]),
+                                     (recoil_track_states_ecal[4]),
+                                     (recoil_track_states_ecal[5])};
+        ldmx_log(debug) << "Electron track pos=(" << pos[0] << "," << pos[1]
+                        << "," << pos[2] << ")";
+        ldmx_log(debug) << "Electron track mom=(" << mom[0] << "," << mom[1]
+                        << "," << mom[2] << ")";
+        etraj = pos;
+        double pz = mom[2];
+        if (pz != 0) {
+          enorm = {mom[0] / pz, mom[1] / pz, 1.0};
+        }
+      } else {
+        ldmx_log(info) << "  No recoil track at ECAL";
+      }
+    } else {
+      ldmx_log(fatal) << "  No electron hit at scoring plane or no tracking";
+    }
+
     // make inputs
-    make_inputs(ecal_geometry, ecal_rec_hits, event);
+    makeInputs(ecal_geometry, ecal_rec_hits, etraj, enorm);
     // run the DNN
     auto logits = rt_->run(input_names_, data_)[0];
     // make a log softmax of the logits then transform back
     // to a probability with an exponential
-    auto prob = std::exp((log_softmax(logits)[1]));
+    auto prob = std::exp((logSoftmax(logits)[1]));
     result.setDiscValue(prob);
   } else {
     result.setDiscValue(-99);
@@ -76,77 +146,10 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
   event.add(collectionName_, result);
 }
 
-void EcalPnetVetoProcessor::make_inputs(
+void EcalPnetVetoProcessor::makeInputs(
     const ldmx::EcalGeometry& geom,
     const std::vector<ldmx::EcalHit>& ecal_rec_hits,
-    const framework::Event& event) {
-  // Compute electron trajectory
-  std::array<double, 3> etraj_sp = {-999., -999., -999.};
-  std::array<double, 3> enorm_sp = {-999., -999., -999.};
-  const ldmx::SimTrackerHit* electron_hit = nullptr;
-  // Use Scoring Plane or Tracking
-  if (!recoil_from_tracking_ &&
-      event.exists("EcalScoringPlaneHits", ecal_sp_hits_passname_)) {
-    auto const& ecal_sp_hits = event.getCollection<ldmx::SimTrackerHit>(
-        "EcalScoringPlaneHits", ecal_sp_hits_passname_);
-    double electron_pz_max = -1.0;
-    for (auto const& hit : ecal_sp_hits) {
-      // Look at the electron only
-      if (hit.getPdgID() != 11) continue;
-      double electron_z = hit.getPosition()[2];
-      // Look at the SP in front of the ECAL
-      if (electron_z <= 239.0 || electron_z >= 240.0) continue;
-      double electron_pz = hit.getMomentum()[2];
-      // Find the highest pz electron
-      if (electron_pz > electron_pz_max) {
-        electron_pz_max = electron_pz;
-        electron_hit = &hit;
-      }
-    }
-    if (electron_hit) {
-      // Get electron hit position/momentum at Ecal surface
-      ldmx_log(trace) << "Electron Found!";
-      auto pos = electron_hit->getPosition();
-      auto mom = electron_hit->getMomentum();
-      ldmx_log(info) << "SPpos=(" << pos[0] << "," << pos[1] << "," << pos[2]
-                     << ")";
-      ldmx_log(info) << "SPmom=(" << mom[0] << "," << mom[1] << "," << mom[2]
-                     << ")";
-      etraj_sp = {pos[0], pos[1], pos[2]};
-      double pz = mom[2];
-      if (pz != 0) {
-        // z-normalized momentum
-        enorm_sp = {mom[0] / pz, mom[1] / pz, 1.0};
-      }
-    }
-  } else {
-    // Use tracking to get electron hit position/momentum at Ecal surface
-    auto recoil_tracks{
-        event.getCollection<ldmx::Track>(track_collection_, track_pass_name_)};
-    ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
-    auto recoil_track_states_ecal =
-        ecal::TrackPropagator::trackProp(recoil_tracks, ts_type, "ecal");
-    if (!recoil_track_states_ecal.empty()) {
-      std::array<double, 3> pos = {recoil_track_states_ecal[0],
-                                   recoil_track_states_ecal[1],
-                                   recoil_track_states_ecal[2]};
-      std::array<double, 3> mom = {(recoil_track_states_ecal[3]),
-                                   (recoil_track_states_ecal[4]),
-                                   (recoil_track_states_ecal[5])};
-      ldmx_log(info) << "Electron track pos=(" << pos[0] << "," << pos[1] << ","
-                     << pos[2] << ")";
-      ldmx_log(info) << "Electron track mom=(" << mom[0] << "," << mom[1] << ","
-                     << mom[2] << ")";
-      etraj_sp = pos;
-      double pz = mom[2];
-      if (pz != 0) {
-        enorm_sp = {mom[0] / pz, mom[1] / pz, 1.0};
-      }
-    } else {
-      ldmx_log(info) << "  No recoil track at ECAL";
-    }
-  }
-
+    std::array<double, 3> etraj, std::array<double, 3> enorm) {
   // clear data
   for (auto& v : data_) {
     std::fill(v.begin(), v.end(), 0);
@@ -155,25 +158,24 @@ void EcalPnetVetoProcessor::make_inputs(
   // Loop on the rechits
   unsigned idx = 0;
   for (const auto& hit : ecal_rec_hits) {
-    if (hit.getEnergy() <= 0) continue;
-    ldmx::EcalID id(hit.getID());
-    auto [x, y, z] = geom.getPosition(id);
-
-    // Compute relative position
-    double etraj_x = -999.;
-    double etraj_y = -999.;
-    if (electron_hit) {
-      double delta_z = z - etraj_sp[2];
-      etraj_x = etraj_sp[0] + enorm_sp[0] * delta_z;
-      etraj_y = etraj_sp[1] + enorm_sp[1] * delta_z;
+    if (hit.getEnergy() <= 0) {
+      ldmx_log(warn)
+          << "Hit with zero energy found, should not happen, skipping it.";
+      continue;
     }
-    data_[0].at(coordinate_x_offset_ + idx) = x - etraj_x;
-    data_[0].at(coordinate_y_offset_ + idx) = y - etraj_y;
-    data_[0].at(coordinate_z_offset_ + idx) = z;
+    ldmx::EcalID id(hit.getID());
+    auto [hit_x, hit_y, hit_z] = geom.getPosition(id);
 
-    data_[1].at(feature_x_offset_ + idx) = x - etraj_x;
-    data_[1].at(feature_y_offset_ + idx) = y - etraj_y;
-    data_[1].at(feature_z_offset_ + idx) = z;
+    double delta_z = hit_z - etraj[2];
+    double etraj_x = etraj[0] + enorm[0] * delta_z;
+    double etraj_y = etraj[1] + enorm[1] * delta_z;
+    data_[0].at(coordinate_x_offset_ + idx) = hit_x - etraj_x;
+    data_[0].at(coordinate_y_offset_ + idx) = hit_y - etraj_y;
+    data_[0].at(coordinate_z_offset_ + idx) = hit_z;
+
+    data_[1].at(feature_x_offset_ + idx) = hit_x - etraj_x;
+    data_[1].at(feature_y_offset_ + idx) = hit_y - etraj_y;
+    data_[1].at(feature_z_offset_ + idx) = hit_z;
     data_[1].at(feature_layerid_offset_ + idx) = id.layer();
     data_[1].at(feature_energy_offset_ + idx) = std::log(hit.getEnergy());
 
@@ -193,7 +195,7 @@ void EcalPnetVetoProcessor::make_inputs(
   ldmx_log(trace) << ss.str();
 }  // end of make inputs
 
-std::vector<float> EcalPnetVetoProcessor::log_softmax(
+std::vector<float> EcalPnetVetoProcessor::logSoftmax(
     const std::vector<float>& logits) {
   // Find max for numerical stability
   auto max_val = *std::max_element(logits.begin(), logits.end());

--- a/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
@@ -17,27 +17,24 @@ EcalPnetVetoProcessor::EcalPnetVetoProcessor(const std::string& name,
 
 void EcalPnetVetoProcessor::configure(
     framework::config::Parameters& parameters) {
-  disc_cut_ = parameters.getParameter<double>("disc_cut");
+  disc_cut_ = parameters.get<double>("disc_cut");
   rt_ = std::make_unique<ldmx::Ort::ONNXRuntime>(
-      parameters.getParameter<std::string>("model_path"));
+      parameters.get<std::string>("model_path"));
 
   // Set the collection name as defined in the configuration
-  collectionName_ = parameters.getParameter<std::string>("collection_name");
+  collectionName_ = parameters.get<std::string>("collection_name");
 
-  rec_coll_name_ = parameters.getParameter<std::string>("rec_coll_name");
+  rec_coll_name_ = parameters.get<std::string>("rec_coll_name");
   ecal_rec_hits_passname_ =
-      parameters.getParameter<std::string>("ecal_rec_hits_passname");
-  ecal_sp_hits_passname_ =
-      parameters.getParameter<std::string>("ecal_sp_hits_passname");
-  track_pass_name_ =
-      parameters.getParameter<std::string>("track_pass_name", "");
-  track_collection_ = parameters.getParameter<std::string>("track_collection");
-  recoil_from_tracking_ = parameters.getParameter<bool>("recoil_from_tracking");
+      parameters.get<std::string>("ecal_rec_hits_passname");
+  ecal_sp_hits_passname_ = parameters.get<std::string>("ecal_sp_hits_passname");
+  track_pass_name_ = parameters.get<std::string>("track_pass_name", "");
+  track_collection_ = parameters.get<std::string>("track_collection");
+  recoil_from_tracking_ = parameters.get<bool>("recoil_from_tracking");
 }
 
 void EcalPnetVetoProcessor::produce(framework::Event& event) {
   ldmx::EcalVetoResult result;
-  // ecal::EcalVetoProcessor proc;
   //  Get the Ecal Geometry
   const auto& ecal_geometry = getCondition<ldmx::EcalGeometry>(
       ldmx::EcalGeometry::CONDITIONS_OBJECT_NAME);
@@ -128,7 +125,7 @@ void EcalPnetVetoProcessor::make_inputs(
         event.getCollection<ldmx::Track>(track_collection_, track_pass_name_)};
     ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
     auto recoil_track_states_ecal =
-        ecal::EcalVetoProcessor::trackProp(recoil_tracks, ts_type, "ecal");
+        ecal::TrackPropagator::trackProp(recoil_tracks, ts_type, "ecal");
     if (!recoil_track_states_ecal.empty()) {
       std::array<double, 3> pos = {recoil_track_states_ecal[0],
                                    recoil_track_states_ecal[1],

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -79,18 +79,17 @@ void EcalVetoProcessor::buildBDTFeatureVector(
 }
 
 void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
-  feature_list_name_ =
-      parameters.getParameter<std::string>("feature_list_name");
+  feature_list_name_ = parameters.get<std::string>("feature_list_name");
 
   sim_particles_passname_ =
-      parameters.getParameter<std::string>("sim_particles_passname");
+      parameters.get<std::string>("sim_particles_passname");
   // Load BDT ONNX file
   rt_ = std::make_unique<ldmx::Ort::ONNXRuntime>(
-      parameters.getParameter<std::string>("bdt_file"));
+      parameters.get<std::string>("bdt_file"));
 
   // Read in arrays holding 68% containment radius per layer
   // for different bins in momentum/angle
-  roc_file_name_ = parameters.getParameter<std::string>("roc_file");
+  roc_file_name_ = parameters.get<std::string>("roc_file");
   if (!std::ifstream(roc_file_name_).good()) {
     EXCEPTION_RAISE(
         "EcalVetoProcessor",
@@ -115,24 +114,23 @@ void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
     }
   }
 
-  n_ecal_layers_ = parameters.getParameter<int>("num_ecal_layers");
+  n_ecal_layers_ = parameters.get<int>("num_ecal_layers");
 
-  bdt_cut_val_ = parameters.getParameter<double>("disc_cut");
+  bdt_cut_val_ = parameters.get<double>("disc_cut");
   ecal_layer_edep_raw_.resize(n_ecal_layers_, 0);
   ecal_layer_edep_readout_.resize(n_ecal_layers_, 0);
   ecal_layer_time_.resize(n_ecal_layers_, 0);
 
-  beam_energy_mev_ = parameters.getParameter<double>("beam_energy");
+  beam_energy_mev_ = parameters.get<double>("beam_energy");
   // Set the collection name as defined in the configuration
-  sp_pass_name_ = parameters.getParameter<std::string>("sp_pass_name");
-  collection_name_ = parameters.getParameter<std::string>("collection_name");
-  rec_pass_name_ = parameters.getParameter<std::string>("rec_pass_name");
-  rec_coll_name_ = parameters.getParameter<std::string>("rec_coll_name");
-  recoil_from_tracking_ = parameters.getParameter<bool>("recoil_from_tracking");
-  track_collection_ = parameters.getParameter<std::string>("track_collection");
-  track_pass_name_ =
-      parameters.getParameter<std::string>("track_pass_name", "");
-  inverse_skim_ = parameters.getParameter<bool>("inverse_skim");
+  sp_pass_name_ = parameters.get<std::string>("sp_pass_name");
+  collection_name_ = parameters.get<std::string>("collection_name");
+  rec_pass_name_ = parameters.get<std::string>("rec_pass_name");
+  rec_coll_name_ = parameters.get<std::string>("rec_coll_name");
+  recoil_from_tracking_ = parameters.get<bool>("recoil_from_tracking");
+  track_collection_ = parameters.get<std::string>("track_collection");
+  track_pass_name_ = parameters.get<std::string>("track_pass_name", "");
+  inverse_skim_ = parameters.get<bool>("inverse_skim");
 }
 
 void EcalVetoProcessor::clearProcessor() {
@@ -272,11 +270,12 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
     ldmx_log(trace) << "  Propagate the recoil ele to the ECAL";
     ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
-    auto recoil_track_states_ecal = trackProp(recoil_tracks, ts_type, "ecal");
+    auto recoil_track_states_ecal =
+        ecal::TrackPropagator::trackProp(recoil_tracks, ts_type, "ecal");
     ldmx_log(trace) << "  Propagate the recoil ele to the Target";
     ldmx::TrackStateType ts_type_target = ldmx::TrackStateType::AtTarget;
-    auto recoil_track_states_target =
-        trackProp(recoil_tracks, ts_type_target, "target");
+    auto recoil_track_states_target = ecal::TrackPropagator::trackProp(
+        recoil_tracks, ts_type_target, "target");
 
     ldmx_log(trace) << "  Set recoil_pos and recoil_p";
     // Redefining recoil_pos now to come from the track state
@@ -1099,67 +1098,6 @@ float EcalVetoProcessor::distTwoLines(TVector3 v1, TVector3 v2, TVector3 w1,
 
 float EcalVetoProcessor::distPtToLine(TVector3 h1, TVector3 p1, TVector3 p2) {
   return ((h1 - p1).Cross(h1 - p2)).Mag() / (p1 - p2).Mag();
-}
-
-std::vector<float> EcalVetoProcessor::trackProp(const ldmx::Tracks &tracks,
-                                                ldmx::TrackStateType ts_type,
-                                                const std::string &ts_title) {
-  // Vector to hold the new track state variables
-  std::vector<float> new_track_states;
-
-  // Return if no tracks
-  if (tracks.empty()) return new_track_states;
-
-  // Otherwise loop on the tracks
-  for (auto &track : tracks) {
-    // Get track state for ts_type
-    auto trk_ts = track.getTrackState(ts_type);
-    // Continue if there's no value
-    if (!trk_ts.has_value()) continue;
-    ldmx::Track::TrackState &ecal_track_state = trk_ts.value();
-
-    // Check that the track state is filled
-    if (ecal_track_state.params.size() < 5) continue;
-
-    float track_state_loc0 = static_cast<float>(ecal_track_state.params[0]);
-    float track_state_loc1 = static_cast<float>(ecal_track_state.params[1]);
-    // param 2 = phi (azimuthal), param 3 = theta (polar)
-    // param 4 = QoP
-    // ACTS (local)  to  LDMX (global) coordinates: (y,z,x)->  (x,y,z)
-    // convert qop [1/GeV] to p [MeV]
-    float p_track_state = (-1 / ecal_track_state.params[4]) * 1000;
-    // p * sin(theta) * sin(phi)
-    float recoil_mom_x = p_track_state * sin(ecal_track_state.params[3]) *
-                         sin(ecal_track_state.params[2]);
-    // p * cos(theta)
-    float recoil_mom_y = p_track_state * cos(ecal_track_state.params[3]);
-    // p * sin(theta) * cos(phi)
-    float recoil_mom_z = p_track_state * sin(ecal_track_state.params[3]) *
-                         cos(ecal_track_state.params[2]);
-
-    // Store the new track state variables
-    new_track_states.push_back(track_state_loc0);
-    new_track_states.push_back(track_state_loc1);
-    // z-position at the ECAL (4) or Target (1)
-    if (ts_type == 4) {
-      // this should match `ECAL_SCORING_PLANE` in CKFProcessor
-      new_track_states.push_back(240.5);
-    } else if (ts_type == 1) {
-      // This should match `target_surface` in CKFProcessor
-      new_track_states.push_back(0.0);
-    }
-
-    new_track_states.push_back(recoil_mom_x);
-    new_track_states.push_back(recoil_mom_y);
-    new_track_states.push_back(recoil_mom_z);
-
-    // Break after getting the first valid track state
-    // TODO: interface this with CLUE to make sure the propageted track
-    //       has an associated cluster in the ECAL
-    break;
-  }
-
-  return new_track_states;
 }
 
 }  // namespace ecal

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -271,11 +271,11 @@ void EcalVetoProcessor::produce(framework::Event &event) {
     ldmx_log(trace) << "  Propagate the recoil ele to the ECAL";
     ldmx::TrackStateType ts_type = ldmx::TrackStateType::AtECAL;
     auto recoil_track_states_ecal =
-        ecal::TrackPropagator::trackProp(recoil_tracks, ts_type, "ecal");
+        ecal::trackProp(recoil_tracks, ts_type, "ecal");
     ldmx_log(trace) << "  Propagate the recoil ele to the Target";
     ldmx::TrackStateType ts_type_target = ldmx::TrackStateType::AtTarget;
-    auto recoil_track_states_target = ecal::TrackPropagator::trackProp(
-        recoil_tracks, ts_type_target, "target");
+    auto recoil_track_states_target =
+        ecal::trackProp(recoil_tracks, ts_type_target, "target");
 
     ldmx_log(trace) << "  Set recoil_pos and recoil_p";
     // Redefining recoil_pos now to come from the track state

--- a/Ecal/src/Ecal/TrackPropagator.cxx
+++ b/Ecal/src/Ecal/TrackPropagator.cxx
@@ -2,9 +2,9 @@
 
 namespace ecal {
 
-std::vector<float> TrackPropagator::trackProp(const ldmx::Tracks &tracks,
-                                              ldmx::TrackStateType ts_type,
-                                              const std::string &ts_title) {
+std::vector<float> trackProp(const ldmx::Tracks &tracks,
+                             ldmx::TrackStateType ts_type,
+                             const std::string &ts_title) {
   // Vector to hold the new track state variables
   std::vector<float> new_track_states;
 

--- a/Ecal/src/Ecal/TrackPropagator.cxx
+++ b/Ecal/src/Ecal/TrackPropagator.cxx
@@ -1,0 +1,66 @@
+#include "Ecal/TrackPropagator.h"
+
+namespace ecal {
+
+std::vector<float> TrackPropagator::trackProp(const ldmx::Tracks &tracks,
+                                              ldmx::TrackStateType ts_type,
+                                              const std::string &ts_title) {
+  // Vector to hold the new track state variables
+  std::vector<float> new_track_states;
+
+  // Return if no tracks
+  if (tracks.empty()) return new_track_states;
+
+  // Otherwise loop on the tracks
+  for (auto &track : tracks) {
+    // Get track state for ts_type
+    auto trk_ts = track.getTrackState(ts_type);
+    // Continue if there's no value
+    if (!trk_ts.has_value()) continue;
+    ldmx::Track::TrackState &ecal_track_state = trk_ts.value();
+
+    // Check that the track state is filled
+    if (ecal_track_state.params.size() < 5) continue;
+
+    float track_state_loc0 = static_cast<float>(ecal_track_state.params[0]);
+    float track_state_loc1 = static_cast<float>(ecal_track_state.params[1]);
+    // param 2 = phi (azimuthal), param 3 = theta (polar)
+    // param 4 = QoP
+    // ACTS (local)  to  LDMX (global) coordinates: (y,z,x)->  (x,y,z)
+    // convert qop [1/GeV] to p [MeV]
+    float p_track_state = (-1 / ecal_track_state.params[4]) * 1000;
+    // p * sin(theta) * sin(phi)
+    float recoil_mom_x = p_track_state * sin(ecal_track_state.params[3]) *
+                         sin(ecal_track_state.params[2]);
+    // p * cos(theta)
+    float recoil_mom_y = p_track_state * cos(ecal_track_state.params[3]);
+    // p * sin(theta) * cos(phi)
+    float recoil_mom_z = p_track_state * sin(ecal_track_state.params[3]) *
+                         cos(ecal_track_state.params[2]);
+
+    // Store the new track state variables
+    new_track_states.push_back(track_state_loc0);
+    new_track_states.push_back(track_state_loc1);
+    // z-position at the ECAL (4) or Target (1)
+    if (ts_type == 4) {
+      // this should match `ECAL_SCORING_PLANE` in CKFProcessor
+      new_track_states.push_back(240.5);
+    } else if (ts_type == 1) {
+      // This should match `target_surface` in CKFProcessor
+      new_track_states.push_back(0.0);
+    }
+
+    new_track_states.push_back(recoil_mom_x);
+    new_track_states.push_back(recoil_mom_y);
+    new_track_states.push_back(recoil_mom_z);
+
+    // Break after getting the first valid track state
+    // TODO: interface this with CLUE to make sure the propageted track
+    //       has an associated cluster in the ECAL
+    break;
+  }
+
+  return new_track_states;
+}
+
+}  // namespace ecal


### PR DESCRIPTION
Uses tracking information for computing ParticleNet input coordinates. Includes a flag "recoil_from_tracking" to choose whether to use tracking or scoring plane information.

<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
