### PR TITLE
Fix typos in tracking module asserts

### DIFF
--- a/Tracking/include/Tracking/Sim/IndexSourceLink.h
+++ b/Tracking/include/Tracking/Sim/IndexSourceLink.h
@@ -78,7 +78,7 @@ struct IndexSourceLinkAccessor
 
   // get the range of elements with requested geoId
   std::pair<Iterator, Iterator> range(const Acts::Surface& surface) const {
-    assert(container != nullptr);
+    assert(container_ != nullptr);
     auto [begin, end] = container_->equal_range(surface.geometryId());
     return {Iterator{begin}, Iterator{end}};
   }

--- a/Tracking/include/Tracking/Sim/MeasurementCalibrator.h
+++ b/Tracking/include/Tracking/Sim/MeasurementCalibrator.h
@@ -62,9 +62,9 @@ class LdmxMeasurementCalibrator {
                  typename traj_t::TrackStateProxy trackState) const {
     acts_examples::IndexSourceLink source_link{
         genericSourceLink.get<acts_examples::IndexSourceLink>()};
-    assert(m_measurements and
+    assert(m_measurements_ and
            "Undefined measurement container in LdmxMeasurementCalibrator");
-    assert((sourceLink.index() < m_measurements->size()) and
+    assert((source_link.index() < m_measurements_->size()) and
            "Source link index is outside the container bounds in "
            "LdmxMeasurementCalibrator");
 
@@ -105,9 +105,9 @@ class LdmxMeasurementCalibrator {
     acts_examples::IndexSourceLink source_link{
         genericSourceLink.get<acts_examples::IndexSourceLink>()};
 
-    assert(m_measurements and
+    assert(m_measurements_ and
            "Undefined measurement container in LdmxMeasurementCalibrator");
-    assert((sourceLink.index() < m_measurements->size()) and
+    assert((source_link.index() < m_measurements_->size()) and
            "Source link index is outside the container bounds in "
            "LdmxMeasurementCalibrator");
 


### PR DESCRIPTION
### What are the issues that this addresses?
Fixes the assert typos in IndexSourceLink.h and MeasurementCalibrator.h that failed to compile, as described in: #1851 

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.

```
[...]
[ 98%] Built target Biasing_Utility
[ 98%] Built target g4-vis
[100%] Built target Biasing
Install the project...
-- Install configuration: "Debug"
-- Up-to-date: /home/ewallin/Programming/dndebug/ldmx-sw/install/lib/libRecon_Event.so
[...]
```

It now compiles in the debug build!
