### PR TITLE
Add fallback zero Tesla CKF

### DIFF
--- a/Tracking/include/Tracking/Reco/CKFProcessor.h
+++ b/Tracking/include/Tracking/Reco/CKFProcessor.h
@@ -201,7 +201,7 @@ class CKFProcessor final : public TrackingGeometryUser {
   // 1DOF pvalues: 0.1 = 2.706 0.05 = 3.841 0.025 = 5.024 0.01 = 6.635 0.005
   // = 7.879 The probability to reject a good measurement is pvalue The
   // probability to reject an outlier is given in NIM A262 (1987) 444-450
-  double outlier_pval_{3.84};
+  double outlier_pval_;
 
   // The output track collection
   std::string out_trk_collection_{"Tracks"};
@@ -226,10 +226,18 @@ class CKFProcessor final : public TrackingGeometryUser {
   std::shared_ptr<tracking::reco::TrackExtrapolatorTool<CkfPropagator>>
       trk_extrap_;
 
+  // Zero-B CKF as fallback
+  std::unique_ptr<const CkfPropagator> propagator_zero_b_;
+  std::unique_ptr<
+      const Acts::CombinatorialKalmanFilter<CkfPropagator, TrackContainer>>
+      ckf_zero_b_;
+  std::shared_ptr<tracking::reco::TrackExtrapolatorTool<CkfPropagator>>
+      trk_extrap_zero_b_;
+
   /// n seeds and n tracks
-  int nseeds_{0};
-  int ntracks_{0};
-  int eventnr_{0};
+  int nseeds_;
+  int ntracks_;
+  int eventnr_;
 
   // BField Systematics
   std::vector<double> map_offset_{

--- a/Tracking/include/Tracking/Reco/CKFProcessor.h
+++ b/Tracking/include/Tracking/Reco/CKFProcessor.h
@@ -234,10 +234,32 @@ class CKFProcessor final : public TrackingGeometryUser {
   std::shared_ptr<tracking::reco::TrackExtrapolatorTool<CkfPropagator>>
       trk_extrap_zero_b_;
 
+  // Const-B (1.5T) CKF as fallback for tagger
+  std::unique_ptr<const CkfPropagator> propagator_const_b_;
+  std::unique_ptr<
+      const Acts::CombinatorialKalmanFilter<CkfPropagator, TrackContainer>>
+      ckf_const_b_;
+  std::shared_ptr<tracking::reco::TrackExtrapolatorTool<CkfPropagator>>
+      trk_extrap_const_b_;
+
   /// n seeds and n tracks
   int nseeds_;
   int ntracks_;
   int eventnr_;
+
+  // CKF fallback statistics
+  int n_fieldmap_ckf_failed_tagger_{0};
+  int n_fieldmap_ckf_failed_recoil_{0};
+  int n_constb_ckf_recovered_tagger_{0};
+  int n_zerob_ckf_recovered_recoil_{0};
+
+  // Extrapolation fallback statistics
+  int n_fieldmap_target_extrap_failed_tagger_{0};
+  int n_constb_target_extrap_recovered_tagger_{0};
+  int n_fieldmap_target_extrap_failed_recoil_{0};
+  int n_zerob_target_extrap_recovered_recoil_{0};
+  int n_fieldmap_ecal_extrap_failed_recoil_{0};
+  int n_zerob_ecal_extrap_recovered_recoil_{0};
 
   // BField Systematics
   std::vector<double> map_offset_{

--- a/Tracking/python/tracking.py
+++ b/Tracking/python/tracking.py
@@ -122,8 +122,6 @@ class CKFProcessor(Producer):
         Can be used to define the number of pion states generated with uniform
         distributions to be propagated through the tracking geometry for
         debugging purposes. <functionality to be moved>
-    steps_output_file_path_ : string
-        DEPRECATED TO BE REMOVED
     bfield : float
         <functionality to be removed>
         If using a constant bfield, this is the BZ component. 

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -27,6 +27,11 @@ void CKFProcessor::onNewRun(const ldmx::RunHeader& rh) {
   profiling_map_["ckf_run"] = 0.;
   profiling_map_["result_loop"] = 0.;
 
+  // Initialize counters
+  nseeds_ = 0;
+  ntracks_ = 0;
+  eventnr_ = 0;
+
   // Generate a constant magnetic field
   Acts::Vector3 b_field(0., 0., bfield_ * Acts::UnitConstants::T);
 
@@ -134,13 +139,9 @@ void CKFProcessor::onNewRun(const ldmx::RunHeader& rh) {
   nav_cfg.resolveSensitive = true;
   const Acts::Navigator navigator(nav_cfg);
 
-  // Setup the propagators
-  propagator_ =
-      const_b_field_
-          ? std::make_unique<CkfPropagator>(const_stepper, navigator)
-          : std::make_unique<CkfPropagator>(
-                stepper, navigator,
-                Acts::getDefaultLogger("CKF_PROP", acts_logging_level));
+  propagator_ = std::make_unique<CkfPropagator>(
+      stepper, navigator,
+      Acts::getDefaultLogger("CKF_PROP", acts_logging_level));
 
   // Setup the finder / fitters
   ckf_ = std::make_unique<std::decay_t<decltype(*ckf_)>>(
@@ -160,6 +161,16 @@ void CKFProcessor::onNewRun(const ldmx::RunHeader& rh) {
   trk_extrap_zero_b_ =
       std::make_shared<std::decay_t<decltype(*trk_extrap_zero_b_)>>(
           *propagator_zero_b_, geometryContext(), magneticFieldContext());
+
+  // Setup const-B (1.5T) CKF as fallback for tagger
+  propagator_const_b_ =
+      std::make_unique<CkfPropagator>(const_stepper, navigator);
+  ckf_const_b_ = std::make_unique<std::decay_t<decltype(*ckf_const_b_)>>(
+      *propagator_const_b_,
+      Acts::getDefaultLogger("CKF_CONST_B", acts_logging_level));
+  trk_extrap_const_b_ =
+      std::make_shared<std::decay_t<decltype(*trk_extrap_const_b_)>>(
+          *propagator_const_b_, geometryContext(), magneticFieldContext());
 }  // end of CKFProcessor::onNewRun()
 
 void CKFProcessor::produce(framework::Event& event) {
@@ -252,7 +263,7 @@ void CKFProcessor::produce(framework::Event& event) {
 
   if (seed_tracks.empty()) {
     std::vector<ldmx::Track> empty;
-    ldmx_log(info) << "No seed tracks, returning...";
+    ldmx_log(warn) << "No seed tracks, returning...";
     event.add(out_trk_collection_, empty);
     return;
   }
@@ -425,12 +436,35 @@ void CKFProcessor::produce(framework::Event& event) {
 
     auto start_params = start_parameters.at(track_id).parameters().transpose();
 
-    // If field-map CKF fails, try zero-B CKF as fallback (only for recoil
-    // tracking)
-    if (!results.ok() && !tagger_tracking_) {
-      ldmx_log(debug) << "    Field-map CKF failed, trying zero-B CKF fallback";
-      results = ckf_zero_b_->findTracks(start_parameters.at(track_id),
-                                        ckf_options, tc);
+    // If field-map CKF fails, try appropriate fallback based on tracking system
+    if (!results.ok()) {
+      if (!tagger_tracking_) {
+        // Recoil tracking: try zero-B CKF as fallback
+        n_fieldmap_ckf_failed_recoil_++;
+        ldmx_log(debug)
+            << "    Field-map CKF failed, trying zero-B CKF fallback";
+        results = ckf_zero_b_->findTracks(start_parameters.at(track_id),
+                                          ckf_options, tc);
+        if (results.ok()) {
+          n_zerob_ckf_recovered_recoil_++;
+          ldmx_log(debug) << "    Yay! Zero-B CKF succeeded as fallback!";
+        } else {
+          ldmx_log(debug) << "    Zero-B CKF also failed!";
+        }
+      } else {
+        // Tagger tracking: try const-B (1.5T) CKF as fallback
+        n_fieldmap_ckf_failed_tagger_++;
+        ldmx_log(debug)
+            << "    Field-map CKF failed, trying const-B (1.5T) CKF fallback";
+        results = ckf_const_b_->findTracks(start_parameters.at(track_id),
+                                           ckf_options, tc);
+        if (results.ok()) {
+          n_constb_ckf_recovered_tagger_++;
+          ldmx_log(debug) << "    Yay! Const-B CKF succeeded as fallback!";
+        } else {
+          ldmx_log(debug) << "    Const-B CKF also failed!";
+        }
+      }
     }
 
     ldmx_log(debug)
@@ -461,14 +495,42 @@ void CKFProcessor::produce(framework::Event& event) {
       bool success = trk_extrap_->trackStateAtSurface(
           track, target_surface_, ts_at_target, ldmx::TrackStateType::AtTarget);
 
-      // If extrapolation with field fails, try zero-B fallback (only for recoil
-      // tracking)
-      if (!success && !tagger_tracking_) {
-        ldmx_log(debug)
-            << "    Field-map extrapolation failed, trying zero-B fallback";
-        success = trk_extrap_zero_b_->trackStateAtSurface(
-            track, target_surface_, ts_at_target,
-            ldmx::TrackStateType::AtTarget);
+      // If extrapolation with field fails, try appropriate fallback based on
+      // tracking system
+      if (!success) {
+        if (tagger_tracking_) {
+          // Tagger tracking: try const-B (1.5T) fallback
+          n_fieldmap_target_extrap_failed_tagger_++;
+          ldmx_log(debug) << "    Field-map target extrapolation failed, "
+                             "trying const-B (1.5T) fallback";
+          success = trk_extrap_const_b_->trackStateAtSurface(
+              track, target_surface_, ts_at_target,
+              ldmx::TrackStateType::AtTarget);
+          if (success) {
+            n_constb_target_extrap_recovered_tagger_++;
+            ldmx_log(debug)
+                << "    Yay! Const-B target extrapolation successful!";
+          } else {
+            ldmx_log(debug) << "    Both field-map and Const-B target "
+                               "extrapolation failed!";
+          }
+        } else {
+          // Recoil tracking: try zero-B fallback
+          n_fieldmap_target_extrap_failed_recoil_++;
+          ldmx_log(debug) << "    Field-map target extrapolation failed, "
+                             "trying zero-B fallback";
+          success = trk_extrap_zero_b_->trackStateAtSurface(
+              track, target_surface_, ts_at_target,
+              ldmx::TrackStateType::AtTarget);
+          if (success) {
+            n_zerob_target_extrap_recovered_recoil_++;
+            ldmx_log(debug)
+                << "    Yay! Zero-B target extrapolation successful!";
+          } else {
+            ldmx_log(debug)
+                << "    Both field-map and Zero-B target extrapolation failed!";
+          }
+        }
       }
 
       // Check if the extrapolation to target succeeded
@@ -483,19 +545,20 @@ void CKFProcessor::produce(framework::Event& event) {
                         << ts_at_target.params_[4];
 
         trk.addTrackState(ts_at_target);
-      } else {
-        ldmx_log(info) << "    Could not extrapolate to target! nhits = "
-                       << track.nMeasurements() << " Printing track states:  ";
+      }  // end if success
+      else {
+        ldmx_log(debug) << "    Could not extrapolate to target! nhits = "
+                        << track.nMeasurements() << " Printing track states:  ";
         for (const auto ts : track.trackStatesReversed()) {
           if (ts.hasSmoothed()) {
-            ldmx_log(info) << "    Track momentum for smoothed track state = "
-                           << 1 / ts.smoothed()[Acts::eBoundQOverP];
-            ldmx_log(info) << "    Parameters: " << ts.smoothed().transpose();
+            ldmx_log(debug) << "    Track momentum for smoothed track state = "
+                            << 1 / ts.smoothed()[Acts::eBoundQOverP];
+            ldmx_log(debug) << "    Parameters: " << ts.smoothed().transpose();
           } else {
-            ldmx_log(info) << "    Track state not smoothed!";
+            ldmx_log(debug) << "    Track state not smoothed!";
           }
         }
-        ldmx_log(info) << "    ...skipping this track candidate...";
+        ldmx_log(debug) << "    ...skipping this track candidate...";
         continue;
       }
 
@@ -631,6 +694,22 @@ void CKFProcessor::produce(framework::Event& event) {
         success = trk_extrap_->trackStateAtSurface(
             track, ecal_surface, ts_at_ecal, ldmx::TrackStateType::AtECAL);
 
+        // If extrapolation with field fails, try zero-B fallback
+        if (!success) {
+          n_fieldmap_ecal_extrap_failed_recoil_++;
+          ldmx_log(debug) << "    Field-map ECAL extrapolation failed, trying "
+                             "zero-B fallback";
+          success = trk_extrap_zero_b_->trackStateAtSurface(
+              track, ecal_surface, ts_at_ecal, ldmx::TrackStateType::AtECAL);
+          if (success) {
+            n_zerob_ecal_extrap_recovered_recoil_++;
+            ldmx_log(debug) << "    Yay! Zero-B ECAL extrapolation successful";
+          } else {
+            ldmx_log(debug)
+                << "    Both field-map and Zero-B ECAL extrapolation failed!";
+          }
+        }
+
         if (success) {
           trk.addTrackState(ts_at_ecal);
           ldmx_log(debug) << "    Successfully obtained TrackState at Ecal";
@@ -641,8 +720,8 @@ void CKFProcessor::produce(framework::Event& event) {
                           << ", theta = " << ts_at_ecal.params_[3]
                           << ", QoP = " << ts_at_ecal.params_[4];
         } else {
-          ldmx_log(info) << "    Could not extrapolate to ECAL!! Please check "
-                            "the track states";
+          ldmx_log(debug) << "    Could not extrapolate to ECAL!! Please check "
+                             "the track states";
         }
       }
 
@@ -702,29 +781,89 @@ void CKFProcessor::onProcessStart() {
 }
 
 void CKFProcessor::onProcessEnd() {
-  ldmx_log(info) << "found " << ntracks_ << " tracks  / " << nseeds_
+  ldmx_log(info) << "--------------------------------- ";
+  ldmx_log(info) << "Found " << ntracks_ << " tracks  / " << nseeds_
                  << " nseeds";
   ldmx_log(info) << "AVG Time/Event: " << std::fixed << std::setprecision(1)
                  << processing_time_ / nevents_ << " ms";
   ldmx_log(info) << "Breakdown::";
-  ldmx_log(info) << "setup       Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  setup       Avg Time/Event = " << std::fixed
                  << std::setprecision(3) << profiling_map_["setup"] / nevents_
                  << " ms";
-  ldmx_log(info) << "hits        Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  hits        Avg Time/Event = " << std::fixed
                  << std::setprecision(2) << profiling_map_["hits"] / nevents_
                  << " ms";
-  ldmx_log(info) << "seeds       Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  seeds       Avg Time/Event = " << std::fixed
                  << std::setprecision(3) << profiling_map_["seeds"] / nevents_
                  << " ms";
-  ldmx_log(info) << "cf_setup    Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  ckf_setup    Avg Time/Event = " << std::fixed
                  << std::setprecision(3)
                  << profiling_map_["ckf_setup"] / nevents_ << " ms";
-  ldmx_log(info) << "ckf_run     Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  ckf_run     Avg Time/Event = " << std::fixed
                  << std::setprecision(3) << profiling_map_["ckf_run"] / nevents_
                  << " ms";
-  ldmx_log(info) << "result_loop Avg Time/Event = " << std::fixed
+  ldmx_log(info) << "  result_loop Avg Time/Event = " << std::fixed
                  << std::setprecision(1)
                  << profiling_map_["result_loop"] / nevents_ << " ms";
+
+  // CKF fallback statistics
+  ldmx_log(info) << "CKF Fallback Statistics::";
+  if (tagger_tracking_) {
+    ldmx_log(info) << "  Tagger: Field-map CKF failed "
+                   << n_fieldmap_ckf_failed_tagger_
+                   << " times, const-B CKF recovered "
+                   << n_constb_ckf_recovered_tagger_ << " ("
+                   << (n_fieldmap_ckf_failed_tagger_ > 0
+                           ? 100.0 * n_constb_ckf_recovered_tagger_ /
+                                 n_fieldmap_ckf_failed_tagger_
+                           : 0.0)
+                   << "%)";
+
+    // Extrapolation fallback statistics for tagger
+    ldmx_log(info) << "Extrapolation Fallback Statistics::";
+    ldmx_log(info) << "  Tagger Target: Field-map extrap failed "
+                   << n_fieldmap_target_extrap_failed_tagger_
+                   << " times, const-B extrap recovered "
+                   << n_constb_target_extrap_recovered_tagger_ << " ("
+                   << (n_fieldmap_target_extrap_failed_tagger_ > 0
+                           ? 100.0 * n_constb_target_extrap_recovered_tagger_ /
+                                 n_fieldmap_target_extrap_failed_tagger_
+                           : 0.0)
+                   << "%)";
+  }
+
+  if (!tagger_tracking_) {
+    ldmx_log(info) << "  Recoil: Field-map CKF failed "
+                   << n_fieldmap_ckf_failed_recoil_
+                   << " times, zero-B CKF recovered "
+                   << n_zerob_ckf_recovered_recoil_ << " ("
+                   << (n_fieldmap_ckf_failed_recoil_ > 0
+                           ? 100.0 * n_zerob_ckf_recovered_recoil_ /
+                                 n_fieldmap_ckf_failed_recoil_
+                           : 0.0)
+                   << "%)";
+
+    // Extrapolation fallback statistics
+    ldmx_log(info) << "Extrapolation Fallback Statistics::";
+    ldmx_log(info) << "  Recoil Target: Field-map extrap failed "
+                   << n_fieldmap_target_extrap_failed_recoil_
+                   << " times, zero-B extrap recovered "
+                   << n_zerob_target_extrap_recovered_recoil_ << " ("
+                   << (n_fieldmap_target_extrap_failed_recoil_ > 0
+                           ? 100.0 * n_zerob_target_extrap_recovered_recoil_ /
+                                 n_fieldmap_target_extrap_failed_recoil_
+                           : 0.0)
+                   << "%)";
+    ldmx_log(info) << "  Recoil ECAL: Field-map extrap failed "
+                   << n_fieldmap_ecal_extrap_failed_recoil_
+                   << " times, zero-B extrap recovered "
+                   << n_zerob_ecal_extrap_recovered_recoil_ << " ("
+                   << (n_fieldmap_ecal_extrap_failed_recoil_ > 0
+                           ? 100.0 * n_zerob_ecal_extrap_recovered_recoil_ /
+                                 n_fieldmap_ecal_extrap_failed_recoil_
+                           : 0.0)
+                   << "%)";
+  }
 }
 
 void CKFProcessor::configure(framework::config::Parameters& parameters) {

--- a/Tracking/src/Tracking/Reco/CKFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/CKFProcessor.cxx
@@ -140,14 +140,27 @@ void CKFProcessor::onNewRun(const ldmx::RunHeader& rh) {
           ? std::make_unique<CkfPropagator>(const_stepper, navigator)
           : std::make_unique<CkfPropagator>(
                 stepper, navigator,
-                Acts::getDefaultLogger("ACTS_PROP", acts_logging_level));
+                Acts::getDefaultLogger("CKF_PROP", acts_logging_level));
 
   // Setup the finder / fitters
   ckf_ = std::make_unique<std::decay_t<decltype(*ckf_)>>(
       *propagator_, Acts::getDefaultLogger("CKF", acts_logging_level));
   trk_extrap_ = std::make_shared<std::decay_t<decltype(*trk_extrap_)>>(
       *propagator_, geometryContext(), magneticFieldContext());
-}
+
+  // Setup zero-B CKF as fallback
+  Acts::ConstantBField zero_b_field(Acts::Vector3(0., 0., 0.));
+  const auto zero_b_stepper = Acts::EigenStepper<>{
+      std::make_shared<Acts::ConstantBField>(zero_b_field)};
+  propagator_zero_b_ =
+      std::make_unique<CkfPropagator>(zero_b_stepper, navigator);
+  ckf_zero_b_ = std::make_unique<std::decay_t<decltype(*ckf_zero_b_)>>(
+      *propagator_zero_b_,
+      Acts::getDefaultLogger("CKF_ZERO_B", acts_logging_level));
+  trk_extrap_zero_b_ =
+      std::make_shared<std::decay_t<decltype(*trk_extrap_zero_b_)>>(
+          *propagator_zero_b_, geometryContext(), magneticFieldContext());
+}  // end of CKFProcessor::onNewRun()
 
 void CKFProcessor::produce(framework::Event& event) {
   eventnr_++;
@@ -162,9 +175,8 @@ void CKFProcessor::produce(framework::Event& event) {
 
   nevents_++;
 
-  auto logging_level = Acts::Logging::DEBUG;
-  ACTS_LOCAL_LOGGER(
-      Acts::getDefaultLogger("LDMX Tracking Geometry Maker", logging_level));
+  ACTS_LOCAL_LOGGER(Acts::getDefaultLogger("LDMX Tracking Geometry Maker",
+                                           Acts::Logging::DEBUG));
 
   // Move this at the start of the producer
   Acts::PropagatorOptions<Acts::StepperPlainOptions,
@@ -406,10 +418,21 @@ void CKFProcessor::produce(framework::Event& event) {
     ldmx_log(debug) << "  Checking options:  multiple scattering = "
                     << ckf_options.multipleScattering
                     << "  energy loss = " << ckf_options.energyLoss;
+
+    // Try field-map CKF first
     auto results =
         ckf_->findTracks(start_parameters.at(track_id), ckf_options, tc);
 
     auto start_params = start_parameters.at(track_id).parameters().transpose();
+
+    // If field-map CKF fails, try zero-B CKF as fallback (only for recoil
+    // tracking)
+    if (!results.ok() && !tagger_tracking_) {
+      ldmx_log(debug) << "    Field-map CKF failed, trying zero-B CKF fallback";
+      results = ckf_zero_b_->findTracks(start_parameters.at(track_id),
+                                        ckf_options, tc);
+    }
+
     ldmx_log(debug)
         << "  Checking CKF success for track candidate with params: "
         << " D0 = " << start_params[0] << " Z0 = " << start_params[1]
@@ -437,6 +460,17 @@ void CKFProcessor::produce(framework::Event& event) {
       // Extrapolate to the target
       bool success = trk_extrap_->trackStateAtSurface(
           track, target_surface_, ts_at_target, ldmx::TrackStateType::AtTarget);
+
+      // If extrapolation with field fails, try zero-B fallback (only for recoil
+      // tracking)
+      if (!success && !tagger_tracking_) {
+        ldmx_log(debug)
+            << "    Field-map extrapolation failed, trying zero-B fallback";
+        success = trk_extrap_zero_b_->trackStateAtSurface(
+            track, target_surface_, ts_at_target,
+            ldmx::TrackStateType::AtTarget);
+      }
+
       // Check if the extrapolation to target succeeded
       if (success) {
         ldmx_log(debug) << "    Successfully obtained TrackState at target";

--- a/Tracking/src/Tracking/Reco/GSFProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/GSFProcessor.cxx
@@ -71,7 +71,7 @@ void GSFProcessor::onNewRun(const ldmx::RunHeader& rh) {
                         // default_transformBField));
                         transform_pos, transform_b_field));
 
-  auto acts_logging_level = Acts::Logging::ERROR;
+  auto acts_logging_level = Acts::Logging::FATAL;
 
   if (debug_) acts_logging_level = Acts::Logging::VERBOSE;
 
@@ -105,15 +105,14 @@ void GSFProcessor::onNewRun(const ldmx::RunHeader& rh) {
 
   BetheHeitlerApprox bethe_heitler = Acts::makeDefaultBetheHeitlerApprox();
 
-  const auto gsf_logger = Acts::getDefaultLogger("GSF", acts_logging_level);
-
   gsf_ = std::make_unique<std::decay_t<decltype(*gsf_)>>(
       std::move(gsf_propagator), std::move(bethe_heitler),
       Acts::getDefaultLogger("GSF", acts_logging_level));
 
   const auto stepper = Acts::EigenStepper<>{map};
   propagator_ = std::make_unique<Propagator>(
-      stepper, navigator, Acts::getDefaultLogger("PROP", acts_logging_level));
+      stepper, navigator,
+      Acts::getDefaultLogger("GSF_EXTRAP", acts_logging_level));
 
   trk_extrap_ = std::make_shared<std::decay_t<decltype(*trk_extrap_)>>(
       *propagator_, geometryContext(), magneticFieldContext());


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Yet another try for https://github.com/LDMX-Software/ldmx-sw/issues/1562

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->


I have a lot of these now:
```
22:49:18    CKF_PROP       ERROR     Step failed with MagneticFieldError:1: Interpolation out of bounds was requested
[ Recoil_TrackFinder ] 8467747 fatal:     Field-map ECAL extrapolation failed, trying zero-B fallback
[ Recoil_TrackFinder ] 8467747 fatal:     Yay! Zero-B ECAL extrapolation successful
22:49:18    CKF_PROP       ERROR     Step failed with MagneticFieldError:1: Interpolation out of bounds was requested
[ Recoil_TrackFinder ] 8501163 fatal:     Field-map ECAL extrapolation failed, trying zero-B fallback
[ Recoil_TrackFinder ] 8501163 fatal:     Yay! Zero-B ECAL extrapolation successful
```

I added the statistics on what fails and recovers. This looks good now.
```
[ Tagger_TrackFinder ] 9949548  info: --------------------------------- 
[ Tagger_TrackFinder ] 9949548  info: Found 200 tracks  / 208 nseeds
[ Tagger_TrackFinder ] 9949548  info: CKF Fallback Statistics::
[ Tagger_TrackFinder ] 9949548  info:   Tagger: Field-map CKF failed 3 times, const-B CKF recovered 3 (100%)
[ Tagger_TrackFinder ] 9949548  info: Extrapolation Fallback Statistics::
[ Tagger_TrackFinder ] 9949548  info:   Tagger Target: Field-map extrap failed 3 times, const-B extrap recovered 3 (100%)

[ Recoil_TrackFinder ] 9949548  info: --------------------------------- 
[ Recoil_TrackFinder ] 9949548  info: Found 143 tracks  / 274 nseeds
[ Recoil_TrackFinder ] 9949548  info:   Recoil: Field-map CKF failed 56 times, zero-B CKF recovered 56 (100%)
[ Recoil_TrackFinder ] 9949548  info: Extrapolation Fallback Statistics::
[ Recoil_TrackFinder ] 9949548  info:   Recoil Target: Field-map extrap failed 0 times, zero-B extrap recovered 0 (0%)
[ Recoil_TrackFinder ] 9949548  info:   Recoil ECAL: Field-map extrap failed 115 times, zero-B extrap recovered 115 (100%)
```