### PR TITLE
add script for multi-fire runs in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ EventDisplay/include/EventDisplay/EventDisplayLinkDef.h
 .denv
 .apptainer
 .wget-hsts
+.parallel

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -56,6 +56,11 @@ set_target_properties(
 add_executable(fire ${PROJECT_SOURCE_DIR}/app/fire.cxx)
 target_link_libraries(fire PRIVATE Framework::Framework)
 install(TARGETS fire DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(FILES app/fire-parallel
+  TYPE BIN
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+              GROUP_READ GROUP_EXECUTE
+              WORLD_READ WORLD_EXECUTE)
 
 # Setup the test
 setup_test(dependencies Framework::Framework)

--- a/Framework/app/fire-parallel
+++ b/Framework/app/fire-parallel
@@ -16,11 +16,11 @@ usage() {
     --help|-h : print this help and exit
     --dry-run : print the jobs that would be run instead of running them
     --log-dir : specify where the logs for the jobs and parallel should be stored
-                if the special string '-', then the logs are not stored and instead
-                printed to the terminal. This '-' prevents '--follow' from being used.
-    --follow  : put the parallel run into the background and watch the parallel
-                job log while waiting for the jobs to complete
-                Cannot be used if '-' is used for '--log-dir'.
+                defaults to printing the output of the jobs to the terminal AFTER
+                the job fully completes (i.e. the parallel default).
+                If this is provided, we instead write the output of each job to
+                its own file and follow parallel's joblog file reporting when jobs
+                complete.
     --        : signal that the rest of the arguments should be passed to GNU parallel
 
   ARGUMENTS
@@ -48,8 +48,7 @@ HELP
 }
 
 dry_run=false
-log_dir="logs"
-follow=false
+log_dir=""
 config=""
 template_args=""
 while [ $# -gt 0 ]; do
@@ -60,9 +59,6 @@ while [ $# -gt 0 ]; do
       ;;
     --dry-run)
       dry_run=true
-      ;;
-    --follow)
-      follow=true
       ;;
     --log-dir)
       shift
@@ -110,11 +106,6 @@ if [ -z "${template_args}" ]; then
   template_args="{}"
 fi
 
-if ${follow} && [ "${log_dir}" = "-" ]; then
-  echo "error: cannot '--follow' when redirecting the logs to the terminal ('--log-dir -')"
-  exit 2
-fi
-
 if [ -z "${config}" ] || [ ! -f "${config}" ]; then
   echo "error: the config script argument is required"
   exit 3
@@ -122,7 +113,7 @@ fi
 
 cmd="parallel"
 if ${dry_run}; then
-  if [ "${log_dir}" != "-" ]; then
+  if [ -n "${log_dir}" ]; then
     if [ -d "${log_dir}" ]; then
       echo "warning: actual run would fail here because the output log directory already exists"
     fi
@@ -130,7 +121,7 @@ if ${dry_run}; then
   fi
   cmd="${cmd} --dry-run"
 else
-  if [ "${log_dir}" != "-" ]; then
+  if [ -n "${log_dir}" ]; then
     if [ -d "${log_dir}" ]; then
       echo "error: output log directory '${log_dir}' already exists"
       exit 4
@@ -139,23 +130,28 @@ else
   fi
 fi
 
-if [ "${log_dir}" != "-" ]; then
+if [ -n "${log_dir}" ]; then
   cmd="${cmd} --joblog ${log_dir}/parallel.log"
 fi
-cmd="${cmd} fire ${config} ${template_args}"
-if [ "${log_dir}" != "-" ]; then
-  cmd="${cmd} &> ${log_dir}/job-{#}.out"
+job_cmd_template="fire ${config} ${template_args}"
+if [ -n "${log_dir}" ]; then
+  cmd="${cmd} ${job_cmd_template} >${log_dir}/job-{#}.out 2>&1"
+else
+  cmd="${cmd} ${job_cmd_template}"
 fi
 cmd="${cmd} ${parallel_args}"
 
 if ${dry_run}; then
-  echo "${cmd}"
-  ${cmd}
-  if ${follow}; then
-    echo "tail -f --pid=<parallel-pid> ${log_dir}/parallel.log"
+  # don't show user `--dry-run` that we'll use to print the jobs from
+  # parallel's perspective later
+  echo "${cmd}" | sed 's|--dry-run ||'
+  if [ -n "${log_dir}" ]; then
+    echo "parallel_pid=\$!"
+    echo "tail -f --pid=\"\${parallel_pid}\" ${log_dir}/parallel.log"
   fi
+  ${cmd}
 else
-  if ${follow}; then
+  if [ -n "${log_dir}" ]; then
     ${cmd} &
     parallel_pid=$!
     # wait until log file appears

--- a/Framework/app/fire-parallel
+++ b/Framework/app/fire-parallel
@@ -158,10 +158,8 @@ else
   if ${follow}; then
     ${cmd} &
     parallel_pid=$!
-    # give parallel some time to open the log file
-    sleep 1
     # watch log file until parallel completes all the jobs
-    tail -f --pid="${parallel_pid}" "${log_dir}/parallel.log"
+    tail --follow=name --retry --pid="${parallel_pid}" "${log_dir}/parallel.log"
   else
     ${cmd}
   fi

--- a/Framework/app/fire-parallel
+++ b/Framework/app/fire-parallel
@@ -158,8 +158,12 @@ else
   if ${follow}; then
     ${cmd} &
     parallel_pid=$!
+    # wait until log file appears
+    while ! [ -f "${log_dir}/parallel.log" ]; do
+      sleep 1
+    done
     # watch log file until parallel completes all the jobs
-    tail --follow=name --retry --pid="${parallel_pid}" "${log_dir}/parallel.log"
+    tail --follow --pid="${parallel_pid}" "${log_dir}/parallel.log"
   else
     ${cmd}
   fi

--- a/Framework/app/fire-parallel
+++ b/Framework/app/fire-parallel
@@ -149,7 +149,7 @@ fi
 cmd="${cmd} ${parallel_args}"
 
 if ${dry_run}; then
-  echo ${cmd}
+  echo "${cmd}"
   ${cmd}
   if ${follow}; then
     echo "tail -f --pid=<parallel-pid> ${log_dir}/parallel.log"

--- a/Framework/app/fire-parallel
+++ b/Framework/app/fire-parallel
@@ -1,0 +1,168 @@
+#!/bin/sh
+#  fire-parallel
+#
+# wrap fire with GNU's parallel to do multiple runs using
+# all available cores
+
+set -o nounset
+set -o errexit
+
+usage() {
+  cat <<HELP
+
+ fire-parallel {config.py} [template ...] [--] parallel ...
+
+  OPTIONS
+    --help|-h : print this help and exit
+    --dry-run : print the jobs that would be run instead of running them
+    --log-dir : specify where the logs for the jobs and parallel should be stored
+                if the special string '-', then the logs are not stored and instead
+                printed to the terminal. This '-' prevents '--follow' from being used.
+    --follow  : put the parallel run into the background and watch the parallel
+                job log while waiting for the jobs to complete
+                Cannot be used if '-' is used for '--log-dir'.
+    --        : signal that the rest of the arguments should be passed to GNU parallel
+
+  ARGUMENTS
+    config.py : configuration script to pass to fire for the parallel jobs
+    template  : template arguments to be passed to the config script after given values
+                by GNU parallel. These are the arguments using curly-braces (e.g. {n})
+                from the GNU parallel manual[0].
+    parallel  : all other arguments are passed to GNU parallel. Most commonly, these
+                are the arguments specifying the values for the template (e.g. '::: 1 2 3').
+                More detail on how to specify these values can be seen in the GNU parallel
+                manual[0].
+
+    [0]: https://www.gnu.org/software/parallel/man.html
+
+  EXAMPLE
+
+    The following runs 6 copies of 'fire config.py N' in parallel where N
+    is 10, 11, 12, 13, 14, or 15. The terminal output of these jobs is
+    saved in the "logs" directory and are named after their "sequence number"
+    according to parallel.
+
+      fire-parallel config.py ::: 10 11 12 13 14 15
+
+HELP
+}
+
+dry_run=false
+log_dir="logs"
+follow=false
+config=""
+template_args=""
+while [ $# -gt 0 ]; do
+  case "${1}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --dry-run)
+      dry_run=true
+      ;;
+    --follow)
+      follow=true
+      ;;
+    --log-dir)
+      shift
+      if [ $# -eq 0 ]; then
+        echo "error: the '--log-dir' option requires an argument after it"
+        exit 1
+      fi
+      log_dir="${1}"
+      ;;
+    --)
+      # user wants the following arguments to be given to GNU parallel
+      shift
+      break
+      ;;
+    "::"*)
+      # obviously a GNU parallel arg, break
+      break
+      ;;
+    *)
+      if [ "${config}" = "" ]; then
+        config="${1}"
+      else
+        template_args="${template_args} ${1}"
+      fi
+      ;;
+  esac
+  shift
+done
+
+# we left the while loop when encountering the break argument '--'
+# or the first obvious GNU parallel argument (starting with '::'),
+# so the rest of the command line arguments are the GNU parallel
+# arguments
+parallel_args="$*"
+if [ -z "${parallel_args}" ]; then
+  echo "error: providing 'parallel' arguments to specify the command line values is required"
+  exit 1
+fi
+
+# if template_args is empty, use the default behavior of GNU parallel
+# where the input line is provided in the same order its specified
+# on the command line. We need to specify this manually so that we
+# can add the capture-to-file suffix to the command.
+if [ -z "${template_args}" ]; then
+  template_args="{}"
+fi
+
+if ${follow} && [ "${log_dir}" = "-" ]; then
+  echo "error: cannot '--follow' when redirecting the logs to the terminal ('--log-dir -')"
+  exit 2
+fi
+
+if [ -z "${config}" ] || [ ! -f "${config}" ]; then
+  echo "error: the config script argument is required"
+  exit 3
+fi
+
+cmd="parallel"
+if ${dry_run}; then
+  if [ "${log_dir}" != "-" ]; then
+    if [ -d "${log_dir}" ]; then
+      echo "warning: actual run would fail here because the output log directory already exists"
+    fi
+    echo "mkdir \"${log_dir}\""
+  fi
+  cmd="${cmd} --dry-run"
+else
+  if [ "${log_dir}" != "-" ]; then
+    if [ -d "${log_dir}" ]; then
+      echo "error: output log directory '${log_dir}' already exists"
+      exit 4
+    fi
+    mkdir "${log_dir}"
+  fi
+fi
+
+if [ "${log_dir}" != "-" ]; then
+  cmd="${cmd} --joblog ${log_dir}/parallel.log"
+fi
+cmd="${cmd} fire ${config} ${template_args}"
+if [ "${log_dir}" != "-" ]; then
+  cmd="${cmd} &> ${log_dir}/job-{#}.out"
+fi
+cmd="${cmd} ${parallel_args}"
+
+if ${dry_run}; then
+  echo ${cmd}
+  ${cmd}
+  if ${follow}; then
+    echo "tail -f --pid=<parallel-pid> ${log_dir}/parallel.log"
+  fi
+else
+  if ${follow}; then
+    ${cmd} &
+    parallel_pid=$!
+    # give parallel some time to open the log file
+    sleep 1
+    # watch log file until parallel completes all the jobs
+    tail -f --pid="${parallel_pid}" "${log_dir}/parallel.log"
+  else
+    ${cmd}
+  fi
+fi

--- a/justfile
+++ b/justfile
@@ -107,6 +107,11 @@ test *ARGS:
 fire config_py *ARGS:
     denv_workspace="{{ this_denv_workspace }}" denv fire {{ config_py }} {{ ARGS }}
 
+# multiple runs of ldmx-sw fire with same input configuration script
+[no-cd]
+fire-parallel config_py *ARGS:
+    denv_workspace="{{ this_denv_workspace }}" denv fire-parallel {{ config_py }} {{ ARGS }}
+
 # run gdb on a config file
 [no-cd]
 debug config_py *ARGS:


### PR DESCRIPTION
I am adding a shell script that runs multiple copies of `fire` with different arguments to the same configuration script. This is only intended for batch processing and should **not** be used in development of ldmx-sw.

### What are the issues that this addresses?
This resolves #1863 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful. (below)
- [x] shellcheck
- [x] need to wait for updated dev image release that includes GNU parallel https://github.com/LDMX-Software/dev-build-context/releases/tag/v5.2.0
- [x] add documentation to doc site https://github.com/LDMX-Software/ldmx-software.github.io/issues/59
    - link to GNU parallel manual
    - point out that output is not "live" (job output only printed to terminal at end of job, saving to file slows everyone down since all jobs then are trying to "live" write their output to disk)
    - mention `hadd` for combining results
    - warnings about how there are no checks on data repetition (repeat run numbers or repeat input files)

## Testing
Using a simple inclusive simulation that takes the number of events and run number from the command line.
```python
from LDMX.Framework import ldmxcfg
p = ldmxcfg.Process('test')
from LDMX.SimCore import simulator as sim
mySim = sim.simulator( "mySim" )
mySim.setDetector('ldmx-det-v14-8gev')
from LDMX.SimCore import generators as gen
mySim.generators.append( gen.single_8gev_e_upstream_tagger() )
mySim.beamSpotSmear = [20.,80.,0.]
mySim.description = 'Basic test Simulation'
p.sequence = [ mySim ]
import sys
import LDMX.Ecal.EcalGeometry
import LDMX.Hcal.HcalGeometry
p.maxEvents = int(sys.argv[1])
p.run = int(sys.argv[2])
p.outputFiles = [f'events-run-{p.run}.root']
```

Generating 10 events with a single process.
```
tom@ty-lee:~/code/ldmx/1863-fire-parallel/test$ time just fire config.py 10 1                                                                                                                                                                 
# omit messages from inside process
---- LDMXSW: Event processing complete  --------                                                                                                                                                                                              

real    0m11.901s                                          
user    0m0.150s                                           
sys     0m0.094s  
```

Generating 10 events with two processes that have different run numbers.
```
tom@ty-lee:~/code/ldmx/1863-fire-parallel/test$ time just fire-parallel config.py 5 {} ::: 2 3                         
---- LDMXSW: Event processing complete  --------

real    0m8.528s
user    0m0.155s
sys     0m0.126s
```

which is about what I expected since the simulation-setup time dominates at this low number of events.