### PR TITLE
Change default settings so only Target + ECAL scoring plane is saved

### DIFF
--- a/.github/validation_samples/deep_ecal_gun/config.py
+++ b/.github/validation_samples/deep_ecal_gun/config.py
@@ -8,7 +8,7 @@ from LDMX.SimCore import generators as gen
 from LDMX.SimCore import simulator as sim
 det = 'ldmx-det-v15-8gev'
 mySim = sim.simulator( "mySim" )
-mySim.setDetector(det, True )
+mySim.setDetector(det, include_scoring_planes_minimal = True )
 mySim.description = 'Deep ECal Gun Simulation'
 
 ene_ang_pos_cmds_ele = [

--- a/.github/validation_samples/inclusive/config.py
+++ b/.github/validation_samples/inclusive/config.py
@@ -4,7 +4,7 @@ p = ldmxcfg.Process('test')
 from LDMX.SimCore import simulator as sim
 mySim = sim.simulator( "mySim" )
 det = 'ldmx-det-v15-8gev'
-mySim.setDetector(det, True )
+mySim.setDetector(det, include_scoring_planes_minimal = True )
 from LDMX.SimCore import generators as gen
 mySim.generators.append( gen.single_8gev_e_upstream_tagger() )
 mySim.beamSpotSmear = [20.,80.,0.]

--- a/.github/validation_samples/reduced_ldmx/config.py
+++ b/.github/validation_samples/reduced_ldmx/config.py
@@ -17,7 +17,7 @@ myGun.enablePoisson = False #True
 
 mySim = sim.simulator( "mySim" ) # Build simulator object
 det = 'ldmx-reduced-v3'
-mySim.setDetector(det, True )
+mySim.setDetector(det, include_scoring_planes_minimal = True )
 mySim.beamSpotSmear = [20.,80.,0.]
 mySim.description = 'Reduced ECal Electron Gun Test Simulation'
 

--- a/.github/validation_samples/target_genie/config.py
+++ b/.github/validation_samples/target_genie/config.py
@@ -8,7 +8,7 @@ from LDMX.SimCore import generators as gen
 from LDMX.SimCore import simulator as sim
 det = 'ldmx-det-v15-8gev'
 mySim = sim.simulator('sim')
-mySim.setDetector(det, True)
+mySim.setDetector(det, include_scoring_planes_minimal = True)
 genie = gen.genie(name=f'genie_G18_02a_02_11b',
                         energy = 8.0,
                         targets = [ 1000741820, 1000741830, 1000741840, 1000741860 ],

--- a/.github/validation_samples/wab_lhe/config.py
+++ b/.github/validation_samples/wab_lhe/config.py
@@ -13,7 +13,7 @@ wab_gen.vertex = [0.0, 0.0, 0.0]
 
 det = 'ldmx-det-v15-8gev'
 mySim = sim.simulator('sim')
-mySim.setDetector(det, True)
+mySim.setDetector(det, include_scoring_planes_minimal = True)
 mySim.generators.append(wab_gen) 
 
 p.sequence = [ mySim ]

--- a/Biasing/python/eat.py
+++ b/Biasing/python/eat.py
@@ -65,7 +65,7 @@ def midshower_nuclear( detector , generator, bias_factor , bias_threshold , min_
 
     #Set the path to the detector to use.
     #the second parameter says we want to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     #Set run parameters
     sim.description = "Biased Mid-Shower Nuclear Interactions ME Background"
@@ -142,7 +142,7 @@ def midshower_dimuon( detector , generator, bias_factor , bias_threshold , min_d
 
     #Set the path to the detector to use.
     #the second parameter says we want to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     #Set run parameters
     sim.description = "Biased Mid-Shower DiMuon Interactions ME Background"
@@ -220,7 +220,7 @@ def dark_brem(ap_mass, db_event_lib, detector, generator,
     from LDMX.Ecal import EcalGeometry
     
     sim.description = "One e- fired far upstream with Dark Brem turned on and biased up in ECal"
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
     sim.generators = [ generator ]
     sim.beamSpotSmear = [ 20., 80., 0. ] #mm
 

--- a/Biasing/python/ecal.py
+++ b/Biasing/python/ecal.py
@@ -48,7 +48,7 @@ def photo_nuclear( detector, generator ) :
     
     # Set the path to the detector to use.
     #   the second parameter says we want to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     # Set run parameters
     xsec_bias_threshold = 0.625 * generator.energy * 1000.
@@ -91,7 +91,7 @@ def nonfiducial_photo_nuclear( detector, generator ) :
     
     # Set the path to the detector to use.
     #   the second parameter says we want to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
     
     # Set run parameters
     xsec_bias_threshold = 0.625 * generator.energy * 1000.
@@ -156,7 +156,7 @@ def gamma_mumu(detector, generator) :
 
     # Set the path to the detector to use
     # Also tell the simulator to include scoring planes
-    sim.setDetector( detector, True )
+    sim.setDetector( detector, include_scoring_planes_minimal = True )
 
     # Set run parameters
     xsec_bias_threshold = 0.625 * generator.energy * 1000.
@@ -195,7 +195,7 @@ def deep_photo_nuclear( detector, generator, bias_threshold, processes, ecal_min
     
     # Set the path to the detector to use.
     #   the second parameter says we want to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
     
     # Set run parameters
     # Set run parameters

--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -42,7 +42,7 @@ def electro_nuclear( detector, generator ) :
 
     # Set the path to the detector to use.
     #   Also tell the simulator to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     # Set run parameters
     sim.description = "Target electron-nuclear, xsec bias 1e5"
@@ -99,7 +99,7 @@ def photo_nuclear( detector, generator ) :
 
     # Set the path to the detector to use.
     #   Also tell the simulator to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     # Set run parameters
     xsec_bias_threshold = 0.625 * generator.energy * 1000.
@@ -164,7 +164,7 @@ def gamma_mumu( detector, generator ) :
 
     # Set the path to the detector to use.
     #   Also tell the simulator to include scoring planes
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
 
     # Set run parameters
     sim.beamSpotSmear = [20., 80., 0.]
@@ -237,7 +237,7 @@ def dark_brem( ap_mass , lhe, detector, generator,
     sim = simulator.simulator( "target_dark_brem_" + str(ap_mass) + "_MeV" )
 
     sim.description = "One e- fired far upstream with Dark Brem turned on and biased up in target"
-    sim.setDetector( detector , True )
+    sim.setDetector( detector , include_scoring_planes_minimal = True )
     sim.generators.append( generators.single_8gev_e_upstream_tagger() )
     sim.beamSpotSmear = [ 20., 80., 0. ] #mm
 

--- a/Ecal/test/ecal_digi_pipeline.py
+++ b/Ecal/test/ecal_digi_pipeline.py
@@ -10,7 +10,7 @@ import LDMX.Ecal.ecal_hardcoded_conditions
 
 from LDMX.SimCore import simulator
 sim = simulator.simulator("mySim")
-sim.setDetector( 'ldmx-det-v12', True  )
+sim.setDetector( 'ldmx-det-v12', include_scoring_planes_minimal = True  )
 sim.description = "ECal Digi Pipeline Tested on Basic 4GeV Gun"
 from LDMX.SimCore import generators
 sim.generators = [ generators.single_4gev_e_upstream_tagger() ]

--- a/Recon/test/particleReco.py
+++ b/Recon/test/particleReco.py
@@ -19,7 +19,7 @@ from LDMX.SimCore import simulator as sim
 import LDMX.Ecal.EcalGeometry
 import LDMX.Hcal.HcalGeometry
 mySim = sim.simulator( "mySim" )
-mySim.setDetector( 'ldmx-det-v14' , True )
+mySim.setDetector( 'ldmx-det-v14' , include_scoring_planes_minimal = True )
 sim.beamSpotSmear = [20., 80., 0.]
 
 # Get a pre-written generator

--- a/Recon/test/sim_and_reco.py
+++ b/Recon/test/sim_and_reco.py
@@ -12,7 +12,7 @@ p.run = 1
 from LDMX.SimCore import simulator
 import LDMX.Ecal.EcalGeometry
 sim = simulator.simulator("mySim")
-sim.setDetector( 'ldmx-det-v12', True  )
+sim.setDetector( 'ldmx-det-v12', include_scoring_planes_minimal = True  )
 sim.description = "ECal photo-nuclear, xsec bias 450"
 sim.randomSeeds = [ 2*p.run , 2*p.run+1 ]
 sim.beamSpotSmear = [20., 80., 0]

--- a/SimCore/exampleConfigs/backwards-positron.py
+++ b/SimCore/exampleConfigs/backwards-positron.py
@@ -34,7 +34,7 @@ import LDMX.Ecal.EcalGeometry
 import LDMX.Hcal.HcalGeometry
 
 mySim = simulator.simulator( "mySim" )
-mySim.setDetector( 'ldmx-det-v14' , True )
+mySim.setDetector( 'ldmx-det-v14' , include_scoring_planes_minimal = True )
 mySim.generators = [ generators.single_backwards_positron(args.beam) ]
 mySim.description = 'Basic test Simulation'
 p.sequence = [ mySim ]

--- a/SimCore/python/simulator.py
+++ b/SimCore/python/simulator.py
@@ -114,15 +114,17 @@ class simulator(Producer):
         from LDMX.SimCore import kaon_physics
         self.kaon_parameters = kaon_physics.KaonPhysics()
 
-    def setDetector(self, det_name , include_scoring_planes = False ) :
+    def setDetector(self, det_name , include_scoring_planes_others = False, include_scoring_planes_minimal = False ) :
         """Set the detector description with the option to include the scoring planes
 
         Parameters
         ----------
         det_name : str
             name of a detector in the Detectors module
-        include_scoring_planes : bool
-            True if you want to import and use scoring planes
+        include_scoring_planes_minimal : bool
+            True if you want to import only target and ecal scoring planes
+        include_scoring_planes_others : bool
+            True if you want to import the remaining other scoring planes
 
         See Also
         --------
@@ -146,12 +148,16 @@ class simulator(Producer):
                 sds.EcalSD(),
                 sds.TrigScintSD.target()
                 ] + trigscint
-        if include_scoring_planes :
+        if include_scoring_planes_minimal :
             self.scoringPlanes = mP.makeScoringPlanesPath( det_name )
             self.sensitive_detectors.extend([
-                sds.ScoringPlaneSD.ecal(),
-                sds.ScoringPlaneSD.hcal(),
                 sds.ScoringPlaneSD.target(),
+                sds.ScoringPlaneSD.ecal(),
+                ])
+        if include_scoring_planes_others :
+            self.scoringPlanes = mP.makeScoringPlanesPath( det_name )
+            self.sensitive_detectors.extend([
+                sds.ScoringPlaneSD.hcal(),
                 sds.ScoringPlaneSD.trigscint(),
                 sds.ScoringPlaneSD.tracker(),
                 sds.ScoringPlaneSD.magnet()

--- a/SimCore/test/basic.py
+++ b/SimCore/test/basic.py
@@ -17,7 +17,7 @@ from LDMX.SimCore import simulator as sim
 import LDMX.Ecal.EcalGeometry
 import LDMX.Hcal.HcalGeometry
 mySim = sim.simulator( "mySim" )
-mySim.setDetector( 'ldmx-det-v14' , True )
+mySim.setDetector( 'ldmx-det-v14' , include_scoring_planes_minimal = True )
 # Get a pre-written generator
 from LDMX.SimCore import generators as gen
 mySim.generators.append( gen.single_4gev_e_upstream_tagger() )

--- a/Tracking/exampleConfigs/reco.py
+++ b/Tracking/exampleConfigs/reco.py
@@ -24,7 +24,7 @@ partGunString='single_8gev_e_upstream_tagger'
 detector = 'ldmx-det-v14-8gev-no-cals'
 ####  set up beam simulation
 sim = simulator.simulator('inclusive_single_8gev')
-sim.setDetector(detector,include_scoring_planes = True)  
+sim.setDetector(detector,include_scoring_planes_minimal = True)  
 sim.description = 'A single 8gev electron shot from upstream of the 8gev tagger.'
 sim.beamSpotSmear = [20., 80., 0]
 particle_gun = generators.single_8gev_e_upstream_tagger()

--- a/Tracking/exampleConfigs/uniform-energy-angle-electrons.py
+++ b/Tracking/exampleConfigs/uniform-energy-angle-electrons.py
@@ -24,7 +24,7 @@ from LDMX.SimCore import simulator
 from LDMX.SimCore import generators
 
 sim = simulator.simulator("uniform-electrons")
-sim.setDetector('ldmx-det-v14-8gev', True)
+sim.setDetector('ldmx-det-v14-8gev', include_scoring_planes_minimal = True)
 sim.description = "Electrons with uniformly sampled energy and angle shot from target"
 sim.beamSpotSmear = [20., 80., 0.]
 # GPS generator

--- a/Tracking/python/geo.py
+++ b/Tracking/python/geo.py
@@ -46,7 +46,7 @@ class TrackersTrackingGeometryProvider(ldmxcfg.ConditionsObjectProvider):
             raise Exception('TrackersTrackingGeometryProvider is a singleton class and should only be retrieved using get_instance()')
         else: 
             super().__init__('TrackersTrackingGeometry', 'tracking::geo::TrackersTrackingGeometryProvider', 'Tracking')
-            self.setDetector('ldmx-det-v14-8gev-no-cals')
+            self.setDetector('ldmx-det-v15-8gev')
             #  acts x = global z
             #   // global z:  -200 - 900/2 = -650 to -200 + 900/2 = 250 mm
             #   // global y: -70 to 70

--- a/TrigScint/exampleConfigs/firmwareEx.py
+++ b/TrigScint/exampleConfigs/firmwareEx.py
@@ -35,7 +35,7 @@ sim = simulator.simulator("test")
 #
 # Set the path to the detector to use (pulled from job config)
 #
-sim.setDetector( version, True )
+sim.setDetector( version, include_scoring_planes_minimal = True )
 sim.scoringPlanes = makeScoringPlanesPath(version)
 
 outname=outputNameString #+".root"

--- a/TrigScint/exampleConfigs/firmwareEx2.py
+++ b/TrigScint/exampleConfigs/firmwareEx2.py
@@ -35,7 +35,7 @@ sim = simulator.simulator("test")
 #
 # Set the path to the detector to use (pulled from job config)
 #
-sim.setDetector( version, True )
+sim.setDetector( version, include_scoring_planes_minimal = True )
 sim.scoringPlanes = makeScoringPlanesPath(version)
 
 outname=outputNameString #+".root"

--- a/TrigScint/exampleConfigs/meganEx.py
+++ b/TrigScint/exampleConfigs/meganEx.py
@@ -35,7 +35,7 @@ sim = simulator.simulator("test")
 #
 # Set the path to the detector to use (pulled from job config)
 #
-sim.setDetector( version, True )
+sim.setDetector( version, include_scoring_planes_minimal = True )
 sim.scoringPlanes = makeScoringPlanesPath(version)
 
 outname=outputNameString #+".root"


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1935

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Basic config and ecal PN CIs both run fine.