### PR TITLE
Add ROOT_INCLUDE_PATH in Dockerfile for cling's compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/usr/local -S /code -B /code/build &&\
     ldconfig
 
 ENV LDMX_SW_INSTALL=/usr/local
+ENV ROOT_INCLUDE_PATH=/usr/local/include


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
I think it resolves https://github.com/LDMX-Software/ldmx-sw/issues/1890
but not sure how to test it, as it's about the production image. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [ ] I ran my developments and the following shows that they are successful.


