### PR TITLE
Add dEdx mass estimator in EN CI, and misc changes

### DIFF
--- a/.github/validation_samples/target_genie/config.py
+++ b/.github/validation_samples/target_genie/config.py
@@ -112,6 +112,10 @@ en_trigger = [
 from LDMX.Recon import pfReco
 pf_reco = pfReco.pfTruthProducer()
 
+# Load the dEdx mass estimator
+from LDMX.Recon import trackDeDxMassEstimator
+recoil_track_mass_estimator = trackDeDxMassEstimator.trackDeDxMassEstimator()
+
 # Load the DQM modules
 from LDMX.DQM import dqm
 
@@ -158,11 +162,11 @@ p.sequence.extend([
         TriggerProcessor('trigger', 8000.),
         *en_trigger,
         pf_reco,
-        *recoil_tracker_dqm
+        recoil_track_mass_estimator
         ])
 
 # Remove TS DQM
-almost_all_dqm = [dqm.sample_validation_dqm + dqm.ecal_dqm + dqm.hcal_dqm + dqm.trigger_dqm]
+almost_all_dqm = [dqm.sample_validation_dqm + recoil_tracker_dqm + dqm.ecal_dqm + dqm.hcal_dqm + dqm.trigger_dqm + dqm.dEdx_dqm] 
 
 p.sequence.extend(*almost_all_dqm)
 

--- a/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
+++ b/DQM/src/DQM/TrkDeDxMassEstFeatures.cxx
@@ -43,7 +43,7 @@ void TrkDeDxMassEstFeatures::analyze(const framework::Event &event) {
         histograms_.fill("mass_estimate_very_low_p_proton", mass_est.getMass());
       }
     }
-    histograms_.fill("track_type", mass_est.getTrackType());
+    histograms_.fill("track_type", mass_est.getTrackType() + 0.5);
   }
 
   return;

--- a/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
+++ b/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
@@ -56,6 +56,12 @@ class TrackDeDxMassEstimate {
   void setMomentum(float momentum) { momentum_ = momentum; }
 
   /**
+   * Set the number of hits used in the dEdx calculation.
+   * @param nhits The number of hits used in the dEdx calculation.
+   */
+  void setNhits(float nhits) { n_hits_ = nhits; }
+
+  /**
    * Set the Ih of the particle/track.
    * @param the_ih The Ih of the particle/track.
    */
@@ -128,6 +134,9 @@ class TrackDeDxMassEstimate {
   /* The momentum of the particle/track */
   float momentum_{0.};
 
+  /* The number of hits used in the dEdx calculation */
+  float n_hits_{0.};
+
   /* The Ih of the particle/track */
   float the_ih_{0.};
 
@@ -146,7 +155,7 @@ class TrackDeDxMassEstimate {
   /**
    * The ROOT class definition.
    */
-  ClassDef(TrackDeDxMassEstimate, 4);
+  ClassDef(TrackDeDxMassEstimate, 5);
 };
 }  // namespace ldmx
 

--- a/Recon/python/trackDeDxMassEstimator.py
+++ b/Recon/python/trackDeDxMassEstimator.py
@@ -20,8 +20,8 @@ fit_res_K : float
 
 Examples
 --------
-    from LDMX.Recon.trackDeDxMassEstimator import reoilTrackMassEstimator
-    p.sequence.append( reoilTrackMassEstimator )
+    from LDMX.Recon.trackDeDxMassEstimator import recoilTrackMassEstimator
+    p.sequence.append( recoilTrackMassEstimator )
 """
 
 from LDMX.Framework import ldmxcfg

--- a/Recon/src/Recon/TrackDeDxMassEstimator.cxx
+++ b/Recon/src/Recon/TrackDeDxMassEstimator.cxx
@@ -60,38 +60,38 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
   for (uint i = 0; i < tracks.size(); i++) {
     auto track = tracks.at(i);
     // If track momentum doen't exist, skip
-    auto the_qo_p = track.getQoP();
-    if (the_qo_p == 0) {
+    auto the_qop = track.getQoP();
+    if (the_qop == 0) {
       ldmx_log(debug) << "Track " << i << "has zero q/p ";
       continue;
     }
 
     int pdg_id = track.getPdgID();
-    float momentum = 1. / std::abs(the_qo_p) * 1000;  // unit: MeV
+    float momentum = 1. / std::abs(the_qop) * 1000;  // unit: MeV
     ldmx_log(debug) << "Track " << i << " has momentum " << momentum;
 
     /// Get the hits_ associated with the truth track
     ldmx::TrackDeDxMassEstimate mass_est;
-    float sum_d_edx_inv2 = 0.;
-    float d_edx;
+    float sum_dedx_inv2 = 0.;
+    float dedx;
     float n_simhits = 0;
     for (auto hit : simhits) {
       // Check if the hit is associated with the track
       if (hit.getTrackID() != track.getTrackID()) continue;
       if (hit.getEdep() >= 0 && hit.getPathLength() > 0) {
-        d_edx = hit.getEdep() / hit.getPathLength() * 10;  // unit: MeV/cm
-        sum_d_edx_inv2 += 1. / (d_edx * d_edx);
+        dedx = hit.getEdep() / hit.getPathLength() * 10;  // unit: MeV/cm
+        sum_dedx_inv2 += 1. / (dedx * dedx);
         n_simhits++;
       }
     }  // end of loop over measurements
 
-    if (sum_d_edx_inv2 == 0) {
+    if (sum_dedx_inv2 == 0) {
       ldmx_log(debug) << "Track " << i << " has no dEdx measurements";
       continue;
     }
 
     // Ih = (1/N * sum_i^N(dE/dx_i)^-2)^-1/2
-    float the_ih = 1. / sqrt(1. / n_simhits * sum_d_edx_inv2);
+    float the_ih = 1. / sqrt(1. / n_simhits * sum_dedx_inv2);
 
     float mass = 0.;
     if (the_ih > fit_res_c_) {
@@ -103,6 +103,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     }
 
     mass_est.setMomentum(momentum);
+    mass_est.setNhits(n_simhits);
     mass_est.setIh(the_ih);
     mass_est.setMass(mass);
     mass_est.setTrackIndex(i);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1925

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.

Ran the CI and I see the output in the histograms:
<img width="971" height="563" alt="Screenshot 2026-01-29 at 10 15 42" src="https://github.com/user-attachments/assets/4dfeefa3-6f53-4fdf-852e-aa924e0a4b9a" />
