### PR TITLE
Include correct layer weights for v15 ECAL

### DIFF
--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -328,8 +328,8 @@ class EcalDigiVerify(ldmxcfg.Analyzer) :
                 "Reconstructed Amplitude [MeV]" , 1000 , 0. , 50. )
 
         self.build2DHistogram( "sim_edep:rec_energy" ,
-                "Simulated Energy [MeV]" , 1000 , 0. , 50. ,
-                "Reconstructed Energy [MeV]" , 1000 , 0. , 50. )
+                "Simulated Energy [MeV]" , 1000 , 0. , 20. ,
+                "Reconstructed Energy [MeV]" , 1000 , 0. , 2000. )
 
 class EcalShowerFeatures(ldmxcfg.Analyzer) :
     """Configured EcalShowerFeatures python object """

--- a/Ecal/python/digi.py
+++ b/Ecal/python/digi.py
@@ -225,13 +225,14 @@ class EcalRecProducer(Producer) :
         The mean of the resulting total recon energy is found by fitting a two-sided normal
         distribution (one mean, a low and high deviation) to the histogram.
         """
-
-        self.secondOrderEnergyCorrection = 1. #8000. / 7998.3
-        self.layerWeights = [ 
-                1.743, 3.401, 5.610, 6.715, 7.820, 10.030, 11.135, 11.135, 11.135, 11.135, 11.135, 
-                11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 
-                11.135, 15.555, 18.869, 18.869, 18.869, 18.869, 18.869, 18.869, 18.869, 9.478
-                ]
+        self.secondOrderEnergyCorrection = 8000. / 7332.8
+        # these layer weights were the 'dE' column of the table output by Detectors/util/ecal_layer_stack.py
+        self.layerWeights = [
+            1.743, 3.401, 5.610, 6.715, 7.820, 10.030, 11.135, 11.135, 11.135, 11.135,
+            11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135,
+            11.135, 11.135, 11.135, 15.555, 18.869, 18.869, 18.869, 18.869, 18.869, 18.869,
+            18.869, 9.478
+        ]
 
     def reduced_v2(self) :
         """Generated for the reduced v2 geometry

--- a/Ecal/python/digi.py
+++ b/Ecal/python/digi.py
@@ -148,7 +148,7 @@ class EcalRecProducer(Producer) :
         # use helper functions to set these
         self.secondOrderEnergyCorrection = 1.
         self.layerWeights = [ ]
-        self.v14()
+        self.v15()
 
     def v2(self) :
         """These layerWeights and energy correction were calculated at least before v3 geometry.
@@ -172,7 +172,7 @@ class EcalRecProducer(Producer) :
         electron events with 4GeV.
         """
 
-        self.secondOrderEnergyCorrection = 4000. / 4012.;
+        self.secondOrderEnergyCorrection = 4000. / 4012.
         self.layerWeights = [
             1.019, 1.707, 3.381, 5.022, 6.679, 8.060, 8.613, 8.613, 8.613, 8.613, 8.613,
             8.613, 8.613, 8.613, 8.613, 8.613, 8.613, 8.613, 8.613, 8.613, 8.613, 8.613,
@@ -206,7 +206,7 @@ class EcalRecProducer(Producer) :
 
         #self.secondOrderEnergyCorrection = 4000. / 3940.5
         self.secondOrderEnergyCorrection = 8000. / 7998.3
-        # these layer weights were the 'dE' column of the table output by Detetectors/util/ecal_layer_stack.py
+        # these layer weights were the 'dE' column of the table output by Detectors/util/ecal_layer_stack.py
         # See https://github.com/LDMX-Software/ldmx-sw/issues/1725
         # TLDR: these are wrong but only off by an absolute value of ~0.2, future detector versions
         # use the newer script with fixed material properties
@@ -215,6 +215,22 @@ class EcalRecProducer(Producer) :
                 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915, 10.915,
                 10.915, 10.915, 14.783, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539, 18.539,
                 18.539, 18.539, 9.938
+                ]
+
+    def v15(self) :
+        """Generated for the v15 geometry
+
+        The secondOrderEnergyCorrection is deteremined by generating 1M single 4GeV or 8GeV
+        electron events shot directly into the front of the ECal from immediately upstream.
+        The mean of the resulting total recon energy is found by fitting a two-sided normal
+        distribution (one mean, a low and high deviation) to the histogram.
+        """
+
+        self.secondOrderEnergyCorrection = 1. #8000. / 7998.3
+        self.layerWeights = [ 
+                1.743, 3.401, 5.610, 6.715, 7.820, 10.030, 11.135, 11.135, 11.135, 11.135, 11.135, 
+                11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 11.135, 
+                11.135, 15.555, 18.869, 18.869, 18.869, 18.869, 18.869, 18.869, 18.869, 9.478
                 ]
 
     def reduced_v2(self) :


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1850

Having it as draft, since I want my students to measure the secondary correction too if we are there already

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.

I ran the ecal CI and it technically works
