### PR TITLE
Remove G4 warnings about no production cuts

### DIFF
--- a/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
+++ b/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
@@ -14,6 +14,7 @@
 #include "G4GDMLEvaluator.hh"
 #include "G4LogicalVolumeStore.hh"
 #include "G4ProductionCuts.hh"
+#include "G4ProductionCutsTable.hh"
 #include "G4Region.hh"
 #include "G4RegionStore.hh"
 #include "G4SDManager.hh"
@@ -246,10 +247,7 @@ void AuxInfoReader::createRegion(const G4String& name,
   auto region = new G4Region(name);
   region->SetUserInformation(region_info);
   // To get rid of those pesky G4 warnings
-  auto defaultcuts = new G4ProductionCuts;
-  defaultcuts->SetProductionCut(
-      1. * mm);  // Omitting index applies it to all particle types
-  region->SetProductionCuts(defaultcuts);
+  region->SetProductionCuts(G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts());
 }
 // NOLINTEND
 

--- a/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
+++ b/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
@@ -13,9 +13,9 @@
 #include "G4FieldManager.hh"
 #include "G4GDMLEvaluator.hh"
 #include "G4LogicalVolumeStore.hh"
+#include "G4ProductionCuts.hh"
 #include "G4Region.hh"
 #include "G4RegionStore.hh"
-#include "G4ProductionCuts.hh"
 #include "G4SDManager.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4UniformMagField.hh"
@@ -245,9 +245,10 @@ void AuxInfoReader::createRegion(const G4String& name,
   // NOLINTBEGIN
   auto region = new G4Region(name);
   region->SetUserInformation(region_info);
-  //To get rid of those pesky G4 warnings
+  // To get rid of those pesky G4 warnings
   auto defaultcuts = new G4ProductionCuts;
-  defaultcuts->SetProductionCut(1.*mm);//Omitting index applies it to all particle types
+  defaultcuts->SetProductionCut(
+      1. * mm);  // Omitting index applies it to all particle types
   region->SetProductionCuts(defaultcuts);
 }
 // NOLINTEND

--- a/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
+++ b/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
@@ -15,6 +15,7 @@
 #include "G4LogicalVolumeStore.hh"
 #include "G4Region.hh"
 #include "G4RegionStore.hh"
+#include "G4ProductionCuts.hh"
 #include "G4SDManager.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4UniformMagField.hh"
@@ -244,6 +245,10 @@ void AuxInfoReader::createRegion(const G4String& name,
   // NOLINTBEGIN
   auto region = new G4Region(name);
   region->SetUserInformation(region_info);
+  //To get rid of those pesky G4 warnings
+  auto defaultcuts = new G4ProductionCuts;
+  defaultcuts->SetProductionCut(1.*mm);//Omitting index applies it to all particle types
+  region->SetProductionCuts(defaultcuts);
 }
 // NOLINTEND
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
Resolving #1891 with a quick fix.
Geant4 is complaining because we're creating G4Regions (to use for other purposes) but not setting explicit production cuts.
The default production cut for most physics lists is ~1 mm, plus or minus a few tenths of a mm, so I just set it to 1 mm.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
Before:
<img width="1622" height="342" alt="image" src="https://github.com/user-attachments/assets/60d19d9a-4f29-43bb-bfc8-65e1aa5ebd15" />

After:
<img width="747" height="201" alt="image" src="https://github.com/user-attachments/assets/8d01e60a-864f-4039-ba3c-6526cfdb35d1" />
