### PR TITLE
Shift TS pad-3 to match LYSO in the default geometry

### DIFF
--- a/ComparePlots/__main__.py
+++ b/ComparePlots/__main__.py
@@ -26,7 +26,7 @@ from ._plotter import plotter
 
 # guard incase someone imports this somehow
 if __name__ == '__main__' :
-    parser = argparse.ArgumentParser("python3 -m Validation",
+    parser = argparse.ArgumentParser("just compare-plots",
         description="""
         Make comparison plots between different files within a directory.
 

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -642,7 +642,7 @@ class DarkBremInteraction(ldmxcfg.Producer) :
 
         # weird binning so we can see the target and trigger pads
         self.build1DHistogram('dark_brem_z',
-            'Z Location of Dark Brem [mm]', 120, -5., 1.)
+            'Z Location of Dark Brem [mm]', 160, -7., 1.)
         # elements are hydrogen and carbon (for trigger pads) and tungsten target
         self.build1DHistogram('dark_brem_element',
             'Element in which Dark Brem Occurred',

--- a/Detectors/data/ldmx-det-v15-8gev/constants.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/constants.gdml
@@ -49,7 +49,9 @@
 <constant name="trigger_pad_offset"    
           value="(target_dim_y - (number_of_bars*trigger_bar_dy + (number_of_bars - 1)*trigger_pad_bar_gap))/2" />
 
-<!-- Trigger pad distance from the target is -2.4262 --> 
+<!-- Trigger pad setup --> 
+<constant name="trigger_gap_from_target"
+          value="1.4248*mm" />
 <constant name="trig_scint_pad12_separation"
           value="60"/>
 <constant name="trigger_pad1_z"
@@ -57,7 +59,7 @@
 <constant name="trigger_pad2_z"    
           value="-(trigger_pad_thickness/2) - clearance" />
 <constant name="trigger_pad3_z"      
-          value="target_z - (target_thickness/2) - (trigger_pad_thickness/2) - clearance" />
+          value="target_z - (target_thickness/2) - (trigger_pad_thickness/2) - trigger_gap_from_target - clearance" />
 
 <!-- Parent volume dimensions --> 
 <constant name="trig_scint_area_envelope_x" value="magnet_gap_dx - 5" />

--- a/Detectors/data/ldmx-det-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/target.gdml
@@ -15,7 +15,8 @@
     <!-- Parent volume dimensions --> 
     <constant name="target_area_envelope_x" value="magnet_gap_dx - 5" />
     <constant name="target_area_envelope_y" value="magnet_gap_dy - 5" />
-    <constant name="target_area_envelope_z" value="2*(target_thickness/2 + 2*clearance + trigger_pad_thickness)" />
+    <constant name="target_area_envelope_z" 
+              value="2*(target_thickness/2 + 2*clearance + + trigger_gap_from_target + trigger_pad_thickness)" />
 
   </define>
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1759

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.

This shows that LYSO and now the default in v15 has the TS at the same Z:
<img width="796" height="572" alt="dark_brem_z_comparison" src="https://github.com/user-attachments/assets/65094b84-4115-4e3d-8621-67ca35c426fb" />

