### PR TITLE
Sample validation DQM PIDs need to shift

### DIFF
--- a/DQM/include/DQM/SampleValidation.h
+++ b/DQM/include/DQM/SampleValidation.h
@@ -19,7 +19,7 @@ class SampleValidation : public framework::Analyzer {
       : Analyzer(name, process) {}
   virtual void configure(framework::config::Parameters& ps) override;
   virtual void analyze(const framework::Event& event) override;
-  int pdgidLabel(const int pdgid);
+  float pdgidLabel(const int pdgid);
 
  private:
   std::string target_scoring_plane_passname_;

--- a/DQM/python/dqm.py
+++ b/DQM/python/dqm.py
@@ -1058,13 +1058,13 @@ class SampleValidation(ldmxcfg.Analyzer) :
             "#pi^{0}",                 # 9
             "K^{+}",                   # 10
             "K^{-}",                   # 11
-            "k_{L}",                   # 12
-            "k_{S}",                   # 13
+            "K_{L}",                   # 12
+            "K_{S}",                   # 13
             "light-N",                 # 14
             "heavy-N",                 # 15
             "#Lambda / #Sigma / #Xi",  # 16
             "A'",                      # 17
-            "else",
+            "else",                    # 18
         ]
 
         #primary histograms

--- a/DQM/src/DQM/SampleValidation.cxx
+++ b/DQM/src/DQM/SampleValidation.cxx
@@ -107,7 +107,7 @@ void SampleValidation::analyze(const framework::Event& event) {
   return;
 }
 
-int SampleValidation::pdgidLabel(const int pdgid) {
+float SampleValidation::pdgidLabel(const int pdgid) {
   // initially assign label as "anything else"/overflow value,
   // only change if the pdg id is something of interest
   int label = 18;
@@ -126,8 +126,9 @@ int SampleValidation::pdgidLabel(const int pdgid) {
   if (pdgid == 130) label = 12;   // K-Long
   if (pdgid == 310) label = 13;   // K-Short
   if (pdgid == 3122 || pdgid == 3222 || pdgid == 3212 || pdgid == 3112 ||
-      pdgid == 3322 || pdgid == 3312)
-    label = 16;  // strange baryon
+      pdgid == 3322 || pdgid == 3312) {
+    label = 16;  // strange baryons
+  }
   /*
    * Nuclear PDG codes are given by ±10LZZZAAAI so to find the atomic
    * number, we divide by 10 (to lose I) and then take the modulo
@@ -143,7 +144,12 @@ int SampleValidation::pdgidLabel(const int pdgid) {
   // dark photon, need pdg id for other models like ALPs and SIMPs
   if (pdgid == 622) label = 17;
 
-  return label;
+  if (label == 18) {
+    ldmx_log(debug) << "Unrecognized PDG ID: " << pdgid
+                    << ", assigning to 'else'";
+  }
+
+  return label + 0.5;
 }
 
 }  // namespace dqm


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
When shooting a 622 particle it ends up in the strange barion category, and shooting other stuff ends up in A' instead of the else category

<img width="737" height="573" alt="Screenshot 2026-01-22 at 11 55 27" src="https://github.com/user-attachments/assets/94f548cf-e6f5-494f-b01c-b5e498889164" />


## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

<img width="696" height="529" alt="Screenshot 2026-01-22 at 20 51 04" src="https://github.com/user-attachments/assets/5af7a876-67f1-420c-828e-41fd72fa7665" />


(For the record I was shooting a tau)
