### PR TITLE
Elaborate log diff in check.sh

### DIFF
--- a/.github/actions/check/check.sh
+++ b/.github/actions/check/check.sh
@@ -27,7 +27,8 @@ __main__() {
   # unpack the logs so we can compare them
   tar xzf ${_archive} gold.log output.log
 
-  if ! diff gold.log output.log > log.diff; then
+  # use sed replace (by blank) to run the diff without the initial HH:MM:SS timestamp
+  if ! diff  -I '^#' <(sed -e 's/^[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}/ /g' gold.log) <(sed -e 's/^[0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}/ /g' output.log) > log.diff; then
     # do not error out (don't set rc here) if diff is non-zero, the timestamps printed out
     # by some processors prevent a full text diff so we do the character
     # count check below to look for big changes

--- a/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalPnetVetoProcessor.cxx
@@ -131,7 +131,7 @@ void EcalPnetVetoProcessor::produce(framework::Event& event) {
     result.setDiscValue(-99);
   }
 
-  ldmx_log(info) << "ParticleNet disc value = " << result.getDisc();
+  ldmx_log(debug) << "ParticleNet disc value = " << result.getDisc();
 
   result.setVetoResult(result.getDisc() > disc_cut_);
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

I added a sed replace to skip the HH:MM:SS timestamp at the beginning of a line in the log comparisons. For the reconstruction time comparison part, some more discussion is needed (comments on #1870 welcome).

### What are the issues that this addresses?
This partially resolves #1870

## Check List
- [x] I ran my developments and the following shows that they are successful: CI tests work as intended
<!-- put plots or some other proof that your developments work and do the intended function -->
