### PR TITLE
LHEReader readline fixes

### DIFF
--- a/SimCore/src/SimCore/LHE/LHEReader.cxx
+++ b/SimCore/src/SimCore/LHE/LHEReader.cxx
@@ -16,8 +16,10 @@ std::unique_ptr<LHEEvent> LHEReader::readNextEvent() {
   std::string line;
   bool found_event_element = false;
   while (getline(ifs_, line)) {
-    auto back  = std::find_if_not(line.rbegin(), line.rend(),
-                                         [](unsigned char c){ return std::isspace(c); }).base();
+    auto back =
+        std::find_if_not(line.rbegin(), line.rend(), [](unsigned char c) {
+          return std::isspace(c);
+        }).base();
     line.erase(back, line.end());
     if (line == "<event>") {
       found_event_element = true;
@@ -36,9 +38,11 @@ std::unique_ptr<LHEEvent> LHEReader::readNextEvent() {
   auto next_event = std::make_unique<LHEEvent>(line);
 
   while (getline(ifs_, line)) {
-    auto back  = std::find_if_not(line.rbegin(), line.rend(),
-                                         [](unsigned char c){ return std::isspace(c); }).base();
-    line.erase(back, line.end());    
+    auto back =
+        std::find_if_not(line.rbegin(), line.rend(), [](unsigned char c) {
+          return std::isspace(c);
+        }).base();
+    line.erase(back, line.end());
     if (line == "</event>" || line == "<mgrwt>") {
       // break if the event ended or in LHE 3.0 if we reach the mgrwt block
       break;

--- a/SimCore/src/SimCore/LHE/LHEReader.cxx
+++ b/SimCore/src/SimCore/LHE/LHEReader.cxx
@@ -16,6 +16,9 @@ std::unique_ptr<LHEEvent> LHEReader::readNextEvent() {
   std::string line;
   bool found_event_element = false;
   while (getline(ifs_, line)) {
+    auto back  = std::find_if_not(line.rbegin(), line.rend(),
+                                         [](unsigned char c){ return std::isspace(c); }).base();
+    line.erase(back, line.end());
     if (line == "<event>") {
       found_event_element = true;
       break;
@@ -33,6 +36,9 @@ std::unique_ptr<LHEEvent> LHEReader::readNextEvent() {
   auto next_event = std::make_unique<LHEEvent>(line);
 
   while (getline(ifs_, line)) {
+    auto back  = std::find_if_not(line.rbegin(), line.rend(),
+                                         [](unsigned char c){ return std::isspace(c); }).base();
+    line.erase(back, line.end());    
     if (line == "</event>" || line == "<mgrwt>") {
       // break if the event ended or in LHE 3.0 if we reach the mgrwt block
       break;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details. Added checks for common whitespace character at line endings.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
