### PR TITLE
fix missing file entry in prod image

### DIFF
--- a/TrigScint/src/TrigScint/ZCCMDecoder.cxx
+++ b/TrigScint/src/TrigScint/ZCCMDecoder.cxx
@@ -201,7 +201,7 @@ void ZCCMDecoder::produce(framework::Event &event) {
     }
     // extract the flag info
     int cid{(flag >> ZCCMOutput::CAPID_POS_IN_FLAG) &
-             Mask8<ZCCMOutput::CAPID_LEN_BITS>::M};
+            Mask8<ZCCMOutput::CAPID_LEN_BITS>::M};
     ldmx_log(trace) << "Got Cap ID " << cid;
     bool bc0{static_cast<bool>((flag >> ZCCMOutput::BC0_POS_IN_FLAG) &
                                Mask8<ZCCMOutput::BC0_LEN_BITS>::M)};
@@ -210,7 +210,7 @@ void ZCCMDecoder::produce(framework::Event &event) {
                               Mask8<ZCCMOutput::CE_LEN_BITS>::M)};
     ldmx_log(trace) << "Got CE flag " << ce;
     int empty_bits{(flag >> ZCCMOutput::EMPTY_FLAG_WORD_POS_IN_FLAG) &
-                         Mask8<ZCCMOutput::EMPTY_FLAG_WORD_LEN_BITS>::M};
+                   Mask8<ZCCMOutput::EMPTY_FLAG_WORD_LEN_BITS>::M};
     if (empty_bits)
       ldmx_log(fatal) << "Empty bits of flag not empty: " << empty_bits;
 

--- a/TrigScint/src/TrigScint/ZCCMDecoder.cxx
+++ b/TrigScint/src/TrigScint/ZCCMDecoder.cxx
@@ -153,8 +153,8 @@ void ZCCMDecoder::produce(framework::Event &event) {
   std::vector<std::vector<trigscint::TrigScintQIEDigis>> out_digis;
   std::size_t n_modules =
       std::ranges::count_if(modules_used_, [](int x) { return x != 0; });
-  for (uint i = 0; i < n_modules; i++)
-    out_digis.emplace_back(std::vector<trigscint::TrigScintQIEDigis>(NULL));
+  // default construct (empty) vectors of digis separated into modules
+  out_digis.resize(n_modules);
 
   // read in words from the output. line them up per channel and time sample.
   // channels are in the electronics ordering
@@ -200,8 +200,8 @@ void ZCCMDecoder::produce(framework::Event &event) {
       ldmx_log(debug) << "Set time sample start lane to " << start_lane;
     }
     // extract the flag info
-    int cid{static_cast<int>((flag >> ZCCMOutput::CAPID_POS_IN_FLAG) &
-                             Mask8<ZCCMOutput::CAPID_LEN_BITS>::M)};
+    int cid{(flag >> ZCCMOutput::CAPID_POS_IN_FLAG) &
+             Mask8<ZCCMOutput::CAPID_LEN_BITS>::M};
     ldmx_log(trace) << "Got Cap ID " << cid;
     bool bc0{static_cast<bool>((flag >> ZCCMOutput::BC0_POS_IN_FLAG) &
                                Mask8<ZCCMOutput::BC0_LEN_BITS>::M)};
@@ -209,9 +209,8 @@ void ZCCMDecoder::produce(framework::Event &event) {
     bool ce{static_cast<bool>((flag >> ZCCMOutput::CE_POS_IN_FLAG) &
                               Mask8<ZCCMOutput::CE_LEN_BITS>::M)};
     ldmx_log(trace) << "Got CE flag " << ce;
-    int empty_bits{
-        static_cast<int>((flag >> ZCCMOutput::EMPTY_FLAG_WORD_POS_IN_FLAG) &
-                         Mask8<ZCCMOutput::EMPTY_FLAG_WORD_LEN_BITS>::M)};
+    int empty_bits{(flag >> ZCCMOutput::EMPTY_FLAG_WORD_POS_IN_FLAG) &
+                         Mask8<ZCCMOutput::EMPTY_FLAG_WORD_LEN_BITS>::M};
     if (empty_bits)
       ldmx_log(fatal) << "Empty bits of flag not empty: " << empty_bits;
 

--- a/cmake/BuildMacros.cmake
+++ b/cmake/BuildMacros.cmake
@@ -115,13 +115,17 @@ macro(setup_library)
   add_library(${alias} ALIAS ${library_name})
 
   if(setup_library_linkdef)
-    file(GLOB headers CONFIGURE_DEPENDS ${include_path}/[a-zA-Z]*.h)
-    file(GLOB linkdef CONFIGURE_DEPENDS "${setup_library_linkdef}")
+    # make sure the headers are relative to the include/ directory so that
+    # the generated dictionary does not require the entire source tree to be present
+    # (it can look at the installed headers)
+    file(GLOB headers RELATIVE ${PROJECT_SOURCE_DIR}/include CONFIGURE_DEPENDS ${include_path}/[a-zA-Z]*.h)
+    file(REAL_PATH "${setup_library_linkdef}" linkdef_full)
+    file(RELATIVE_PATH linkdef ${PROJECT_SOURCE_DIR}/include "${linkdef_full}")
     list(REMOVE_ITEM headers "${linkdef}")
     root_generate_dictionary(
       ${library_name}Dict
       ${headers}
-      LINKDEF ${linkdef}
+      LINKDEF ${setup_library_linkdef}
       MODULE ${library_name})
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib${library_name}_rdict.pcm DESTINATION lib)
   endif()


### PR DESCRIPTION
- **use paths relative to include** which avoids compiling full paths into the dictionary
- **cleanup warnings that were failing on trunk**


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #1890

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

I built a production image locally and observed that the FileEntry warnings were gone.
https://github.com/LDMX-Software/ldmx-sw/issues/1890#issuecomment-3711703909
