### PR TITLE
Move G4 msgs to ldmx logging

### DIFF
--- a/SimCore/include/SimCore/G4Session.h
+++ b/SimCore/include/SimCore/G4Session.h
@@ -2,103 +2,65 @@
  * @file G4Session.h
  * @brief Classes which redirect the output of G4cout and G4cerr
  * @author Tom Eichlersmith, University of Minnesota
+ * @author Tamas Almos Vami, UCSB
  */
 
-#ifndef SIMCORE_G4SESSION_H_
-#define SIMCORE_G4SESSION_H_
+#ifndef SIMCORE_G4SESSION_H
+#define SIMCORE_G4SESSION_H
 
-#include <fstream>
-#include <iostream>
+#include <algorithm>
+#include <string>
 
-// Geant4
+#include "Framework/Logger.h"
 #include "G4UIsession.hh"
 
 namespace simcore {
 
 /**
  * @class LoggedSession
+ * @brief Session that routes G4cout and G4cerr through the Framework logger
  *
- * Log the output of Geant4 to files in current directory.
+ * This session intercepts all Geant4 output and routes it through the
+ * Framework's logging system with the logger name "Geant4". Messages are
+ * parsed to determine appropriate log levels:
+ * - G4cout with "WARNING" -> warn
+ * - G4cout with "ERROR" -> error
+ * - G4cout with verbose tracking info -> trace
+ * - G4cout default -> debug
+ * - G4cerr with "ERROR" or "FATAL" -> error
+ * - G4cerr default -> warn
  */
 class LoggedSession : public G4UIsession {
  public:
   /**
-   * Constructor
-   *
-   * Sets up output file streams for the cout and cerr paths.
+   * Constructor - creates a logger named "Geant4"
    */
-  LoggedSession(const std::string& coutFileName = "G4cout.log",
-                const std::string& cerrFileName = "G4cerr.log");
+  LoggedSession(std::string logging_prefix = "Geant4");
 
   /**
    * Destructor
-   *
-   * Closes the output files streams
    */
-  ~LoggedSession();
+  ~LoggedSession() override = default;
 
   /**
-   * Required hook for Geant4
-   *
-   * Does nothing
+   * Receive a message from G4cout
+   * @param message The message from Geant4
+   * @return 0 for success
    */
-  G4UIsession* SessionStart() { return nullptr; }
+  G4int ReceiveG4cout(const G4String& message) override;
 
   /**
-   * Redirects cout to file
+   * Receive a message from G4cerr
+   * @param message The message from Geant4
+   * @return 0 for success
    */
-  G4int ReceiveG4cout(const G4String& message);
-
-  /**
-   * Redirects cerr to file
-   */
-  G4int ReceiveG4cerr(const G4String& message);
+  G4int ReceiveG4cerr(const G4String& message) override;
 
  private:
-  /** cout log file */
-  std::ofstream cout_file_;
-
-  /** cerr log file */
-  std::ofstream cerr_file_;
-
-};  // LoggedSession
-
-/**
- * @class BatchSession
- *
- * Do _nothing_ with G4cout and G4cerr messages. This is made to improve
- * performance.
- */
-class BatchSession : public G4UIsession {
- public:
-  /**
-   * Constructor
-   */
-  BatchSession() {}
-
-  /**
-   * Destructor
-   */
-  ~BatchSession() {}
-
-  /**
-   * Required hook for Geant4
-   *
-   * Does nothing
-   */
-  G4UIsession* SessionStart() { return nullptr; }
-
-  /**
-   * Does nothing with input
-   */
-  G4int ReceiveG4cout(const G4String&) { return 0; }
-
-  /**
-   * Does nothing with input
-   */
-  G4int ReceiveG4cerr(const G4String&) { return 0; }
+  /// Framework logger for Geant4 messages
+  mutable framework::logging::logger the_log_;
 };
 
 }  // namespace simcore
 
-#endif
+#endif  // SIMCORE_G4SESSION_H

--- a/SimCore/include/SimCore/SimulatorBase.h
+++ b/SimCore/include/SimCore/SimulatorBase.h
@@ -49,7 +49,7 @@ class SimulatorBase : public framework::Producer {
   std::unique_ptr<RunManager> run_manager_;
 
   /// Handle to the G4Session -> how to deal with G4cout and G4cerr
-  std::unique_ptr<G4UIsession> session_handle_;
+  std::unique_ptr<LoggedSession> session_handle_;
 
   /// Commands not allowed to be passed from python config file
   ///     This is because Simulator already runs them.

--- a/SimCore/python/simulator.py
+++ b/SimCore/python/simulator.py
@@ -97,7 +97,7 @@ class simulator(Producer):
         self.postInitCommands = [ ]
         self.actions = [ ]
         self.biasing_operators = [ ]
-        self.logging_prefix = ''
+        self.logging_prefix = 'GEANT4'
         self.rootPrimaryGenUseSeed = False
         self.validate_detector = False
         self.verbosity = 0

--- a/SimCore/src/SimCore/G4Session.cxx
+++ b/SimCore/src/SimCore/G4Session.cxx
@@ -1,44 +1,37 @@
-/**
- * @file G4Session.cxx
- * @brief Classes which redirect the output of G4cout and G4cerr
- * @author Tom Eichlersmith, University of Minnesota
- */
-
 #include "SimCore/G4Session.h"
-
-#include "Framework/Exception/Exception.h"
 
 namespace simcore {
 
-LoggedSession::LoggedSession(const std::string& coutFileName,
-                             const std::string& cerrFileName) {
-  cout_file_.open(coutFileName);
-  if (not cout_file_.is_open()) {
-    EXCEPTION_RAISE("G4Logging",
-                    "Unable to open log file '" + coutFileName + "'.");
+LoggedSession::LoggedSession(std::string logging_prefix)
+    : the_log_{::framework::logging::makeLogger(logging_prefix)} {}
+
+G4int LoggedSession::ReceiveG4cout(const G4String& msg) {
+  std::string message = msg;
+  std::transform(message.begin(), message.end(), message.begin(), ::toupper);
+
+  if (message.find("WARNING") != std::string::npos) {
+    ldmx_log(warn) << msg;
+  } else if (message.find("ERROR") != std::string::npos) {
+    ldmx_log(error) << msg;
+  } else {
+    ldmx_log(debug) << msg;
   }
 
-  cerr_file_.open(cerrFileName);
-  if (not cerr_file_.is_open()) {
-    EXCEPTION_RAISE("G4Logging",
-                    "Unable to open log file '" + cerrFileName + "'.");
+  return 0;
+}
+
+G4int LoggedSession::ReceiveG4cerr(const G4String& msg) {
+  std::string message = msg;
+  std::transform(message.begin(), message.end(), message.begin(), ::toupper);
+
+  if (message.find("ERROR") != std::string::npos ||
+      message.find("FATAL") != std::string::npos) {
+    ldmx_log(error) << msg;
+  } else {
+    ldmx_log(debug) << msg;
   }
+
+  return 0;
 }
 
-LoggedSession::~LoggedSession() {
-  cout_file_.close();
-  cerr_file_.close();
-}
-
-G4int LoggedSession::ReceiveG4cout(const G4String& message) {
-  cout_file_ << message;
-  cout_file_.flush();
-  return 0;  // 0 return value == sucess
-}
-
-G4int LoggedSession::ReceiveG4cerr(const G4String& message) {
-  cerr_file_ << message;
-  cerr_file_.flush();
-  return 0;  // 0 return value == sucess
-}
 }  // namespace simcore

--- a/SimCore/src/SimCore/SimulatorBase.cxx
+++ b/SimCore/src/SimCore/SimulatorBase.cxx
@@ -146,10 +146,7 @@ void SimulatorBase::configure(framework::config::Parameters& parameters) {
 }
 void SimulatorBase::createLogging() {
   auto logging_prefix = parameters_.get<std::string>("logging_prefix");
-  // For now dont print out anything from GEANT
-  // Next step is to modify G4Session to print everything into our logging
-  // system
-  session_handle_ = std::make_unique<BatchSession>();
+  session_handle_ = std::make_unique<LoggedSession>(logging_prefix);
 
   if (session_handle_ != nullptr)
     ui_manager_->SetCoutDestination(session_handle_.get());


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1319

It's the last bit of https://github.com/LDMX-Software/ldmx-sw/issues/1319

But also needed for running the detector validation, and given that we have 3 PRs ready with GMDL changes I thought it's time to do this.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

<details>
  <summary>Output</summary>
denv_workspace="/sdf/group/ldmx/users/tamasvami/iss1319-G4Session-Logging/ldmx-sw" denv fire .github/validation_samples/ecal_pn/config.py 
---- LDMXSW: Loading configuration --------
Setting detector for tracking to ldmx-det-v14-8gev-no-cals
Setting detector for tracking to ldmx-det-v14-8gev
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Air
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Carbon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Silicon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Polyvinyltoluene
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Air
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Carbon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Silicon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_AIR
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_AIR
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ TruthSeedProcessor ] 0  info: Seed Smearing is set to false
---- LDMXSW: Configuration load complete  --------
---- LDMXSW: Starting event processing --------
[ RunManager ] 0  info:  Biasing enabled with 1 operator(s)
[ RunManager ] 0  info: Biasing operator 'ecal_bias_pn' set to bias gamma
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: Warning : Region <CalorimeterRegion> does not have specific production cuts,
[ GEANT4 ] 0  warn: Warning : Region <MagnetRegion> does not have specific production cuts,
[ GEANT4 ] 0  warn: Warning : Region <tagger> does not have specific production cuts,
[ GEANT4 ] 0  warn: Warning : Region <trig_scint> does not have specific production cuts,
[ GEANT4 ] 0  warn: Warning : Region <target> does not have specific production cuts,
[ ecal_bias_pn ] 0  info: Biasing particles of type gamma
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Air
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Carbon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Silicon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Air
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Carbon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Silicon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Tungsten
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Polyvinyltoluene
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Polyvinyltoluene
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Air
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Carbon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Silicon
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_Al
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material FR4
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Glue
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_Si
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material CarbonEpoxyComposite
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_AIR
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_W
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_C
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material G4_AIR
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Steel
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Scintillator
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Vacuum
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Fe
[ GEANT4 ] 0  warn: G4Material WARNING: duplicate name of material Cu
[ TrackersTrackingGeometry ] 0  info: x_length = 609 y_length = 480 z_length = 240
[ TrackersTrackingGeometry ] 0  info: x_length = 181 y_length = 480 z_length = 240
[ Process ] 0  info: RunHeader { run: 1, numTries: 0, detectorName: ldmx-det-v15-8gev, description: ECal PN Test Simulation
  intParameters: 
    BiasOperators::PhotoNuclear::Bias Conv Down = 1
    BiasOperators::PhotoNuclear::Only Children Of Primary = 1
    Included Scoring Planes = 1
    RandomNumberMasterSeed[test] = 1
    Use Random Seed from Event Header = 0
  floatParameters: 
    BiasOperators::PhotoNuclear::Factor = 550
    BiasOperators::PhotoNuclear::Threshold = 5000
    Gen0 Direction X = 0.0485658
    Gen0 Direction Y = 0
    Gen0 Direction Z = 0.99882
    Gen0 Energy [GeV] = 8
    Gen0 Time [ns] = 0
    Gen0 X [mm] = -21.7459
    Gen0 Y [mm] = 0
    Gen0 Z [mm] = -883
    Smear Beam Spot [mm] X = 20
    Smear Beam Spot [mm] Y = 80
    Smear Beam Spot [mm] Z = 0
  stringParameters: 
    BiasOperators::PhotoNuclear::Volume = ecal
    Geant4 revision = 
    Gen0 Class = simcore::generators::ParticleGun
    Gen0 Particle = e-
    Pass = test, version = v4.5.4
    SIM revision = 8b486cf30dc2fbc54942d392274d850b798af7e1
    SIM version = v4.5.4
}
[ ecal_photonNuclear_filter ] 1  info:  Brem photon produced 12 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 1  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 1  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 1  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 1  info: Number of CKF tracks 1
[ GreedySolverTagger ] 1  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 1  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 1  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 1  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 1  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 1  info: Using CLUE clustering algorithm
[ CLUE ] 1  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 1  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 1  info:  BDT was ran, score is 0.000108123
[ ecalVeto ] 1  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 1  info: Finding linreg tracks from a total of 49 hits using a radius of 35 mm
[ ecalMipTracking ] 1  info:  MIP tracking completed; found 5 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 1  info: There are 74 / 123 HCal hits read out. 74 are not associated with the recoil ele. Total PE of 6500
[ hcalVeto ] 1  info: HCAL veto passed? false
[ ElectronCounter ] 1  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 1  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 1  info: Got trigger energy sum 3528.86; and decision is pass = false
[ EcalClusterAnalyzer ] 1  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 1  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 2  info:  Brem photon produced 30 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 2  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 2  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 2  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 2  info: Number of CKF tracks 1
[ GreedySolverTagger ] 2  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 2  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 2  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 2  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 2  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 2  info: Using CLUE clustering algorithm
[ CLUE ] 2  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 2  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 2  info:  BDT was ran, score is 0.000151157
[ ecalVeto ] 2  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 2  info: Finding linreg tracks from a total of 53 hits using a radius of 35 mm
[ ecalMipTracking ] 2  info:  MIP tracking completed; found 0 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 2  info: There are 27 / 70 HCal hits read out. 27 are not associated with the recoil ele. Total PE of 158
[ hcalVeto ] 2  info: HCAL veto passed? false
[ ElectronCounter ] 2  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 2  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 2  info: Got trigger energy sum 6747.13; and decision is pass = false
[ EcalClusterAnalyzer ] 2  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 2  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 3  info:  Brem photon produced 15 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 3  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 3  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 3  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 3  info: Number of CKF tracks 1
[ GreedySolverTagger ] 3  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 3  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 3  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 3  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 3  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 3  info: Using CLUE clustering algorithm
[ CLUE ] 3  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 3  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 3  info:  BDT was ran, score is 2.59876e-05
[ ecalVeto ] 3  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 3  info: Finding linreg tracks from a total of 85 hits using a radius of 35 mm
[ ecalMipTracking ] 3  info:  MIP tracking completed; found 4 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 3  info: There are 27 / 62 HCal hits read out. 27 are not associated with the recoil ele. Total PE of 186
[ hcalVeto ] 3  info: HCAL veto passed? false
[ ElectronCounter ] 3  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 3  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 3  info: Got trigger energy sum 6565.58; and decision is pass = false
[ EcalClusterAnalyzer ] 3  info: Avg number of clusters per layer: 1
[ EcalClusterAnalyzer ] 3  info: Number of ECal CLUE clusters: 1, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 4  info:  Brem photon produced 7 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 4  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 4  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 4  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 4  info: Number of CKF tracks 1
[ GreedySolverTagger ] 4  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 4  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 4  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 4  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 4  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 4  info: Using CLUE clustering algorithm
[ CLUE ] 4  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 4  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 4  info:  BDT was ran, score is 7.41482e-05
[ ecalVeto ] 4  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 4  info: Finding linreg tracks from a total of 41 hits using a radius of 35 mm
[ ecalMipTracking ] 4  info:  MIP tracking completed; found 3 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 4  info: There are 38 / 102 HCal hits read out. 38 are not associated with the recoil ele. Total PE of 2240
[ hcalVeto ] 4  info: HCAL veto passed? false
[ ElectronCounter ] 4  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 4  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 4  info: Got trigger energy sum 7110.74; and decision is pass = false
[ EcalClusterAnalyzer ] 4  info: Avg number of clusters per layer: 1
[ EcalClusterAnalyzer ] 4  info: Number of ECal CLUE clusters: 1, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 5  info:  Brem photon produced 9 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 5  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 5  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 5  info: Number of RecoilRecoSeeds seed tracks = 0
[ Recoil_TrackFinder ] 5  info: No seed tracks, returning...
[ GreedySolverTagger ] 5  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 5  info:  Resolved to 0 tracks from  0
[ TrackerVetoProcessor ] 5  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 5  info: Recoil requirements passed for 0 tracks
[ TrackerVetoProcessor ] 5  info: Tracker veto failed
[ ecalClusters ] 5  info: Using CLUE clustering algorithm
[ CLUE ] 5  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 5  info:    Is this event is fiducial in ECAL? false
[ ecalVeto ] 5  info:  BDT was ran, score is 0.000583768
[ ecalVeto ] 5  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 5  info: Finding linreg tracks from a total of 51 hits using a radius of 35 mm
[ ecalMipTracking ] 5  info:  MIP tracking completed; found 15 straight tracks and 0 lin-reg tracks
[ EcalPnetVeto ] 5  info:   No recoil track at ECAL
[ hcalVeto ] 5  info: There are 4 / 4 HCal hits read out. 4 are not associated with the recoil ele. Total PE of 6
[ hcalVeto ] 5  info: HCAL veto passed? true
[ ElectronCounter ] 5  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 5  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 5  info: Got trigger energy sum 7309.95; and decision is pass = false
[ EcalClusterAnalyzer ] 5  info: Avg number of clusters per layer: 1
[ EcalClusterAnalyzer ] 5  info: Number of ECal CLUE clusters: 1, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 6  info:  Brem photon produced 8 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 6  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 6  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 6  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 6  info: Number of CKF tracks 1
[ GreedySolverTagger ] 6  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 6  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 6  info: Tagger requirements passed for 0 tracks
[ TrackerVetoProcessor ] 6  info: Recoil requirements passed for 0 tracks
[ TrackerVetoProcessor ] 6  info: Tracker veto failed
[ ecalClusters ] 6  info: Using CLUE clustering algorithm
[ CLUE ] 6  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 6  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 6  info:  BDT was ran, score is 1.43051e-05
[ ecalVeto ] 6  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 6  info: Finding linreg tracks from a total of 71 hits using a radius of 35 mm
[ ecalMipTracking ] 6  info:  MIP tracking completed; found 7 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 6  info: There are 6 / 6 HCal hits read out. 6 are not associated with the recoil ele. Total PE of 9
[ hcalVeto ] 6  info: HCAL veto passed? true
[ ElectronCounter ] 6  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 6  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 6  info: Got trigger energy sum 7254.38; and decision is pass = false
[ EcalClusterAnalyzer ] 6  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 6  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 7  info:  Brem photon produced 15 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 7  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 7  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 7  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 7  info: Number of CKF tracks 1
[ GreedySolverTagger ] 7  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 7  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 7  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 7  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 7  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 7  info: Using CLUE clustering algorithm
[ CLUE ] 7  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 7  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 7  info:  BDT was ran, score is 9.56059e-05
[ ecalVeto ] 7  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 7  info: Finding linreg tracks from a total of 62 hits using a radius of 35 mm
[ ecalMipTracking ] 7  info:  MIP tracking completed; found 5 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 7  info: There are 13 / 28 HCal hits read out. 13 are not associated with the recoil ele. Total PE of 40
[ hcalVeto ] 7  info: HCAL veto passed? false
[ ElectronCounter ] 7  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 7  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 7  info: Got trigger energy sum 5844.69; and decision is pass = false
[ EcalClusterAnalyzer ] 7  info: Avg number of clusters per layer: 1
[ EcalClusterAnalyzer ] 7  info: Number of ECal CLUE clusters: 1, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 8  info:  Brem photon produced 30 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 8  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 8  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 8  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 8  info: Number of CKF tracks 1
[ GreedySolverTagger ] 8  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 8  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 8  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 8  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 8  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 8  info: Using CLUE clustering algorithm
[ CLUE ] 8  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 8  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 8  info:  BDT was ran, score is 3.3617e-05
[ ecalVeto ] 8  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 8  info: Finding linreg tracks from a total of 71 hits using a radius of 35 mm
[ ecalMipTracking ] 8  info:  MIP tracking completed; found 2 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 8  info: There are 22 / 46 HCal hits read out. 22 are not associated with the recoil ele. Total PE of 83
[ hcalVeto ] 8  info: HCAL veto passed? false
[ ElectronCounter ] 8  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 8  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 8  info: Got trigger energy sum 6963.1; and decision is pass = false
[ EcalClusterAnalyzer ] 8  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 8  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 9  info:  Brem photon produced 33 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 9  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 9  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 9  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 9  info: Number of CKF tracks 1
[ GreedySolverTagger ] 9  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 9  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 9  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 9  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 9  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 9  info: Using CLUE clustering algorithm
[ CLUE ] 9  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 9  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 9  info:  BDT was ran, score is 4.33922e-05
[ ecalVeto ] 9  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 9  info: Finding linreg tracks from a total of 53 hits using a radius of 35 mm
[ ecalMipTracking ] 9  info:  MIP tracking completed; found 4 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 9  info: There are 32 / 79 HCal hits read out. 32 are not associated with the recoil ele. Total PE of 1329
[ hcalVeto ] 9  info: HCAL veto passed? false
[ ElectronCounter ] 9  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 9  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 9  info: Got trigger energy sum 4220.96; and decision is pass = false
[ EcalClusterAnalyzer ] 9  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 9  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ ecal_photonNuclear_filter ] 10  info:  Brem photon produced 12 particles via biasWrapper(photonNuclear) process.
[ Tagger_TrackFinder ] 10  info: Number of TaggerRecoSeeds seed tracks = 1
[ Tagger_TrackFinder ] 10  info: Number of CKF tracks 1
[ Recoil_TrackFinder ] 10  info: Number of RecoilRecoSeeds seed tracks = 1
[ Recoil_TrackFinder ] 10  info: Number of CKF tracks 1
[ GreedySolverTagger ] 10  info:  Resolved to 1 tracks from  1
[ GreedySolverRecoil ] 10  info:  Resolved to 1 tracks from  1
[ TrackerVetoProcessor ] 10  info: Tagger requirements passed for 1 tracks
[ TrackerVetoProcessor ] 10  info: Recoil requirements passed for 1 tracks
[ TrackerVetoProcessor ] 10  info: Tracker veto passed, skim will keep the event
[ ecalClusters ] 10  info: Using CLUE clustering algorithm
[ CLUE ] 10  info: Starting CLUE clustering with parameters:dc 5, rc 550, delta_c 10, delta_o 40, nbr_of_layers 1, reclustering false
[ ecalVeto ] 10  info:    Is this event is fiducial in ECAL? true
[ ecalVeto ] 10  info:  BDT was ran, score is 3.39746e-05
[ ecalVeto ] 10  info:  The pred > bdtCutVal = false
[ ecalMipTracking ] 10  info: Finding linreg tracks from a total of 104 hits using a radius of 35 mm
[ ecalMipTracking ] 10  info:  MIP tracking completed; found 6 straight tracks and 0 lin-reg tracks
[ hcalVeto ] 10  info: There are 10 / 21 HCal hits read out. 10 are not associated with the recoil ele. Total PE of 169
[ hcalVeto ] 10  info: HCAL veto passed? false
[ ElectronCounter ] 10  info: Found 1 electrons (tracks) using input collection TriggerPadTracksY_
[ trigger ] 10  info: Got trigger energy cut 3000 for 1 electrons counted in the event.
[ trigger ] 10  info: Got trigger energy sum 7734.45; and decision is pass = false
[ EcalClusterAnalyzer ] 10  info: Avg number of clusters per layer: 0
[ EcalClusterAnalyzer ] 10  info: Number of ECal CLUE clusters: 0, TS counted electrons: 1, SP electrons: 1
[ SimulatorBase ] 10  warn: Started 520 events to produce 10 events.
[ SeedTagger ] 10  info: AVG Time/Event: 0.3 ms
[ SeedTagger ] 10  info: Total Seeds/Events: 10/10
[ SeedTagger ] 10  info: Seeds discarded due to multiple hits on layers 0
[ SeedTagger ] 10  info: not enough seed points 0
[ SeedTagger ] 10  info:  nfailpmin=0
[ SeedTagger ] 10  info:    nfailpmax=0
[ SeedTagger ] 10  info:    nfaild0max=0
[ SeedTagger ] 10  info:    nfaild0min=0
[ SeedTagger ] 10  info:    nfailphicut=0
[ SeedTagger ] 10  info:    nfailthetacut=0
[ SeedTagger ] 10  info:    nfailz0max=0
[ SeedRecoil ] 10  info: AVG Time/Event: 0.2 ms
[ SeedRecoil ] 10  info: Total Seeds/Events: 9/10
[ SeedRecoil ] 10  info: Seeds discarded due to multiple hits on layers 0
[ SeedRecoil ] 10  info: not enough seed points 0
[ SeedRecoil ] 10  info:  nfailpmin=0
[ SeedRecoil ] 10  info:    nfailpmax=0
[ SeedRecoil ] 10  info:    nfaild0max=0
[ SeedRecoil ] 10  info:    nfaild0min=0
[ SeedRecoil ] 10  info:    nfailphicut=0
[ SeedRecoil ] 10  info:    nfailthetacut=0
[ SeedRecoil ] 10  info:    nfailz0max=0
[ Tagger_TrackFinder ] 10  info: found 10 tracks  / 10 nseeds
[ Tagger_TrackFinder ] 10  info: AVG Time/Event: 0.8 ms
[ Tagger_TrackFinder ] 10  info: Breakdown::
[ Tagger_TrackFinder ] 10  info: setup       Avg Time/Event = 0.002 ms
[ Tagger_TrackFinder ] 10  info: hits        Avg Time/Event = 0.08 ms
[ Tagger_TrackFinder ] 10  info: seeds       Avg Time/Event = 0.068 ms
[ Tagger_TrackFinder ] 10  info: cf_setup    Avg Time/Event = 0.007 ms
[ Tagger_TrackFinder ] 10  info: ckf_run     Avg Time/Event = 0.560 ms
[ Tagger_TrackFinder ] 10  info: result_loop Avg Time/Event = 0.0 ms
[ Recoil_TrackFinder ] 10  info: found 9 tracks  / 9 nseeds
[ Recoil_TrackFinder ] 10  info: AVG Time/Event: 0.4 ms
[ Recoil_TrackFinder ] 10  info: Breakdown::
[ Recoil_TrackFinder ] 10  info: setup       Avg Time/Event = 0.001 ms
[ Recoil_TrackFinder ] 10  info: hits        Avg Time/Event = 0.09 ms
[ Recoil_TrackFinder ] 10  info: seeds       Avg Time/Event = 0.025 ms
[ Recoil_TrackFinder ] 10  info: cf_setup    Avg Time/Event = 0.005 ms
[ Recoil_TrackFinder ] 10  info: ckf_run     Avg Time/Event = 0.264 ms
[ Recoil_TrackFinder ] 10  info: result_loop Avg Time/Event = 0.0 ms
[ ecalVeto ] 10  info: AVG Time/Event: 1.02 ms
[ ecalVeto ] 10  info: Breakdown::
[ ecalVeto ] 10  info: setup                  Avg Time/Event = 0.024 ms
[ ecalVeto ] 10  info: recoil_electron        Avg Time/Event = 0.018 ms
[ ecalVeto ] 10  info: trajectories           Avg Time/Event = 0.011 ms
[ ecalVeto ] 10  info: roc_var                Avg Time/Event = 0.002 ms
[ ecalVeto ] 10  info: fill_hitmaps           Avg Time/Event = 0.224 ms
[ ecalVeto ] 10  info: containment_var        Avg Time/Event = 0.006 ms
[ ecalVeto ] 10  info: mip_tracking_setup     Avg Time/Event = 0.591 ms
[ ecalVeto ] 10  info: set_variables           Avg Time/Event = 0.017 ms
[ ecalVeto ] 10  info: bdt_variables           Avg Time/Event = 0.414 ms
[ ecalMipTracking ] 10  info: AVG Time/Event: 0.59 ms
[ ecalMipTracking ] 10  info: Breakdown::
[ ecalMipTracking ] 10  info: straight_tracks        Avg Time/Event = 0.542 ms
[ ecalMipTracking ] 10  info: linreg_tracks        Avg Time/Event = 0.025 ms
---- LDMXSW: Event processing complete  --------

</details>