### PR TITLE
Remove debug log for dark brem process reset

### DIFF
--- a/SimCore/src/SimCore/RunManager.cxx
+++ b/SimCore/src/SimCore/RunManager.cxx
@@ -192,7 +192,6 @@ void RunManager::TerminateOneEvent() {
   };
 
   reactivate_dark_brem(G4Electron::Definition()->GetProcessManager());
-  ldmx_log(debug) << "Reset the dark brem process (if it was activated)";
 }
 
 DetectorConstruction* RunManager::getDetectorConstruction() {


### PR DESCRIPTION
Removed debug log message for resetting dark brem process.


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1945

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
