### PR TITLE
remove `ldmx` in favor of using `denv` in PR Validation

### DIFF
--- a/.github/actions/common.sh
+++ b/.github/actions/common.sh
@@ -6,8 +6,7 @@
 #
 #   Assumptions
 #     - The env variable LDMX_DOCKER_TAG has the image we should be using
-#     - The label for the gold plots is in
-#         .github/actions/validate/gold_label
+#     - The label for the gold plots is in ci-data/label
 #     - ldmx-sw has been checked out using actions/checkout@v2
 #       OR the build package was unpacked to mimic this effect
 #       (this assumption basically means that GITHUB_WORKSPACE points to ldmx-sw)
@@ -19,16 +18,6 @@
 #       source ${GITHUB_ACTION_PATH}/../common.sh
 #     https://docs.github.com/en/actions/reference/environment-variables
 ###############################################################################
-
-# Print the gold label
-ldmx_gold_label() {
-  #  git the commit that last edited any of the validation samples
-  #  use git describe --tags to deduce the tag it is closest to
-  #  cut out the first field which is the name of the closest tag
-  git log -n 1 --pretty=format:"%h" -- ${LDMX_BASE}/ldmx-sw/.github/validation_samples/*/** |\
-    xargs git describe --tags |\
-    cut -f 1 -d -
-}
 
 # GitHub workflow command to set an output key,val pair
 set_output() {

--- a/.github/actions/common.sh
+++ b/.github/actions/common.sh
@@ -30,19 +30,6 @@ ldmx_gold_label() {
     cut -f 1 -d -
 }
 
-# container running command
-#   - Assume LDMX_DOCKER_TAG is the image we run in
-#   - Full command needs to be provided
-#   - Runs inside the present working directory
-ldmx() {
-  docker run \
-    -i -v ${LDMX_BASE}:${LDMX_BASE} -e LDMX_BASE \
-    -e LDMX_NUM_EVENTS -e LDMX_RUN_NUMBER \
-    -u $(id -u $USER):$(id -g $USER) \
-    ${LDMX_DOCKER_TAG} $(pwd) $@
-  return $?
-}
-
 # GitHub workflow command to set an output key,val pair
 set_output() {
   local _key="$1"

--- a/.github/actions/validate/validate.sh
+++ b/.github/actions/validate/validate.sh
@@ -39,7 +39,7 @@ __main__() {
 
   # assume sample directory has its config called 'config.py'
   start_group Run config.py
-  ldmx fire config.py | tee output.log || return $?
+  denv fire config.py | tee output.log || return $?
   end_group
 
   start_group Compare to Golden Histograms
@@ -47,7 +47,7 @@ __main__() {
     # assume sample directory has its gold histogram called 'gold.root'
     #   compare has 4 CLI inputs:
     #    gold_f, gold_label, test_f, test_label
-    ldmx python3 $GITHUB_ACTION_PATH/compare.py \
+    denv python3 $GITHUB_ACTION_PATH/compare.py \
       ${_ref_dir}/gold.root \
       $(cat ${GITHUB_WORKSPACE}/ci-data/label) \
       hist.root \

--- a/.github/actions/validate/validate.sh
+++ b/.github/actions/validate/validate.sh
@@ -27,6 +27,7 @@ __main__() {
   echo "Sample Name: ${_sample}"
   echo "Sample Dir: ${_sample_dir}"
   echo "Not Running Comparison? ${_no_comp}"
+  denv config env copy LDMX_NUM_EVENTS LDMX_RUN_NUMBER
   end_group
 
   start_group Sample-Specific Initialization

--- a/.github/validation_samples/it_pileup/init.sh
+++ b/.github/validation_samples/it_pileup/init.sh
@@ -9,9 +9,9 @@
 ###############################################################################
 
 start_group Generate Main Events
-ldmx fire gen_main.py
+denv fire gen_main.py
 end_group
 
 start_group Generate Pileup Events
-ldmx fire gen_pileup.py
+denv fire gen_pileup.py
 end_group

--- a/.github/validation_samples/signal/init.sh
+++ b/.github/validation_samples/signal/init.sh
@@ -8,10 +8,7 @@
 ###############################################################################
 
 start_group Produce Dark Brem Library
-curl -s https://tomeichlersmith.github.io/denv/install | sh
-# use docker so we don't have to tell podman to look at the docker.io registry
-export DENV_RUNNER=docker
-denv init ldmx/dark-brem-lib-gen:v5.2.0
+denv init --over ldmx/dark-brem-lib-gen:v5.2.0
 denv dark-brem-lib-gen \
   --run 1 \
   --max-energy 8.0 \

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -64,7 +64,7 @@ When validating, this action is roughly equivalent to the following procedure.
 (Look at the `.github/actions/validate` directory for the details.)
 
 - Download the latest `ci-data`: `git clone https://github.com/LDMX-Software/ci-data.git`
-- Set-up ldmx to use `dev latest`: `just pull dev latest`
+- Set-up ldmx to use `dev latest`: `just pull ldmx/dev:latest`
 - Compile and Install ldmx-sw: `just compile`
 - Go to the sample of your choosing: `cd .github/validation_samples/<sample>/`
 - Run the configuration: `just setenv LDMX_RUN_NUMBER=1; just setenv LDMX_NUM_EVENTS=10000; just fire config.py`

--- a/.github/workflows/new_pre_release.yml
+++ b/.github/workflows/new_pre_release.yml
@@ -73,6 +73,8 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         tar xf ldmx-sw-package.tar
 
+    - run: just install-denv init
+
     - name: Run ${{matrix.sample}} ${{matrix.run}}
       id: validation
       uses: ./.github/actions/validate
@@ -100,6 +102,8 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         tar xf ldmx-sw-build-${GITHUB_SHA}/ldmx-sw-package.tar
 
+    - run: just install-denv init
+
     - name: Package Histograms together for Release
       id: packaging
       run: |
@@ -108,7 +112,7 @@ jobs:
         _hists=$(pwd)/hists-out
         set_output hists "${_hists}/*"
         for s in inclusive ecal_pn it_pileup; do
-          ldmx hadd ${_hists}/${s}.root ${s}-*-hists/*
+          denv hadd ${_hists}/${s}.root ${s}-*-hists/*
         done
       shell: bash
 

--- a/.github/workflows/new_pre_release.yml
+++ b/.github/workflows/new_pre_release.yml
@@ -73,6 +73,8 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         tar xf ldmx-sw-package.tar
 
+    - uses: extractions/setup-just@v3
+
     - run: just install-denv init
 
     - name: Run ${{matrix.sample}} ${{matrix.run}}
@@ -101,6 +103,8 @@ jobs:
       run: |
         cd ${GITHUB_WORKSPACE}
         tar xf ldmx-sw-build-${GITHUB_SHA}/ldmx-sw-package.tar
+
+    - uses: extractions/setup-just@v3
 
     - run: just install-denv init
 

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -104,6 +104,8 @@ jobs:
         submodules: 'recursive'
         fetch-depth: 0
         ref: ${{ env.HEAD_REF }}
+          
+    - uses: extractions/setup-just@v3
 
     - run: just install-denv init
 

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -105,6 +105,8 @@ jobs:
         fetch-depth: 0
         ref: ${{ env.HEAD_REF }}
 
+    - run: just install-denv init
+
     - name: Download ldmx-sw Package
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1804 

While this isn't a full refactoring of the CI, it is a good first draft to test run replacing the entrypoint-based running with the `denv`-based running.
