### PR TITLE
Let hcal_dqm use the new default for PE threshold

### DIFF
--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -948,19 +948,19 @@ ecal_dqm = [
         ]
 
 hcal_dqm = [
-        HCalDQM(pe_threshold=5,
+        HCalDQM(pe_threshold=8,
                 section=0
                 ),
-        HCalDQM(pe_threshold=5,
+        HCalDQM(pe_threshold=8,
                 section=1
                 ),
-        HCalDQM(pe_threshold=5,
+        HCalDQM(pe_threshold=8,
                 section=2
                 ),
-        HCalDQM(pe_threshold=5,
+        HCalDQM(pe_threshold=8,
                 section=3
                 ),
-        HCalDQM(pe_threshold=5,
+        HCalDQM(pe_threshold=8,
                 section=4
                 ),
         HcalInefficiencyAnalyzer(),


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
No issue, just a simple default change that was missed earlier

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
