### PR TITLE
Cleaned up material definitions+updated trackers to compare against v15

### DIFF
--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -218,9 +218,9 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
     }
 
     // Now the interaction material
-    if (pn_interaction_material.find("G4_Si") != std::string::npos) {
+    if (pn_interaction_material.find("Silicon") != std::string::npos || pn_interaction_material.find("G4_Si") != std::string::npos) {
       histograms_.fill("pn_interaction_material", 2);
-    } else if (pn_interaction_material.find("G4_W") != std::string::npos) {
+    } else if (pn_interaction_material.find("Tungsten") != std::string::npos || pn_interaction_material.find("G4_W") != std::string::npos) {
       histograms_.fill("pn_interaction_material", 3);
     } else if (pn_interaction_material.find("FR4") != std::string::npos) {
       // Glass epoxy
@@ -237,7 +237,7 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
     } else if (pn_interaction_material.find("Glue") != std::string::npos) {
       // This is the notion for PVT
       histograms_.fill("pn_interaction_material", 8);
-    } else if (pn_interaction_material.find("G4_AIR") != std::string::npos) {
+    } else if (pn_interaction_material.find("Air") != std::string::npos || pn_interaction_material.find("G4_AIR") != std::string::npos) {
       // Air
       histograms_.fill("pn_interaction_material", 9);
     } else {

--- a/DQM/src/DQM/PhotoNuclearDQM.cxx
+++ b/DQM/src/DQM/PhotoNuclearDQM.cxx
@@ -218,9 +218,11 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
     }
 
     // Now the interaction material
-    if (pn_interaction_material.find("Silicon") != std::string::npos || pn_interaction_material.find("G4_Si") != std::string::npos) {
+    if (pn_interaction_material.find("Silicon") != std::string::npos ||
+        pn_interaction_material.find("G4_Si") != std::string::npos) {
       histograms_.fill("pn_interaction_material", 2);
-    } else if (pn_interaction_material.find("Tungsten") != std::string::npos || pn_interaction_material.find("G4_W") != std::string::npos) {
+    } else if (pn_interaction_material.find("Tungsten") != std::string::npos ||
+               pn_interaction_material.find("G4_W") != std::string::npos) {
       histograms_.fill("pn_interaction_material", 3);
     } else if (pn_interaction_material.find("FR4") != std::string::npos) {
       // Glass epoxy
@@ -237,7 +239,8 @@ void PhotoNuclearDQM::analyze(const framework::Event &event) {
     } else if (pn_interaction_material.find("Glue") != std::string::npos) {
       // This is the notion for PVT
       histograms_.fill("pn_interaction_material", 8);
-    } else if (pn_interaction_material.find("Air") != std::string::npos || pn_interaction_material.find("G4_AIR") != std::string::npos) {
+    } else if (pn_interaction_material.find("Air") != std::string::npos ||
+               pn_interaction_material.find("G4_AIR") != std::string::npos) {
       // Air
       histograms_.fill("pn_interaction_material", 9);
     } else {

--- a/Detectors/data/ldmx-det-v15-8gev/ecal.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/ecal.gdml
@@ -113,234 +113,6 @@
     <rotation name="flip" unit="deg" x="0" y="180" z="0"/>
   </define>
 
-  <materials>
-    <!-- alimunum for support box -->
-    <material Z="13" name="G4_Al0x2705780" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="166"/>
-      <D unit="g/cm3" value="2.699"/>
-      <atom unit="g/mole" value="26.9815"/>
-    </material>
-
-    <!-- PCB mixture -->
-    <isotope N="63" Z="29" name="Cu630x271bbf0">
-      <atom unit="g/mole" value="62.9296"/>
-    </isotope>
-    <isotope N="65" Z="29" name="Cu650x271bc60">
-      <atom unit="g/mole" value="64.9278"/>
-    </isotope>
-    <element name="Cu0x271b990">
-      <fraction n="0.6917" ref="Cu630x271bbf0"/>
-      <fraction n="0.3083" ref="Cu650x271bc60"/>
-    </element>
-    <isotope N="16" Z="8" name="O160x271e090">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O170x271e400">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O180x271e490">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O0x271e1a0">
-      <fraction n="0.99757" ref="O160x271e090"/>
-      <fraction n="0.00038" ref="O170x271e400"/>
-      <fraction n="0.00205" ref="O180x271e490"/>
-    </element>
-    <isotope N="23" Z="11" name="Na230x2725ef0">
-      <atom unit="g/mole" value="22.9898"/>
-    </isotope>
-    <element name="Na0x2725c90">
-      <fraction n="1" ref="Na230x2725ef0"/>
-    </element>
-    <isotope N="28" Z="14" name="Si280x271c4f0">
-      <atom unit="g/mole" value="27.9769"/>
-    </isotope>
-    <isotope N="29" Z="14" name="Si290x271c560">
-      <atom unit="g/mole" value="28.9765"/>
-    </isotope>
-    <isotope N="30" Z="14" name="Si300x271c5f0">
-      <atom unit="g/mole" value="29.9738"/>
-    </isotope>
-    <element name="Si0x271c2c0">
-      <fraction n="0.922296077703922" ref="Si280x271c4f0"/>
-      <fraction n="0.0468319531680468" ref="Si290x271c560"/>
-      <fraction n="0.0308719691280309" ref="Si300x271c5f0"/>
-    </element>
-    <isotope N="40" Z="20" name="Ca400x2726160">
-      <atom unit="g/mole" value="39.9626"/>
-    </isotope>
-    <isotope N="42" Z="20" name="Ca420x27261d0">
-      <atom unit="g/mole" value="41.9586"/>
-    </isotope>
-    <isotope N="43" Z="20" name="Ca430x2726240">
-      <atom unit="g/mole" value="42.9588"/>
-    </isotope>
-    <isotope N="44" Z="20" name="Ca440x27262e0">
-      <atom unit="g/mole" value="43.9555"/>
-    </isotope>
-    <isotope N="46" Z="20" name="Ca460x2726350">
-      <atom unit="g/mole" value="45.9537"/>
-    </isotope>
-    <isotope N="48" Z="20" name="Ca480x2726390">
-      <atom unit="g/mole" value="47.9525"/>
-    </isotope>
-    <element name="Ca0x2725f30">
-      <fraction n="0.96941" ref="Ca400x2726160"/>
-      <fraction n="0.00647" ref="Ca420x27261d0"/>
-      <fraction n="0.00135" ref="Ca430x2726240"/>
-      <fraction n="0.02086" ref="Ca440x27262e0"/>
-      <fraction n="4e-05" ref="Ca460x2726350"/>
-      <fraction n="0.00187" ref="Ca480x2726390"/>
-    </element>
-    <material name="FR40x27264f0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="201.221278976803"/>
-      <D unit="g/cm3" value="5.68"/>
-      <fraction n="0.5" ref="Cu0x271b990"/>
-      <fraction n="0.22990022990023" ref="O0x271e1a0"/>
-      <fraction n="0.0482205482205482" ref="Na0x2725c90"/>
-      <fraction n="0.168276668276668" ref="Si0x271c2c0"/>
-      <fraction n="0.0536025536025536" ref="Ca0x2725f30"/>
-    </material>
-
-    <!-- glue mixture -->
-    <isotope N="12" Z="6" name="C120x271ddf0">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C130x271de60">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C0x271db90">
-      <fraction n="0.9893" ref="C120x271ddf0"/>
-      <fraction n="0.0107" ref="C130x271de60"/>
-    </element>
-    <isotope N="1" Z="1" name="H10x271f760">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H20x271f7d0">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H0x271f530">
-      <fraction n="0.999885" ref="H10x271f760"/>
-      <fraction n="0.000115" ref="H20x271f7d0"/>
-    </element>
-    <material name="Glue0x272cce0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="73.3297495741215"/>
-      <D unit="g/cm3" value="0.845"/>
-      <fraction n="0.84491305" ref="C0x271db90"/>
-      <fraction n="0.042542086" ref="H0x271f530"/>
-      <fraction n="0.11254487" ref="O0x271e1a0"/>
-    </material>
-
-    <!-- sensitive silicon -->
-    <material name="G4_Si0x271c1c0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="173"/>
-      <D unit="g/cm3" value="2.33"/>
-      <fraction n="1" ref="Si0x271c2c0"/>
-    </material>
-
-    <!-- 
-    carbon+epoxy composite material for cooling plane 
-    
-    - taking the Epoxy mixture from the PDG values for
-      Epotek-301
-      https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
-    - the MEE value is pretty much made up at this point,
-      assuming it is the same as pure carbon which seems
-      to be an ok assumption since a majority of the epoxy
-      is carbon as well
-    - the epoxy to C-fiber ratio is 0.955 _by weight_
-
-    Fractions calculated by doing
-      C = 1+PDGFrac / 1.955
-      H = PDGFrac / 1.955
-      O = PDGFrac / 1.955
-      N = PDGFrac / 1.955
-    where PDGFrac is that material's mass fraction in the PDG
-    material linked above which we convert to molar fraction
-    by converting each fraction to moles individually and then
-    dividing by the sum.
-    -->
-    <material name="CarbonEpoxyComposite" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="1.439"/>
-      <fraction n="0.624883102" ref="C0x271db90"/>
-      <fraction n="0.308001109" ref="H0x271f530"/>
-      <fraction n="0.064281977" ref="O0x271e1a0"/>
-      <fraction n="0.002833811" ref="G4_AIR0x271da60"/><!--ref="N140x271e0d0"/>-->
-    </material>
-
-    <!-- air for gaps -->
-    <isotope N="14" Z="7" name="N140x271e0d0">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N150x271e140">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N0x271dea0">
-      <fraction n="0.99632" ref="N140x271e0d0"/>
-      <fraction n="0.00368" ref="N150x271e140"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar360x271e730">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar380x271e7c0">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar400x271e850">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar0x271e500">
-      <fraction n="0.003365" ref="Ar360x271e730"/>
-      <fraction n="0.000632" ref="Ar380x271e7c0"/>
-      <fraction n="0.996003" ref="Ar400x271e850"/>
-    </element>
-    <material name="G4_AIR0x271da60" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C0x271db90"/>
-      <fraction n="0.755267755267755" ref="N0x271dea0"/>
-      <fraction n="0.231781231781232" ref="O0x271e1a0"/>
-      <fraction n="0.0128270128270128" ref="Ar0x271e500"/>
-    </material>
-
-    <!-- Tungsten for absorber -->
-    <isotope N="180" Z="74" name="W1800x270c100">
-      <atom unit="g/mole" value="179.947"/>
-    </isotope>
-    <isotope N="182" Z="74" name="W1820x270c170">
-      <atom unit="g/mole" value="181.948"/>
-    </isotope>
-    <isotope N="183" Z="74" name="W1830x270c210">
-      <atom unit="g/mole" value="182.95"/>
-    </isotope>
-    <isotope N="184" Z="74" name="W1840x270c2b0">
-      <atom unit="g/mole" value="183.951"/>
-    </isotope>
-    <isotope N="186" Z="74" name="W1860x270c2f0">
-      <atom unit="g/mole" value="185.954"/>
-    </isotope>
-    <element name="W0x270bea0">
-      <fraction n="0.0012" ref="W1800x270c100"/>
-      <fraction n="0.265" ref="W1820x270c170"/>
-      <fraction n="0.1431" ref="W1830x270c210"/>
-      <fraction n="0.3064" ref="W1840x270c2b0"/>
-      <fraction n="0.2843" ref="W1860x270c2f0"/>
-    </element>
-    <material name="G4_W0x270bda0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="727"/>
-      <D unit="g/cm3" value="19.3"/>
-      <fraction n="1" ref="W0x270bea0"/>
-    </material>
-
-  </materials>
-
   <solids>
     <!--
       Strongback Parts
@@ -519,22 +291,22 @@
     </assembly>
 
     <volume name="PCB_volume">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="PCB_hexagon"/>
     </volume>
   
     <volume name="Glue_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Glue"/>
       <solidref ref="Glue_hexagon"/>
     </volume>
   
     <volume name="Si_volume">
-      <materialref ref="G4_Si0x271c1c0"/>
+      <materialref ref="Silicon"/>
       <solidref ref="Si_hexagon"/>
     </volume>
   
     <volume name="GlueThick_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Glue"/>
       <solidref ref="GlueThick_hexagon"/>
     </volume>
 
@@ -547,16 +319,16 @@
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
     <loop for="bilayer" from="1" to="num_bilayers-1" step="1">
       <volume name="strongback_bar_volume[bilayer]">
-        <materialref ref="G4_Al0x2705780" />
+        <materialref ref="Aluminum" />
         <solidref ref="strongback_bar[bilayer]" />
       </volume>
       <volume name="W_front_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_front_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
       <volume name="W_cooling_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_cooling_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
@@ -599,7 +371,7 @@
                           Back Tolerance Gap
     -->
     <volume name="em_calorimeters">
-      <materialref ref="G4_AIR"/>
+      <materialref ref="Air"/>
       <solidref ref="ECal_box"/>
 
       <!--

--- a/Detectors/data/ldmx-det-v15-8gev/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/ecal_motherboard5_assembly.gdml
@@ -275,7 +275,7 @@
 
   <structure>
     <volume name="nohole_motherboard5_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard5_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-det-v15-8gev/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/ecal_motherboard6_assembly.gdml
@@ -361,7 +361,7 @@
 
   <structure>
     <volume name="nohole_motherboard6_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard6_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-det-v15-8gev/ecal_support_box.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/ecal_support_box.gdml
@@ -1480,7 +1480,7 @@
 
   <structure>
     <volume name="support_box">
-      <materialref ref="G4_Al0x2705780"/>
+      <materialref ref="Aluminum"/>
       <solidref ref="support_box-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-det-v15-8gev/hcal.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/hcal.gdml
@@ -43,122 +43,8 @@
                   -(ecal_side_dy/2.0-hcal_scintWidth/2.0)
                   ecal_side_dy/2.0-hcal_scintWidth/2.0"/>
   </define>
-    
-  <materials>
-    <isotope N="16" Z="8" name="O16">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O17">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O18">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O">
-      <fraction n="0.99757" ref="O16"/>
-      <fraction n="0.00038" ref="O17"/>
-      <fraction n="0.00205" ref="O18"/>
-    </element>
-    <isotope N="12" Z="6" name="C12">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C13">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C">
-      <fraction n="0.9893" ref="C12"/>
-      <fraction n="0.0107" ref="C13"/>
-    </element>
-    <isotope N="1" Z="1" name="H1">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H2">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H">
-      <fraction n="0.999885" ref="H1"/>
-      <fraction n="0.000115" ref="H2"/>
-    </element>
-    <material name="G4_C" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="2"/>
-      <fraction n="1" ref="C"/>
-    </material>
-    <isotope N="14" Z="7" name="N14">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N15">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N">
-      <fraction n="0.99632" ref="N14"/>
-      <fraction n="0.00368" ref="N15"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar36">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar38">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar40">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar">
-      <fraction n="0.003365" ref="Ar36"/>
-      <fraction n="0.000632" ref="Ar38"/>
-      <fraction n="0.996003" ref="Ar40"/>
-    </element>
-    <material name="G4_AIR" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C"/>
-      <fraction n="0.755267755267755" ref="N"/>
-      <fraction n="0.231781231781232" ref="O"/>
-      <fraction n="0.0128270128270128" ref="Ar"/>
-    </material>
-    <isotope N="55" Z="25" name="Mn55">
-      <atom unit="g/mole" value="54.938"/>
-    </isotope>
-    <element name="Mn">
-      <fraction n="1" ref="Mn55"/>
-    </element>
-    <isotope N="54" Z="26" name="Fe54">
-      <atom unit="g/mole" value="53.9396"/>
-    </isotope>
-    <isotope N="56" Z="26" name="Fe56">
-      <atom unit="g/mole" value="55.9349"/>
-    </isotope>
-    <isotope N="57" Z="26" name="Fe57">
-      <atom unit="g/mole" value="56.9354"/>
-    </isotope>
-    <isotope N="58" Z="26" name="Fe58">
-      <atom unit="g/mole" value="57.9333"/>
-    </isotope>
-    <element name="Fe">
-      <fraction n="0.05845" ref="Fe54"/>
-      <fraction n="0.91754" ref="Fe56"/>
-      <fraction n="0.02119" ref="Fe57"/>
-      <fraction n="0.00282" ref="Fe58"/>
-    </element>
-    <material name="Steel" state="solid">
-       <T unit="K" value="293.15"/>
-       <D unit="g/cm3" value="7.87"/>
-       <fraction n="0.9843" ref="G4_Fe"/>
-       <fraction n="0.014" ref="G4_Mn"/>
-       <fraction n="0.0017" ref="G4_C"/>
-    </material>
-    <material name="Scintillator" state="solid">
-       <T unit="K" value="293.15"/>
-       <!-- <MEE unit="eV" value="64.7494480275643"/> -->
-       <D unit="g/cm3" value="1.032"/>
-       <fraction n="0.91512109"  ref="G4_C"/>
-       <fraction n="0.084878906" ref="G4_H"/>
-    </material>
-  </materials>
 
-
+  
   <solids>
   
     <!-- - - - - - - - - HCal solids - - - - - - - -  -->
@@ -240,7 +126,7 @@
       
       <!-- - - - - - - - -  FULL HCAL STRUCTURES - - - - - - - -  -->
     <volume name="hadronic_calorimeter">
-      <materialref ref="G4_AIR" />
+      <materialref ref="Air" />
       <solidref ref="hadron_calorimeter_Box" />
       <!-- BACK HCAL  -->
         <!-- Note the step size of 2  -->

--- a/Detectors/data/ldmx-det-v15-8gev/magnet.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/magnet.gdml
@@ -3455,25 +3455,6 @@
         <rotation name="identity" unit="radian" z="0" x="0" y="0" />
     </define>
 
-    <materials>
-        <element Z="1" formula="H" name="H">
-            <atom type="A" unit="g/mol" value="1.00794"/>
-        </element>
-        <material name="Vacuum" state="gas">
-            <MEE unit="eV" value="19.2"/>
-            <D unit="g/cm3" value="9.99999473841014e-09"/>
-            <fraction n="1" ref="H"/>
-        </material>
-        <material name="Fe" Z="26.0">
-            <D value="7.874" />
-            <atom value="55.845" />
-        </material>
-        <material name="Cu" Z="29.0">
-            <D value="8.96" />
-            <atom value="63.546" />
-        </material>
-    </materials>
-
     <solids>
         <box aunit="radian" lunit="mm" name="magnet_box" x="magnet_box_x" y="magnet_box_y" z="magnet_box_z" />
         <box aunit="radian" lunit="mm" name="shim_right_box" x="shim_x" y="shim_y" z="shim_z" />
@@ -10224,43 +10205,43 @@
     
     <structure>
         <volume name="coil_1_vol" >
-            <materialref ref="Cu" />
+            <materialref ref="Copper" />
             <solidref ref="coil_1" />
         </volume>
         <volume name="coil_2_vol" >
-            <materialref ref="Cu" />
+            <materialref ref="Copper" />
             <solidref ref="coil_2" />
         </volume>
         <volume name="shim_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="shim_right_box" />
         </volume>
         <volume name="shim_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="shim_left_box" />
         </volume>
         <volume name="corner_iron_block_top_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_left_box" />
         </volume>
         <volume name="corner_iron_block_top_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_right_box" />
         </volume>
         <volume name="corner_iron_block_bot_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_left_box" />
         </volume>
         <volume name="corner_iron_block_bot_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_right_box" />
         </volume>
         <volume name="center_iron_block_top" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="center_iron_block_top_box" />
         </volume>
         <volume name="center_iron_block_bot" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="center_iron_block_bot_box" />
         </volume>
         <volume name="ldmx_magnet" >

--- a/Detectors/data/ldmx-det-v15-8gev/materials.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/materials.gdml
@@ -1,6 +1,36 @@
+<!--
+This file is organized in the following way:
+
+Element definitions
+Pure (one element) material definitions
+Composite material definitions
+
+We don't currently have any enriched elements in LDMX, but
+if we did, I would add those between the element definitions
+and the pure material definitions. And don't worry about the
+isotopic composition of the natural elements - GDML is at
+least smart enough to assign those abundances automatically
+
+Both the elements and the pure materials are organized by
+Z number in ascending order. Also, not all elements have
+corresponding pure materials defined (but most do). If you
+add more, please try to keep the ordering correct!
+
+Lastly, the naming conventions are as follows:
+Element definitions should use the element's abbreviation
+as seen on the periodic table. Pure elemental materials
+should have the formal name listed on the periodic table
+(I guess we'll use the US standard named like 'aluminum'
+instead of 'aluminium' because Geant4 is US-based and
+uses those standards). Composite materials can have
+whatever name you want, but I would recommend using
+names that are coloquially understandable, like how we
+use "glue" instead of listing the chemical formula.
+
+-->
 
 <element Z="1" formula="H" name="H">
-  <atom type="A" unit="g/mol" value="1.00794"/>
+  <atom type="A" unit="g/mol" value="1.00782"/>
 </element>
 <element Z="6" formula="C" name="C">
   <atom type="A" unit="g/mol" value="12.0107"/>
@@ -11,13 +41,99 @@
 <element Z="8" formula="O" name="O">
   <atom type="A" unit="g/mol" value="15.9994"/>
 </element>
+<element Z="11" formula="Na" name="Na">
+  <atom type="A" unit="g/mol" value="22.9898"/>
+</element>
+<element Z="14" formula="Si" name="Si">
+  <atom type="A" unit="g/mol" value="28.0854"/>
+</element>
 <element Z="18" formula="Ar" name="Ar">
   <atom type="A" unit="g/mol" value="39.9477"/>
 </element>
+<element Z="20" formula="Ca" name="Ca">
+  <atom type="A" unit="g/mol" value="40.08"/>
+</element>
+<element Z="25" formula="Mn" name="Mn">
+  <atom type="A" unit="g/mol" value="54.938"/>
+</element>
+<element Z="26" formula="Fe" name="Fe">
+  <atom type="A" unit="g/mol" value="55.845"/>
+</element>
+<element Z="29" formula="Cu" name="Cu">
+  <atom type="A" unit="g/mol" value="63.546"/>
+</element>           
 <element Z="74" formula="W" name="W">
   <atom type="A" unit="g/mol" value="183.842"/>
 </element>           
 
+<material name="Hydrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="13.6"/>
+  <D unit="g/cm3" value="0.0000899"/>
+  <fraction n="1" ref="H"/>
+</material>
+<material name="Carbon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="81"/>
+  <D unit="g/cm3" value="1.99999894768203"/>
+  <fraction n="1" ref="C"/>
+</material>
+<material name="Nitrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="82.0"/>
+  <D unit="g/cm3" value="0.00125"/>
+  <fraction n="1" ref="N"/>
+</material>
+<material name="Oxygen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="95.0"/>
+  <D unit="g/cm3" value="0.001429"/>
+  <fraction n="1" ref="O"/>
+</material>
+<material name="Aluminum" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="166"/>
+  <D unit="g/cm3" value="2.699"/>
+  <fraction n="1" ref="Al"/>
+</material>
+<material name="Silicon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="173"/>
+  <D unit="g/cm3" value="2.32999877404956"/>
+  <fraction n="1" ref="Si"/>
+</material>
+<material name="Argon" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="188"/>
+  <D unit="g/cm3" value="0.00178"/>
+  <fraction n="1" ref="Ar"/>
+</material>
+<material name="Iron" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="286.0"/>
+  <D unit="g/cm3" value="7.874"/>
+  <fraction n="1" ref="Fe"/>
+</material>
+<material name="Copper" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="322"/>
+  <D unit="g/cm3" value="8.96"/>
+  <fraction n="1" ref="Cu"/>
+</material>
+<material name="Tungsten" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="727.0"/>
+  <D unit="g/cm3" value="19.25"/>
+  <fraction n="1" ref="W"/>
+</material>
+
+
+<material name="Vacuum" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="19.2"/>
+  <D unit="g/cm3" value="9.99999473841014e-09"/>
+  <fraction n="1" ref="H"/>
+</material>
 <material name="Air" state="gas">
   <MEE unit="eV" value="85.643664635028"/>
   <D unit="g/cm3" value="0.00119999936860922"/>
@@ -25,21 +141,72 @@
   <fraction n="0.234" ref="O"/>
   <fraction n="0.012" ref="Ar"/>
 </material>
-<material name="Carbon" state="solid">
+<material name="FR4" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="201.221278976803"/>
+  <D unit="g/cm3" value="5.68"/>
+  <fraction n="0.5"                ref="Cu"/>
+  <fraction n="0.22990022990023"   ref="O"/>
+  <fraction n="0.0482205482205482" ref="Na"/>
+  <fraction n="0.168276668276668"  ref="Si"/>
+  <fraction n="0.0536025536025536" ref="Ca"/>
+</material>
+<material name="Glue" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="73.3297495741215"/>
+  <D unit="g/cm3" value="0.845"/>
+  <fraction n="0.84491305" ref="C"/>
+  <fraction n="0.042542086" ref="H"/>
+  <fraction n="0.11254487" ref="O"/>
+</material>
+<!-- 
+     carbon+epoxy composite material for cooling plane 
+     
+     - taking the Epoxy mixture from the PDG values for
+     Epotek-301
+     https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
+     - the MEE value is pretty much made up at this point,
+     assuming it is the same as pure carbon which seems
+     to be an ok assumption since a majority of the epoxy
+     is carbon as well
+     - the epoxy to C-fiber ratio is 0.955 _by weight_
+     
+     Fractions calculated by doing
+     C = 1+PDGFrac / 1.955
+     H = PDGFrac / 1.955
+     O = PDGFrac / 1.955
+     N = PDGFrac / 1.955
+     where PDGFrac is that material's mass fraction in the PDG
+     material linked above which we convert to molar fraction
+     by converting each fraction to moles individually and then
+     dividing by the sum.
+-->
+<material name="CarbonEpoxyComposite" state="solid">
+  <T unit="K" value="293.15"/>
   <MEE unit="eV" value="81"/>
-  <D unit="g/cm3" value="1.99999894768203"/>
-  <fraction n="1" ref="C"/>
+  <D unit="g/cm3" value="1.439"/>
+  <fraction n="0.624883102" ref="C"/>
+  <fraction n="0.308001109" ref="H"/>
+  <fraction n="0.064281977" ref="O"/>
+  <fraction n="0.002833811" ref="Air"/>
 </material>
-<element Z="14" formula="Si" name="Si">
-  <atom type="A" unit="g/mol" value="28.0854"/>
-</element>
-<material name="Silicon" state="solid">
-  <MEE unit="eV" value="173"/>
-  <D unit="g/cm3" value="2.32999877404956"/>
-  <fraction n="1" ref="Si"/>
+<material name="Steel" state="solid">
+  <T unit="K" value="293.15"/>
+  <D unit="g/cm3" value="7.87"/>
+  <fraction n="0.9843" ref="Fe"/>
+  <fraction n="0.014" ref="Mn"/>
+  <fraction n="0.0017" ref="C"/>
 </material>
-<material name="Vacuum" state="gas">
-  <MEE unit="eV" value="19.2"/>
-  <D unit="g/cm3" value="9.99999473841014e-09"/>
-  <fraction n="1" ref="H"/>
+<material name="Scintillator" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="64.7494480275643"/>
+  <D unit="g/cm3" value="1.032"/>
+  <fraction n="0.91512109"  ref="C"/>
+  <fraction n="0.084878906" ref="H"/>
+</material>
+<material name="Polyvinyltoluene">
+  <D type="density" value="1.023" unit="g/cm3"/>
+  <!--Vinyltoluene chemical formula is C9H10-->
+  <composite n="9" ref="C"/>
+  <composite n="10" ref="H"/>
 </material>

--- a/Detectors/data/ldmx-det-v15-8gev/recoil.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/recoil.gdml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
       xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
@@ -65,9 +64,7 @@
                                                       stereo_angle
                                                      -stereo_angle" />
   </define>
-  <materials> 
-    &materials;
-  </materials>
+
   <solids>
     <box lunit="mm" name="recoil_l14_active_sensor_box" 
          x="si_large_active_sensor_dx" y="si_large_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-det-v15-8gev/scoring_planes.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/scoring_planes.gdml
@@ -152,13 +152,6 @@
 
   </define>
 
-  <materials>
-    <material name="Vacuum" Z="1" state="gas">
-      <D unit="g/cm3" value="1e-12"/>
-      <atom unit="g/mole" value="1" />
-    </material> 
-  </materials>
-
   <solids>
     <box name="world_box" x="world_dim" y="world_dim" z="world_dim"/>
 

--- a/Detectors/data/ldmx-det-v15-8gev/tagger.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/tagger.gdml
@@ -2,7 +2,6 @@
 
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -46,9 +45,7 @@
   
   
   </define>
-  <materials> 
-    &materials;
-  </materials>
+
   <solids>
     <box lunit="mm" name="tagger_active_sensor_box" 
        x="si_active_sensor_dx" y="si_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-det-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/target.gdml
@@ -29,31 +29,6 @@
 
   </solids>
 
-  <materials>
-
-      <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
-    
-    <!-- Target --> 
-    <material name="Tungsten" state="solid">
-      <MEE unit="eV" value="727"/>
-      <D unit="g/cm3" value="19.2999898451316"/>
-      <fraction n="1" ref="W"/>
-    </material>
-
-    
-    <!-- Scintillator -->
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
-
-  </materials>
-
   <structure>
 
     <volume name="target">

--- a/Detectors/data/ldmx-det-v15-8gev/trig_scint.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/trig_scint.gdml
@@ -22,23 +22,6 @@
   
   </solids>
 
-  <materials>
-
-      <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
-    
-    <!-- Scintillator -->
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
-
-  </materials>
-
   <structure>
 
     <volume name="trigger_pad2_bar_volume">

--- a/SimCore/src/SimCore/BiasOperators/PhotoNuclear.cxx
+++ b/SimCore/src/SimCore/BiasOperators/PhotoNuclear.cxx
@@ -69,13 +69,13 @@ G4VBiasingOperation* PhotoNuclear::ProposeOccurenceBiasingOperation(
     double em_xsec_biased =
         std::max(em_xsec_unbiased + pn_xsec_unbiased_ - pn_xsec_biased_,
                  pn_xsec_unbiased_);
-    static auto material_tungsten = simcore::g4user::ptrretrieval::getMaterial("Tungsten");
-    //For versions < v15
-    if(material_tungsten==nullptr)
-      {
-	ldmx_log(warn) << "Attempting to use old tungsten material G4_W... ";
+    static auto material_tungsten =
+        simcore::g4user::ptrretrieval::getMaterial("Tungsten");
+    // For versions < v15
+    if (material_tungsten == nullptr) {
+      ldmx_log(warn) << "Attempting to use old tungsten material G4_W... ";
       material_tungsten = simcore::g4user::ptrretrieval::getMaterial("G4_W");
-      }
+    }
     auto interaction_material = track->GetMaterial();
     if ((em_xsec_biased == pn_xsec_unbiased_) &&
         (interaction_material == material_tungsten)) {

--- a/SimCore/src/SimCore/BiasOperators/PhotoNuclear.cxx
+++ b/SimCore/src/SimCore/BiasOperators/PhotoNuclear.cxx
@@ -69,8 +69,13 @@ G4VBiasingOperation* PhotoNuclear::ProposeOccurenceBiasingOperation(
     double em_xsec_biased =
         std::max(em_xsec_unbiased + pn_xsec_unbiased_ - pn_xsec_biased_,
                  pn_xsec_unbiased_);
-    static auto material_tungsten =
-        simcore::g4user::ptrretrieval::getMaterial("G4_W");
+    static auto material_tungsten = simcore::g4user::ptrretrieval::getMaterial("Tungsten");
+    //For versions < v15
+    if(material_tungsten==nullptr)
+      {
+	ldmx_log(warn) << "Attempting to use old tungsten material G4_W... ";
+      material_tungsten = simcore::g4user::ptrretrieval::getMaterial("G4_W");
+      }
     auto interaction_material = track->GetMaterial();
     if ((em_xsec_biased == pn_xsec_unbiased_) &&
         (interaction_material == material_tungsten)) {

--- a/Tracking/python/full_tracking_sequence.py
+++ b/Tracking/python/full_tracking_sequence.py
@@ -3,7 +3,7 @@ from LDMX.Tracking import tracking
 from LDMX.Tracking import geo
 
 from LDMX.Tracking.geo import TrackersTrackingGeometryProvider as trackgeo
-trackgeo.get_instance().setDetector('ldmx-det-v14-8gev')
+trackgeo.get_instance().setDetector('ldmx-det-v15-8gev')
 
 # Truth seeder
 # Runs truth tracking producing tracks from target scoring plane hits for Recoil

--- a/Tracking/python/geo.py
+++ b/Tracking/python/geo.py
@@ -13,7 +13,7 @@ class TrackersTrackingGeometryProvider(ldmxcfg.ConditionsObjectProvider):
         from LDMX.Tracking.geo import TrackersTrackingGeometryProvider as trackgeo
         trackgeo.get_instance().setDetector('ldmx-det-v12')
 
-    The default detector is 'ldmx-det-v14'.
+    The default detector is 'ldmx-det-v15-8gev'.
     """
 
     __instance = None
@@ -46,7 +46,7 @@ class TrackersTrackingGeometryProvider(ldmxcfg.ConditionsObjectProvider):
             raise Exception('TrackersTrackingGeometryProvider is a singleton class and should only be retrieved using get_instance()')
         else: 
             super().__init__('TrackersTrackingGeometry', 'tracking::geo::TrackersTrackingGeometryProvider', 'Tracking')
-            self.setDetector('ldmx-det-v14-8gev-no-cals')
+            self.setDetector('ldmx-det-v15-8gev')
             #  acts x = global z
             #   // global z:  -200 - 900/2 = -650 to -200 + 900/2 = 250 mm
             #   // global y: -70 to 70

--- a/Tracking/python/geo.py
+++ b/Tracking/python/geo.py
@@ -13,7 +13,7 @@ class TrackersTrackingGeometryProvider(ldmxcfg.ConditionsObjectProvider):
         from LDMX.Tracking.geo import TrackersTrackingGeometryProvider as trackgeo
         trackgeo.get_instance().setDetector('ldmx-det-v12')
 
-    The default detector is 'ldmx-det-v15-8gev'.
+    The default detector is 'ldmx-det-v14'.
     """
 
     __instance = None
@@ -46,7 +46,7 @@ class TrackersTrackingGeometryProvider(ldmxcfg.ConditionsObjectProvider):
             raise Exception('TrackersTrackingGeometryProvider is a singleton class and should only be retrieved using get_instance()')
         else: 
             super().__init__('TrackersTrackingGeometry', 'tracking::geo::TrackersTrackingGeometryProvider', 'Tracking')
-            self.setDetector('ldmx-det-v15-8gev')
+            self.setDetector('ldmx-det-v14-8gev-no-cals')
             #  acts x = global z
             #   // global z:  -200 - 900/2 = -650 to -200 + 900/2 = 250 mm
             #   // global y: -70 to 70


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

In v14, geometry definitions are kind of all over the place in more than one sense. They're located in various files, inconsistently named, and often re-defined. Materials exported from other software may even have slightly different material properties, like density, composition, or atomic mass.

Compounding this issue, many python scripts used for validation, tracking etc. are still pointing to 'ldmx-det-v14-8gev' or 'ldmx-det-v14-8gev-nocals'. I don't know if v15 is stable enough for all of the python scripts yet, but using a script which references v14 but then uses v15 causes ldmx-sw to load both geometries and then apply one. However, the material definitions are still loaded, causing all the warnings.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

This (mostly) resolves #1892 . Read below if you want to know why it doesn't fully resolve it, or you can skip the next paragraph.

I don't consider this fully resolved for 3 reasons.
1) As you can see in the screenshots, the detector is still set twice in the ecal_pn test (I haven't run the other validation tests manually but I assume there will be similar behavior). This is related to the next point,
2) There is still exactly _one_ re-definition of each material. On the bright side, this is kind of nice because it lists all of the defined materials in the terminal output during runtime - but is still unintended. I wasted some time trying to track (pun intended) down this issue, and it seems to have something to do with the tracking, specifically `geo.py` and/or `full_tracking_sequence.py`. I don't want to deal with this (or at best deal with it in a separate issue) so I'm not investigating further.
3) There are other python scripts in the repo that are still hardcoded to use v14 instead of v15. Again, I don't feel like re-validating all of these scripts with v15, and that should be a separate issue anyway.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Before:
<img width="1355" height="763" alt="image" src="https://github.com/user-attachments/assets/cd8944cf-c207-4eed-9250-e51f8f545e08" />
<img width="897" height="562" alt="image" src="https://github.com/user-attachments/assets/80a4e99e-30b1-4f2a-92dc-4c40cb743a95" />

After:
<img width="1537" height="743" alt="image" src="https://github.com/user-attachments/assets/91a411bd-6614-4a47-a6b6-9f5d02f2900b" />

