### PR TITLE
Fast fix for out-of-range array in EcalClusterAnalyzer.cxx.

### DIFF
--- a/DQM/src/DQM/EcalClusterAnalyzer.cxx
+++ b/DQM/src/DQM/EcalClusterAnalyzer.cxx
@@ -211,7 +211,7 @@ void EcalClusterAnalyzer::analyze(const framework::Event& event) {
     // for each cluster
     // total number of hits coming from electron, index = electron ID
     std::vector<double> n_hits_from_electron;
-    n_hits_from_electron.resize(nbr_of_electrons + 1);
+    n_hits_from_electron.resize(nbr_of_electrons + 2);
     // total number of energy coming from electron, index = electron ID
     std::vector<double> energy_from_electron;
     energy_from_electron.resize(nbr_of_electrons + 1);

--- a/DQM/src/DQM/EcalClusterAnalyzer.cxx
+++ b/DQM/src/DQM/EcalClusterAnalyzer.cxx
@@ -214,7 +214,7 @@ void EcalClusterAnalyzer::analyze(const framework::Event& event) {
     n_hits_from_electron.resize(nbr_of_electrons + 2);
     // total number of energy coming from electron, index = electron ID
     std::vector<double> energy_from_electron;
-    energy_from_electron.resize(nbr_of_electrons + 1);
+    energy_from_electron.resize(nbr_of_electrons + 2);
     double energy_sum = 0.;
     double n_sum = 0.;
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
When running with the address sanitizer enabled, a heap-buffer-overflow is detected for any event with 0 reconstructed electron tracks reaching the ECal. This is due to an array which has a size based on the number of reconstructed electron tracks going out of range during the clustering.

It's important to note that the clustering algorithm runs, even if there are no primary electrons reaching the ECal. I think this is correct, because other particles can still reach the ECal. A possible improvement would be to not run the ECalClusterAnalyzer (or any part of the ECal reco/DQM) for events with NO depositions in the ECal, but this should be a very small fraction of events and would negligibly impact runtime.

Editing to add: this (hopefully) resolves #1744 , although the error states look slightly different. Also, we may want to consider increasing the number of events in the asan-ubsan validation test to a significantly higher number.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
Before:
<img width="1918" height="260" alt="image" src="https://github.com/user-attachments/assets/d19f742f-83b0-421e-b3e6-a4ca4a7e6afd" />
After:
<img width="1246" height="133" alt="image" src="https://github.com/user-attachments/assets/874f885d-26db-4189-a084-cecbeba19c40" />
