### PR TITLE
compare ratio of weighted histograms

### DIFF
--- a/ComparePlots/_differ.py
+++ b/ComparePlots/_differ.py
@@ -156,7 +156,8 @@ class Differ :
                 ax = ratio_ax,
                 yerr = hist.intervals.ratio_uncertainty(
                     num = num_h.values(),
-                    denom = den_h.values()
+                    denom = den_h.values(),
+                    uncertainty_type = 'poisson-ratio'
                 ),
                 histtype='errorbar',
                 color = num_art[0].stairs.get_edgecolor()

--- a/ComparePlots/_differ.py
+++ b/ComparePlots/_differ.py
@@ -9,6 +9,7 @@ import matplotlib
 import uproot
 import numpy as np
 import hist.intervals
+import mplhep
 
 # us
 from ._file import File
@@ -144,7 +145,9 @@ class Differ :
         den_h, _den_art = raw_histograms[0]
         bins = den_h.axes[0].edges
         for num_h, num_art in raw_histograms[1:]:
-            (den_h/num_h).plot1d(
+            mplhep.histplot(
+                (num_h.values()/den_h.values()),
+                bins = bins,
                 ax = ratio_ax,
                 yerr = hist.intervals.ratio_uncertainty(
                     num = num_h.values(),

--- a/ComparePlots/_differ.py
+++ b/ComparePlots/_differ.py
@@ -145,8 +145,13 @@ class Differ :
         den_h, _den_art = raw_histograms[0]
         bins = den_h.axes[0].edges
         for num_h, num_art in raw_histograms[1:]:
+            # NumPy nicely warns us when we divide by zero,
+            # but its defaults are sensible to use
+            # x/0 = inf, 0/0 = nan
+            with np.errstate(divide="ignore", invalid="ignore"):
+                ratio = num_h.values() / den_h.values()
             mplhep.histplot(
-                (num_h.values()/den_h.values()),
+                ratio,
                 bins = bins,
                 ax = ratio_ax,
                 yerr = hist.intervals.ratio_uncertainty(


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1831 by avoiding direct division of two histogram objects. We can use the `ratio_uncertainty` function from `hist.intervals` to estimate error bars for the ratio still and we can use the `poisson-ratio` uncertainty type to pass on our intent.
