### PR TITLE
Add ci-data checkout step in generate_pr_gold.yml

### DIFF
--- a/.github/workflows/generate_pr_gold.yml
+++ b/.github/workflows/generate_pr_gold.yml
@@ -54,6 +54,14 @@ jobs:
     - uses: actions/checkout@v6
     - uses: extractions/setup-just@v3
     - run: just install-denv init
+    
+    - name: Checkout ci-data
+      uses: actions/checkout@v6
+      with:
+        repository: LDMX-Software/ci-data
+        path: ci-data
+        token: ${{ secrets.CI_DATA_PAT }}
+        
     - name: Download ldmx-sw Package
       uses: actions/download-artifact@v7
       with:


### PR DESCRIPTION
Added step to checkout ci-data repository in the workflow.


I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Gold creation failed in https://github.com/LDMX-Software/ldmx-sw/actions/runs/21970246351/job/63470773603

## Check List
- [ ] I successfully compiled _ldmx-sw_ with my developments.
- [ ] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [ ] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
