### PR TITLE
Exit gracefully when PREEMPTED

### DIFF
--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -24,6 +24,8 @@
 // This code allows ldmx-app to exit gracefully when receiving preemption
 // signals from the SDF (SIGUSR2) or Ctrl-c (SIGINT). It finishes the current
 // event and closes ROOT files properly instead of losing work.
+// NOTE: This seems to be container dependent. It has been tested and works
+//       with apptainer while does not work with podman.
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern volatile std::sig_atomic_t preemption_received_;
 

--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -22,8 +22,9 @@
 // using namespace framework;
 
 // This code allows ldmx-app to exit gracefully when receiving preemption
-// signals from the HPC (SIGUSR2) or Ctrl-c (SIGINT). It finishes the current
+// signals from the SDF (SIGUSR2) or Ctrl-c (SIGINT). It finishes the current
 // event and closes ROOT files properly instead of losing work.
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern volatile std::sig_atomic_t preemption_received_;
 
 static void softFinish(int sig, siginfo_t* siginfo, void* context) {
@@ -119,6 +120,7 @@ int main(int argc, char* argv[]) try {
     //  where logging is closed, so we can do one more error message and then
     //  close it.
     // ldmx_log macro needs this variable to be named 'the_log_'
+    // NOLINTNEXTLINE(readability-identifier-naming)
     auto the_log_{framework::logging::makeLogger("fire")};
     ldmx_log(fatal) << "[" << e.name() << "] : " << e.message() << "\n"
                     << "  at " << e.module() << ":" << e.line() << " in "

--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -25,7 +25,7 @@
 // signals from the SDF (SIGUSR2) or Ctrl-c (SIGINT). It finishes the current
 // event and closes ROOT files properly instead of losing work.
 // NOTE: This seems to be container dependent. It has been tested and works
-//       with apptainer while does not work with podman.
+//       with apptainer v1.2 (at SDF) while does not work with podman.
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern volatile std::sig_atomic_t preemption_received_;
 

--- a/Framework/app/fire.cxx
+++ b/Framework/app/fire.cxx
@@ -21,16 +21,14 @@
  */
 // using namespace framework;
 
-// This code allows ldmx-app to exit gracefully when Ctrl-c is used. It is
-// currently causing segfaults when certain processors are used.  The code
-// will remain commented out until these issues are investigated further.
-/*
-static Process* p { 0 };
+// This code allows ldmx-app to exit gracefully when receiving preemption
+// signals from the HPC (SIGUSR2) or Ctrl-c (SIGINT). It finishes the current
+// event and closes ROOT files properly instead of losing work.
+extern volatile std::sig_atomic_t preemption_received_;
 
-static void softFinish (int sig, siginfo_t *siginfo, void *context) {
-if (p) p->requestFinish();
+static void softFinish(int sig, siginfo_t* siginfo, void* context) {
+  preemption_received_ = 1;
 }
-*/
 
 /**
  * @func printUsage
@@ -90,22 +88,25 @@ int main(int argc, char* argv[]) try {
   std::cout << "---- LDMXSW: Configuration load complete  --------"
             << std::endl;
 
-  // If Ctrl-c is used, immediately exit the application.
+  // Setup signal handlers for graceful shutdown
   struct sigaction act;
   memset(&act, '\0', sizeof(act));
-  if (sigaction(SIGINT, &act, NULL) < 0) {
-    perror("sigaction");
+  act.sa_sigaction = &softFinish;
+  act.sa_flags = SA_SIGINFO;
+
+  // Handle SIGUSR2 (SDF preemption signal)
+  if (sigaction(SIGUSR2, &act, NULL) < 0) {
+    std::cerr << "Error setting up SIGUSR2 handler: " << strerror(errno)
+              << std::endl;
     return 5;
   }
 
-  // See comment above for reason why this code is commented out.
-  /* Use the sa_sigaction field because the handles has two additional
-   * parameters */
-  // act.sa_sigaction = &softFinish;
-
-  /* The SA_SIGINFO flag tells sigaction() to use the sa_sigaction field, not
-   * sa_handler. */
-  // act.sa_flags = SA_SIGINFO;
+  // Also handle SIGINT (Ctrl-C)
+  if (sigaction(SIGINT, &act, NULL) < 0) {
+    std::cerr << "Error setting up SIGINT handler: " << strerror(errno)
+              << std::endl;
+    return 5;
+  }
 
   std::cout << "---- LDMXSW: Starting event processing --------" << std::endl;
 

--- a/Framework/include/Framework/Logger.h
+++ b/Framework/include/Framework/Logger.h
@@ -145,6 +145,7 @@ class Formatter {
  * Assumes to have access to a variable named the_log_ of type logger.
  * Input logging level (without namespace or enum).
  */
+// NOLINTNEXTLINE(readability-identifier-naming)
 #define ldmx_log(lvl) BOOST_LOG_SEV(the_log_, ::framework::logging::level::lvl)
 
 #endif  // FRAMEWORK_LOGGER_H

--- a/Framework/include/Framework/Process.h
+++ b/Framework/include/Framework/Process.h
@@ -16,6 +16,7 @@
 #include "Framework/StorageControl.h"
 
 // STL
+#include <csignal>
 #include <map>
 #include <memory>
 #include <vector>

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -21,6 +21,7 @@
 #include "TROOT.h"
 
 // Preemption flag that can be set by signal handlers
+// NOLINTNEXTLINE(readability-identifier-naming)
 volatile std::sig_atomic_t preemption_received_ = 0;
 
 namespace framework {

--- a/Framework/src/Framework/Process.cxx
+++ b/Framework/src/Framework/Process.cxx
@@ -20,6 +20,9 @@
 #include "TFile.h"
 #include "TROOT.h"
 
+// Preemption flag that can be set by signal handlers
+volatile std::sig_atomic_t preemption_received_ = 0;
+
 namespace framework {
 
 Process::Process(const framework::config::Parameters &configuration)
@@ -219,6 +222,13 @@ void Process::run() {
       event_limit = total_events_;
     }
     while (n_events_processed < event_limit) {
+      // Check for preemption before processing each event
+      if (preemption_received_) {
+        ldmx_log(fatal)
+            << "Preemption signal received, stopping event generation";
+        break;
+      }
+
       total_tries++;
       num_tries++;
 
@@ -344,9 +354,10 @@ void Process::run() {
       }
 
       bool event_completed = true;
-      while (master_file->nextEvent(
+      while (!preemption_received_ &&
+             master_file->nextEvent(
                  storage_controller_.keepEvent(event_completed)) &&
-             (event_limit_ < 0 || (n_events_processed) < event_limit_)) {
+             ((event_limit_ < 0) || (n_events_processed < event_limit_))) {
         // clean up for storage control calculation
         storage_controller_.resetEventState();
         logging::Formatter::set(the_event.getEventNumber());
@@ -373,6 +384,11 @@ void Process::run() {
 
         n_events_processed++;
       }  // loop through events
+
+      if (preemption_received_) {
+        ldmx_log(fatal) << "Preemption signal received, stopping event "
+                           "processing and closing files";
+      }
 
       bool leave_early{false};
       if (event_limit_ > 0 && n_events_processed == event_limit_) {

--- a/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
+++ b/SimCore/src/SimCore/Geo/AuxInfoReader.cxx
@@ -247,7 +247,8 @@ void AuxInfoReader::createRegion(const G4String& name,
   auto region = new G4Region(name);
   region->SetUserInformation(region_info);
   // To get rid of those pesky G4 warnings
-  region->SetProductionCuts(G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts());
+  region->SetProductionCuts(G4ProductionCutsTable::GetProductionCutsTable()
+                                ->GetDefaultProductionCuts());
 }
 // NOLINTEND
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1918

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

I tested both the generation and the event reading with the `ctrl-c` option, this indeed closes gracefully and the output root file is not broken, yaay!
Hard to test the preempt on SDF.... as it happens "randomly", I say we merge this and whenever a preempt happens come back to it.
