### PR TITLE
Update target.py dark_brem() function

### DIFF
--- a/.github/validation_samples/signal/config.py
+++ b/.github/validation_samples/signal/config.py
@@ -4,6 +4,7 @@ p = ldmxcfg.Process('test')
 p.maxTriesPerEvent = 10000
 
 from LDMX.Biasing import target
+from LDMX.SimCore import generators
 det = 'ldmx-det-v14-8gev'
 mySim = target.dark_brem(
     #A' mass in MeV - set in init.sh to same value in GeV
@@ -12,7 +13,8 @@ mySim = target.dark_brem(
     #   easiest way to find this path out is by running `. init.sh` locally to see what
     #   is produced
     'electron_tungsten_MaxE_8.0_MinE_4.0_RelEStep_0.1_UndecayedAP_mA_0.01_run_1',
-    det
+    det,
+    generators.single_8gev_e_upstream_tagger()
 )
 
 p.sequence = [ mySim ]

--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -198,7 +198,10 @@ def gamma_mumu( detector, generator ) :
 
     return sim
 
-def dark_brem( ap_mass , lhe, detector) :
+def dark_brem( ap_mass , lhe, detector, generator,
+             scale_APrime = False, decay_mode = 'no_decay', 
+             ap_tau = -1.0, dist_decay_min = 0.0,
+             dist_decay_max = 1.0) :
     """Example configuration for producing dark brem interactions in the target.
 
     This configures the sim to fire a 8 GeV electron upstream of the
@@ -243,6 +246,11 @@ def dark_brem( ap_mass , lhe, detector) :
     db_model = dark_brem.G4DarkBreMModel(lhe)
     db_model.threshold = 4. #GeV - minimum energy electron needs to have to dark brem
     db_model.epsilon   = 0.01 #decrease epsilon from one to help with Geant4 biasing calculations
+    db_model.scale_APrime = scale_APrime
+    db_model.decay_mode = decay_mode
+    db_model.ap_tau = ap_tau
+    db_model.dist_decay_min = dist_decay_min
+    db_model.dist_decay_max = dist_decay_max
     sim.dark_brem.activate( ap_mass , db_model )
 
     import math


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
_This resolves #1776_ by matching the dark_brem function of [target biasing](https://github.com/LDMX-Software/ldmx-sw/blob/trunk/Biasing/python/target.py) to the [EaT biasing config](https://github.com/LDMX-Software/ldmx-sw/blob/trunk/Biasing/python/eat.py#L168). 
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
<img width="605" height="431" alt="primary_daughter_start-z" src="https://github.com/user-attachments/assets/86ef4899-8f09-4d38-a387-b77ef53cda94" />
<img width="605" height="431" alt="primary_daughter_pdgid" src="https://github.com/user-attachments/assets/31f8bfa8-b520-4977-a3a3-7b5dad9e60d6" />
<img width="605" height="431" alt="primary_daughter_energy" src="https://github.com/user-attachments/assets/0de018ae-bf80-4040-832b-fe5423a1a240" />
<img width="605" height="431" alt="primary_daughter_end-z" src="https://github.com/user-attachments/assets/c47095f4-35fb-4c37-8209-523e7f876e47" />
<img width="605" height="431" alt="Aprime_daughter_start-z" src="https://github.com/user-attachments/assets/44620694-c133-4a1f-ac6c-1f12083ec583" />
<img width="605" height="431" alt="Aprime_daughter_pdgid" src="https://github.com/user-attachments/assets/cfc05322-8eea-4eb6-9b94-51eb878d132b" />