### PR TITLE
Made Ecal face start not hardcoded (#1887)

### DIFF
--- a/DetDescr/include/DetDescr/EcalGeometry.h
+++ b/DetDescr/include/DetDescr/EcalGeometry.h
@@ -209,6 +209,12 @@ class EcalGeometry : public framework::ConditionsObject {
   }
 
   /**
+   * Get the z-coordinate of the Ecal face
+   * @return z-coordinate of the Ecal face
+   */
+  double getEcalFrontZ() const { return ecal_front_z_; }
+
+  /**
    * Get the number of layers in the Ecal Geometry
    *
    * @returns number fo layers in geometry

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -754,7 +754,8 @@ void EcalVetoProcessor::produce(framework::Event &event) {
   // Find the location of the recoil electron
   // Ecal face is not where the first layer_ starts,
   // defined in DetDescr/python/EcalGeometry.py
-  const float dz_from_face{7.932};
+  const float dz_from_face =
+      (geometry_->getZPosition(0)) - (geometry_->getEcalFrontZ());
   float drifted_recoil_x{-9999.};
   float drifted_recoil_y{-9999.};
   if (recoil_p[2] > 0.) {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1887 by changing the [Ecal first layer z position declaration](https://github.com/LDMX-Software/ldmx-sw/blob/5573e3abe55a6c47cf1440c740d6b9c8c875a079/Ecal/src/Ecal/EcalVetoProcessor.cxx#L757) from the magic number 7.932 (which since it was set is now out of date and incorrect) to a configurable declaration dependent on the specified detector geometry.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Upon adding a temporary `ldmx_log(info)` line to print the result of `geometry_->getZPosition(0)` in the EcalVetoProcessor, the following was returned repeatedly when processing events.
<img width="902" height="156" alt="Screenshot 2025-12-01 at 13 38 34" src="https://github.com/user-attachments/assets/b442372a-a2cc-4a2b-95b7-da7b9386285d" />

With the adjustment of `geometry_->getEcalFrontZ()` in the `dz_from_face` variable definition, the following was observed.
<img width="895" height="157" alt="Screenshot 2025-12-01 at 13 54 01" src="https://github.com/user-attachments/assets/bc859949-5469-4efc-b6d0-95b4e5bb3dc0" />

This matches the v14 geometry from [here](https://github.com/LDMX-Software/ldmx-sw/blob/5573e3abe55a6c47cf1440c740d6b9c8c875a079/DetDescr/python/EcalGeometry.py#L116), as specified in the relevant config file. 
