### PR TITLE
iss1954 Track ID management in OverlayProducer, and SimParticles overlay

### DIFF
--- a/.github/validation_samples/it_pileup/config.py
+++ b/.github/validation_samples/it_pileup/config.py
@@ -98,6 +98,9 @@ ecal_veto_pnet.ecal_rec_hits_passname = this_pass_name
 ecal_veto_pnet.ecal_sp_coll_name += overlay_str
 ecal_veto_pnet.track_pass_name = this_pass_name
 
+ecal_mip.ecal_pass_name = this_pass_name
+ecal_mip.mip_pass_name = this_pass_name
+
 # Load the HCAL modules
 import LDMX.Hcal.digi as hcal_digi_and_reco
 

--- a/DetDescr/python/hcal_geometry.py
+++ b/DetDescr/python/hcal_geometry.py
@@ -332,7 +332,7 @@ class HcalGeometry:
             + side_hcal_num_layers[2]
             + side_hcal_num_layers[3]
         ) * 2
-        
+
         ecal_side_dx = 880.6815
         ecal_side_dy = 600.0
         ecal_front_z = 24.0 * 10

--- a/Detectors/data/ldmx-det-v15-8gev/makeTSassemblyfiles.py
+++ b/Detectors/data/ldmx-det-v15-8gev/makeTSassemblyfiles.py
@@ -1,5 +1,6 @@
-import sys
 import os
+import sys
+
 
 abspath = os.path.abspath(__file__)
 dname = os.path.dirname(abspath)
@@ -41,7 +42,7 @@ should still be defined elsewhere, for example in the constants.gdml or material
 
 #Material variable names (material definitions should be found in materials.gdml)
 scintillator_mat ="Polyvinyltoluene"
-lightpipe_mat    ="AcrylicPMMA" 
+lightpipe_mat    ="AcrylicPMMA"
 sipm_mat         ="Silicon"
 
 #To streamline TargetDarkBremFilter.cxx, TSPad3 and its components are considered part of

--- a/Ecal/include/Ecal/EcalVetoProcessor.h
+++ b/Ecal/include/Ecal/EcalVetoProcessor.h
@@ -162,6 +162,7 @@ class EcalVetoProcessor : public framework::Producer {
   std::string track_pass_name_;
   std::string track_collection_;
 
+  std::string sim_particles_coll_name_;
   std::string sim_particles_passname_;
   bool inverse_skim_{false};
 

--- a/Ecal/src/Ecal/EcalVetoProcessor.cxx
+++ b/Ecal/src/Ecal/EcalVetoProcessor.cxx
@@ -126,6 +126,8 @@ void EcalVetoProcessor::configure(framework::config::Parameters &parameters) {
   ecal_sp_coll_name_ = parameters.get<std::string>("ecal_sp_coll_name");
   target_sp_coll_name_ = parameters.get<std::string>("target_sp_coll_name");
   sp_pass_name_ = parameters.get<std::string>("sp_pass_name");
+  sim_particles_coll_name_ =
+      parameters.get<std::string>("sim_particles_coll_name");
   collection_name_ = parameters.get<std::string>("collection_name");
   rec_pass_name_ = parameters.get<std::string>("rec_pass_name");
   rec_coll_name_ = parameters.get<std::string>("rec_coll_name");
@@ -198,7 +200,7 @@ void EcalVetoProcessor::produce(framework::Event &event) {
 
     // Get the collection of simulated particles from the event
     auto particle_map{event.getMap<int, ldmx::SimParticle>(
-        "SimParticles", sim_particles_passname_)};
+        sim_particles_coll_name_, sim_particles_passname_)};
 
     // Search for the recoil electron
     auto [recoil_track_id, recoil_electron] = analysis::getRecoil(particle_map);

--- a/Recon/include/Recon/OverlayProducer.h
+++ b/Recon/include/Recon/OverlayProducer.h
@@ -201,16 +201,6 @@ class OverlayProducer : public framework::Producer {
    * Inclusive.
    */
   int start_event_max_{10000};
-
-  /**
-   * For Ecal, overlay hits should be added as contribs.
-   * But these are required to be unique, by the Ecal rconstruction code.
-   * So assign a nonsensical trackID, incidentID, and PDG ID to the contribs
-   * from overlay. These are hardwired right here.
-   */
-  int overlay_incident_id_{-1000};
-  int overlay_track_id_{-1000};
-  int overlay_pdg_code_{0};
 };
 }  // namespace recon
 

--- a/Recon/include/Recon/OverlayProducer.h
+++ b/Recon/include/Recon/OverlayProducer.h
@@ -101,6 +101,12 @@ class OverlayProducer : public framework::Producer {
   std::vector<std::string> tracker_collections_;
 
   /**
+   * List of SimParticle collection(s) to loop over and add hits from,
+   * combining sim and pileup
+   */
+  std::vector<std::string> particle_collections_;
+
+  /**
    * List of SimCalorimeterHit collections which keep track of hit contribs.
    */
   std::vector<std::string> contrib_collections_;

--- a/Recon/include/Recon/OverlayProducer.h
+++ b/Recon/include/Recon/OverlayProducer.h
@@ -3,6 +3,7 @@
 
 //---< C++ StdLib >---//
 #include <algorithm>
+#include <bitset>
 #include <map>
 #include <memory>
 #include <string>
@@ -63,6 +64,19 @@ class OverlayProducer : public framework::Producer {
    * appended string "Overlay". This name is also currently hardwired.
    */
   void produce(framework::Event &event) override;
+
+  /**
+   * Encode track ID with overlay event information.
+   *
+   * Performs bitwise encoding on track ID integer with version and event
+   * index.
+   *
+   * VERSION DESCRIPTION
+   * - 0 : no encoding, leaves track_id alone
+   * - 1 : four bit version (27-31) plus three bit event index (24-26)
+   */
+  int encodeTrack(int track_id, const unsigned int encoding_version,
+                  const unsigned int event_index = 0);
 
   /**
    * At the start of processing, the pileup overlay file is set up.
@@ -201,6 +215,18 @@ class OverlayProducer : public framework::Producer {
    * Inclusive.
    */
   int start_event_max_{10000};
+
+  /**
+   * Track ID encoding scheme version. Version is stored
+   * in first 4 bits after the sign bit in the track ID int
+   * variables (i.e. bits 28-31)
+   *
+   * If this variable is left as the hardcoded default 0, then
+   * the OverlayProducer will default to not managing track IDs,
+   * instead setting all equal to nonsense values as was the case
+   * before the introduction of this track ID management.
+   */
+  unsigned track_id_encoding_{0};
 };
 }  // namespace recon
 

--- a/Recon/python/overlay.py
+++ b/Recon/python/overlay.py
@@ -70,6 +70,7 @@ class OverlayProducer(ldmxcfg.Producer) :
         self.calo_collections =  ["TriggerPad1SimHits", "TriggerPad2SimHits", "TriggerPad3SimHits",
                                    "TargetSimHits", "EcalSimHits", "HcalSimHits"]
         self.tracker_collections = [ "TaggerSimHits", "RecoilSimHits", "EcalScoringPlaneHits", "TargetScoringPlaneHits" ]
+        self.particle_collections = [ "SimParticles" ]
         self.contrib_collections = [ "EcalSimHits", "HcalSimHits" ]
         self.out_coll_postfix = "Overlay"
         self.poisson_mu = 2.

--- a/Recon/python/overlay.py
+++ b/Recon/python/overlay.py
@@ -11,10 +11,14 @@ sim_passname : string
     Pass name of the sim events
 overlay_passname : string
     Pass name of the pileup events
-calo_collections : string
+calo_collections : list[str]
     List of SimCalorimeterHit collections to pull from the sim and pileup events and combine
-tracker_collections_ : string
+tracker_collections : list[str]
     List of SimTrackerHit collections to pull from the sim and pileup events and combine
+particle_collections : list[str]
+    List of SimParticles collections to pull from the sim and pileup events and combine.
+contrib_collections : list[str]
+    List of SimCalorimeterHit collections which need contribs added separately.
 poisson_mu : int
     The total number of interactions combined (including the sim event)
 do_poisson_in_time : bool

--- a/Recon/python/overlay.py
+++ b/Recon/python/overlay.py
@@ -44,6 +44,8 @@ start_event_min : int
     The minimum event number to start overlaying pileup events.
 start_event_max : int
     The max event number to start overlaying pileup events.
+track_id_encoding : int
+    The version number for the track ID bitwise encoding schema. Possible values range over [0, 15]. The version number is stored in bits 27-31 in the C++ int type.
 """
 
 from LDMX.Framework import ldmxcfg
@@ -69,7 +71,8 @@ class OverlayProducer(ldmxcfg.Producer) :
         self.overlay_passname = "sim"
         self.calo_collections =  ["TriggerPad1SimHits", "TriggerPad2SimHits", "TriggerPad3SimHits",
                                    "TargetSimHits", "EcalSimHits", "HcalSimHits"]
-        self.tracker_collections = [ "TaggerSimHits", "RecoilSimHits", "EcalScoringPlaneHits", "TargetScoringPlaneHits" ]
+        self.tracker_collections = [ "TaggerSimHits", "RecoilSimHits", "EcalScoringPlaneHits",
+                                   "TargetScoringPlaneHits" ]
         self.particle_collections = [ "SimParticles" ]
         self.contrib_collections = [ "EcalSimHits", "HcalSimHits" ]
         self.out_coll_postfix = "Overlay"
@@ -86,3 +89,4 @@ class OverlayProducer(ldmxcfg.Producer) :
         self.tree_name = 'LDMX_Events'
         self.start_event_min = 1
         self.start_event_max = 10000
+        self.track_id_encoding = 1

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -110,9 +110,8 @@ void OverlayProducer::produce(framework::Event &event) {
   std::map<std::string, std::map<int, ldmx::SimParticle>>
       particle_collection_map;
   std::map<std::string, std::map<int, ldmx::SimCalorimeterHit>> hit_map;
-  int track_id_increment =
-      -1;  // there should only be one SimParticles collection, so it's fine for
-           // this to be just an integer rather than a vector
+  int track_id_increment = 100000;  // track_id's for overlay events will be
+                                    // incremented by this value
 
   // start by copying over all the collections from the sim event
 
@@ -203,7 +202,7 @@ void OverlayProducer::produce(framework::Event &event) {
     }
   }  // over particle collections for sim event
 
-  /* ----------- now do the pileup overlay ----------- */
+  /* ----------- now do the overlay ----------- */
 
   // we could shift these by a random number, effectively placing the
   // sim event at random positions in the interval, preserving the
@@ -309,18 +308,51 @@ void OverlayProducer::produce(framework::Event &event) {
             if (this_coll_hit_map.find(overlay_hit_id) ==
                 this_coll_hit_map
                     .end()) {  // there wasn't already a simhit in this id
+              ldmx_log(trace)
+                  << "No existing simhit found for ID " << overlay_hit_id
+                  << "; copying overlay hit to output collection";
               this_coll_hit_map[overlay_hit_id] = ldmx::SimCalorimeterHit();
               this_coll_hit_map[overlay_hit_id].setID(overlay_hit_id);
               std::vector<float> hit_pos = overlay_hit.getPosition();
-              this_coll_hit_map[overlay_hit_id].setPosition(
-                  hit_pos[0], hit_pos[1], hit_pos[2]);
-            }
-            // add the overlay hit (as a) contrib
-            // incidentID = -1000, trackID = -1000, pdgCode = 0  <-- these are
-            // set in the header for now but could be parameters
-            this_coll_hit_map[overlay_hit_id].addContrib(
-                overlay_incident_id_, overlay_track_id_, overlay_pdg_code_,
-                overlay_hit.getEdep(), overlay_time);
+              this_coll_hit_map[overlay_hit_id].setPosition(hit_pos[0], hit_pos[1],
+                                                  hit_pos[2]);
+              std::vector<float> pre_step_pos =
+                  overlay_hit.getPreStepPosition();
+              this_coll_hit_map[overlay_hit_id].setPreStepPosition(
+                  pre_step_pos[0], pre_step_pos[1], pre_step_pos[2]);
+              std::vector<float> post_step_pos =
+                  overlay_hit.getPostStepPosition();
+              this_coll_hit_map[overlay_hit_id].setPostStepPosition(
+                  post_step_pos[0], post_step_pos[1], post_step_pos[2]);
+              this_coll_hit_map[overlay_hit_id].setEdep(overlay_hit.getEdep());
+              this_coll_hit_map[overlay_hit_id].setPathLength(
+                  overlay_hit.getPathLength());
+              this_coll_hit_map[overlay_hit_id].setPreStepTime(
+                  overlay_hit.getPreStepTime() + time_offset);
+              this_coll_hit_map[overlay_hit_id].setPostStepTime(
+                  overlay_hit.getPostStepTime() + time_offset);
+              this_coll_hit_map[overlay_hit_id].setVelocity(overlay_hit.getVelocity());
+            }  // if overlay_hit_id not present
+
+            // add the overlay hit contribs to existing hit,
+            // incrementing track IDs and timestamp as needed
+            int n_contribs = overlay_hit.getNumberOfContribs();
+            ldmx_log(trace)
+                << "Copying and reindexing " << n_contribs
+                << " contributors to the sim hit for ID " << overlay_hit_id;
+            for (int i = 0; i < n_contribs; i++) {
+              ldmx::SimCalorimeterHit::Contrib contrib{
+                  overlay_hit.getContrib(i)};
+              int incident_id = contrib.incident_id_ + track_id_increment;
+              int track_id = contrib.track_id_ + track_id_increment;
+              float time = contrib.time_ + time_offset;
+              this_coll_hit_map[overlay_hit_id].addContrib(incident_id, track_id,
+                                                 contrib.pdg_code_,
+                                                 contrib.edep_, time);
+            }  // loop over contribs in overlay_hit
+            ldmx_log(trace) << "There are now "
+                            << this_coll_hit_map[overlay_hit_id].getNumberOfContribs()
+                            << " total contributors in the output collection";
           }  // if add overlay as contribs
           else {
             calo_collection_map[out_coll_name].push_back(overlay_hit);
@@ -338,7 +370,7 @@ void OverlayProducer::produce(framework::Event &event) {
 
       /* ----------- now do simtracker hits_ overlay ----------- */
 
-      // get the SimTrackerHit collections that we want to overlay
+      // loop over the SimTrackerHit collections that we want to overlay
       for (const auto &coll : tracker_collections_) {
         auto overlay_tracker_hits{
             overlay_event_.getCollection<ldmx::SimTrackerHit>(
@@ -382,14 +414,42 @@ void OverlayProducer::produce(framework::Event &event) {
         ldmx_log(trace) << "in loop: printing overlay event: ";
 
         for (auto &[track_id, particle] : overlay_particles) {
-          auto overlay_time{particle.getTime() + time_offset};
-          particle.setTime(overlay_time);
           int new_track_id = track_id + track_id_increment;
-          particle_collection_map[out_coll_name_particles].emplace(new_track_id,
-                                                                   particle);
+          // need to increment all the track ids which requires
+          // copying each variable individually
+          ldmx::SimParticle new_particle;
+          new_particle.setEnergy(particle.getEnergy());
+          new_particle.setPdgID(particle.getPdgID());
+          new_particle.setGenStatus(particle.getGenStatus());
+          new_particle.setTime(particle.getTime() + time_offset);
+          std::vector<double> vertex = particle.getVertex();
+          new_particle.setVertex(vertex[0], vertex[1], vertex[2]);
+          new_particle.setVertexVolume(particle.getVertexVolume());
+          new_particle.setInteractionMaterial(
+              particle.getInteractionMaterial());
+          std::vector<double> end_point = particle.getEndPoint();
+          new_particle.setEndPoint(end_point[0], end_point[1], end_point[2]);
+          std::vector<double> momentum = particle.getMomentum();
+          new_particle.setMomentum(momentum[0], momentum[1], momentum[2]);
+          new_particle.setMass(particle.getMass());
+          new_particle.setCharge(particle.getCharge());
+          new_particle.setProcessType(particle.getProcessType());
+          std::vector<double> end_point_momentum =
+              particle.getEndPointMomentum();
+          new_particle.setEndPointMomentum(end_point_momentum[0],
+                                           end_point_momentum[1],
+                                           end_point_momentum[2]);
+          for (int &id : particle.getDaughters()) {
+            new_particle.addDaughter(id + track_id_increment);
+          }
+          for (int &id : particle.getParents()) {
+            new_particle.addParent(id + track_id_increment);
+          }
+          particle_collection_map[out_coll_name_particles].emplace(
+              new_track_id, new_particle);
 
           ldmx_log(trace) << "Track ID: " << new_track_id << " --- "
-                          << particle;
+                          << new_particle;
           ldmx_log(trace) << "Adding sim particle to output map "
                           << out_coll_name_particles;
         }  // over overlay sim particles collection

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -546,6 +546,18 @@ int OverlayProducer::encodeTrack(int track_id,
                         std::to_string(encoding_version) +
                         " has exceeded version maximum value of 15");
   }
+  if (track_id < 0) {
+    // if track_id < 0 it's probably a default nonsense value -1;
+    // encoding at present DOES NOT WORK for negative values because C++ uses
+    // twos complement encoding for negative numbers;
+    // thus when decoding you should first check the first bit, and
+    // set it to a nonsense -1 if the number is negative.
+    // Right now (2026-03-07) the only place where track IDs are -1 are the origin
+    // ids in the SimCalorimeterHit contribs, which aren't used anyways and present
+    // no risk for overwriting data for duplicate track IDs, so we can leave this alone
+    ldmx_log(warn) << "Track ID has value " << track_id << " < 0; no encoding will be applied";
+    return track_id;
+  }
 
   // encode Track ID according to provided version
   switch (encoding_version) {

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -12,6 +12,8 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
       parameters.get<std::vector<std::string>>("calo_collections");
   tracker_collections_ =
       parameters.get<std::vector<std::string>>("tracker_collections");
+  particle_collections_ =
+      parameters.get<std::vector<std::string>>("particle_collections");
   contrib_collections_ =
       parameters.get<std::vector<std::string>>("contrib_collections");
   sim_passname_ = parameters.get<std::string>("sim_passname");
@@ -41,6 +43,11 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
 
   ldmx_log(debug) << "\n\t overlayTrackerHitCollections = ";
   for (const std::string &coll : tracker_collections_) {
+    ldmx_log(debug) << coll << "; ";
+  }
+
+  ldmx_log(debug) << "\n\t overlayParticleCollections = ";
+  for (const std::string &coll : particle_collections_) {
     ldmx_log(debug) << coll << "; ";
   }
 
@@ -100,7 +107,12 @@ void OverlayProducer::produce(framework::Event &event) {
       calo_collection_map;
   std::map<std::string, std::vector<ldmx::SimTrackerHit>>
       tracker_collection_map;
+  std::map<std::string, std::map<int, ldmx::SimParticle>>
+      particle_collection_map;
   std::map<std::string, std::map<int, ldmx::SimCalorimeterHit>> hit_map;
+  int track_id_increment =
+      -1;  // there should only be one SimParticles collection, so it's fine for
+           // this to be just an integer rather than a vector
 
   // start by copying over all the collections from the sim event
 
@@ -165,6 +177,31 @@ void OverlayProducer::produce(framework::Event &event) {
       ldmx_log(trace) << simhit;
     }
   }  // over tracker collections for sim event
+
+  /* ----------- and finish up with SimParticles ----------- */
+
+  // get the SimParticle collections that we want to overlay, by looping
+  // over the list of collections passed to the producer : particle_collections_
+  for (const auto &coll_name : particle_collections_) {
+    auto sim_particles =
+        event.getMap<int, ldmx::SimParticle>(coll_name, sim_passname_);
+    particle_collection_map[coll_name + out_coll_postfix_] = sim_particles;
+
+    // the rest is printouts for debugging
+    ldmx_log(debug) << "in loop: size of sim particles map " << coll_name
+                    << " is " << sim_particles.size();
+
+    ldmx_log(debug) << "in loop: start of collection " << coll_name
+                    << "in loop: printing current sim event: ";
+
+    for (const auto &[track_id, particle] : sim_particles) {
+      if (track_id > track_id_increment) {
+        track_id_increment = track_id;
+      }
+      ldmx_log(trace) << "Sim particle has track_id " << track_id;
+      ldmx_log(trace) << particle;
+    }
+  }  // over particle collections for sim event
 
   /* ----------- now do the pileup overlay ----------- */
 
@@ -317,7 +354,7 @@ void OverlayProducer::produce(framework::Event &event) {
         for (auto &overlay_hit : overlay_tracker_hits) {
           auto overlay_time{overlay_hit.getTime() + time_offset};
           overlay_hit.setTime(overlay_time);
-          auto overlay_track_id{overlay_hit.getTrackID()};
+          auto overlay_track_id{overlay_hit.getTrackID() + track_id_increment};
           overlay_hit.setTrackID(overlay_track_id);
           tracker_collection_map[out_coll_name_tracker].push_back(overlay_hit);
 
@@ -331,6 +368,32 @@ void OverlayProducer::produce(framework::Event &event) {
                         << tracker_collection_map[out_coll_name_tracker].size();
 
       }  // over tracker_collections_
+
+      /* ----------- finally do SimParticles overlay ----------- */
+      for (const auto &coll : particle_collections_) {
+        auto overlay_particles{overlay_event_.getMap<int, ldmx::SimParticle>(
+            coll, overlay_passname_)};
+
+        ldmx_log(debug) << "in loop: size of overlay particles map is "
+                        << overlay_particles.size();
+
+        std::string out_coll_name_particles{coll + out_coll_postfix_};
+
+        ldmx_log(trace) << "in loop: printing overlay event: ";
+
+        for (auto &[track_id, particle] : overlay_particles) {
+          auto overlay_time{particle.getTime() + time_offset};
+          particle.setTime(overlay_time);
+          int new_track_id = track_id + track_id_increment;
+          particle_collection_map[out_coll_name_particles].emplace(new_track_id,
+                                                                   particle);
+
+          ldmx_log(trace) << "Track ID: " << new_track_id << " --- "
+                          << particle;
+          ldmx_log(trace) << "Adding sim particle to output map "
+                          << out_coll_name_particles;
+        }  // over overlay sim particles collection
+      }  // over particle_collections_
 
     }  // over overlay events
   }  // over bunches
@@ -381,6 +444,16 @@ void OverlayProducer::produce(framework::Event &event) {
     ldmx_log(trace) << "List of hits_ added: ";
     for (auto &hit : coll) {
       ldmx_log(trace) << hit;
+    }
+    event.add(name, coll);
+  }
+
+  // and finally for sim particles
+  for (auto &[name, coll] : particle_collection_map) {
+    ldmx_log(debug) << "Writing " << name << " to event bus.";
+    ldmx_log(trace) << "List of particles added: ";
+    for (auto &[track_id, particle] : coll) {
+      ldmx_log(trace) << "Track ID: " << track_id << " --- " << particle;
     }
     event.add(name, coll);
   }

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -30,8 +30,7 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
   bunch_spacing_ = parameters.get<double>("bunch_spacing");
   start_event_min_ = parameters.get<int>("start_event_min");
   start_event_max_ = parameters.get<int>("start_event_max");
-  track_id_encoding_ =
-      unsigned(parameters.get<int>("track_id_encoding", 0));
+  track_id_encoding_ = unsigned(parameters.get<int>("track_id_encoding", 0));
 
   /// Print the parameters actually set. Helpful in case of typos.
   ldmx_log(debug) << "Got parameters \n \t overlayFileName = "
@@ -552,10 +551,12 @@ int OverlayProducer::encodeTrack(int track_id,
     // twos complement encoding for negative numbers;
     // thus when decoding you should first check the first bit, and
     // set it to a nonsense -1 if the number is negative.
-    // Right now (2026-03-07) the only place where track IDs are -1 are the origin
-    // ids in the SimCalorimeterHit contribs, which aren't used anyways and present
-    // no risk for overwriting data for duplicate track IDs, so we can leave this alone
-    ldmx_log(warn) << "Track ID has value " << track_id << " < 0; no encoding will be applied";
+    // Right now (2026-03-07) the only place where track IDs are -1 are the
+    // origin ids in the SimCalorimeterHit contribs, which aren't used anyways
+    // and present no risk for overwriting data for duplicate track IDs, so we
+    // can leave this alone
+    ldmx_log(warn) << "Track ID has value " << track_id
+                   << " < 0; no encoding will be applied";
     return track_id;
   }
 

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -30,6 +30,8 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
   bunch_spacing_ = parameters.get<double>("bunch_spacing");
   start_event_min_ = parameters.get<int>("start_event_min");
   start_event_max_ = parameters.get<int>("start_event_max");
+  track_id_encoding_ =
+      unsigned(parameters.get<int>("track_id_encoding", 0));
 
   /// Print the parameters actually set. Helpful in case of typos.
   ldmx_log(debug) << "Got parameters \n \t overlayFileName = "
@@ -110,8 +112,6 @@ void OverlayProducer::produce(framework::Event &event) {
   std::map<std::string, std::map<int, ldmx::SimParticle>>
       particle_collection_map;
   std::map<std::string, std::map<int, ldmx::SimCalorimeterHit>> hit_map;
-  int track_id_increment = 100000;  // track_id's for overlay events will be
-                                    // incremented by this value
 
   // start by copying over all the collections from the sim event
 
@@ -135,6 +135,15 @@ void OverlayProducer::produce(framework::Event &event) {
     // overlay contribs have been added. then add everything through the hit_map
     if (!needs_contribs_added) {
       calo_collection_map[coll_name + out_coll_postfix_] = simhits_calo;
+      // after copying, perform track ID encodings;
+      // the main sample gets the event index 0 by default
+      for (auto &simhit : calo_collection_map[coll_name + out_coll_postfix_]) {
+        simhit.encodeTracks(
+            [this](int id, unsigned enc, unsigned idx) {
+              return encodeTrack(id, enc, idx);
+            },
+            track_id_encoding_, (unsigned)0);
+      }
     }
 
     ldmx_log(debug) << "in loop: start of collection " << coll_name
@@ -150,7 +159,12 @@ void OverlayProducer::produce(framework::Event &event) {
         ldmx_log(trace) << simhit;
         // this copies the hit, its ID and its coordinates directly
         hit_map[coll_name + out_coll_postfix_][simhit.getID()] = simhit;
-
+        // now encode track IDs on copied object
+        hit_map[coll_name + out_coll_postfix_][simhit.getID()].encodeTracks(
+            [this](int id, unsigned enc, unsigned idx) {
+              return encodeTrack(id, enc, idx);
+            },
+            track_id_encoding_, (unsigned)0);
       }  // over calo simhit collection
     }  // if needContribs
 
@@ -164,6 +178,12 @@ void OverlayProducer::produce(framework::Event &event) {
     auto simhits_tracker =
         event.getCollection<ldmx::SimTrackerHit>(coll_name, sim_passname_);
     tracker_collection_map[coll_name + out_coll_postfix_] = simhits_tracker;
+    // after copying, perform track ID encoding
+    for (auto &simhit : tracker_collection_map[coll_name + out_coll_postfix_]) {
+      int encoded_track_id =
+          encodeTrack(simhit.getTrackID(), track_id_encoding_, (unsigned)0);
+      simhit.setTrackID(encoded_track_id);
+    }
 
     // the rest is printouts for debugging
     ldmx_log(debug) << "in loop: size of sim hits_ vector " << coll_name
@@ -184,20 +204,25 @@ void OverlayProducer::produce(framework::Event &event) {
   for (const auto &coll_name : particle_collections_) {
     auto sim_particles =
         event.getMap<int, ldmx::SimParticle>(coll_name, sim_passname_);
-    particle_collection_map[coll_name + out_coll_postfix_] = sim_particles;
+    auto &output_map = particle_collection_map[coll_name + out_coll_postfix_];
 
-    // the rest is printouts for debugging
     ldmx_log(debug) << "in loop: size of sim particles map " << coll_name
                     << " is " << sim_particles.size();
 
     ldmx_log(debug) << "in loop: start of collection " << coll_name
                     << "in loop: printing current sim event: ";
 
-    for (const auto &[track_id, particle] : sim_particles) {
-      if (track_id > track_id_increment) {
-        track_id_increment = track_id;
-      }
-      ldmx_log(trace) << "Sim particle has track_id " << track_id;
+    // need to copy SimParticles individually because of std::map key
+    // immutability
+    for (auto &[track_id, particle] : sim_particles) {
+      int encoded_track_id =
+          encodeTrack(track_id, track_id_encoding_, (unsigned)0);
+      output_map[encoded_track_id] = particle;
+      output_map[encoded_track_id].encodeTracks(
+          [this](int id, unsigned enc, unsigned idx) {
+            return encodeTrack(id, enc, idx);
+          },
+          track_id_encoding_, (unsigned)0);
       ldmx_log(trace) << particle;
     }
   }  // over particle collections for sim event
@@ -212,6 +237,10 @@ void OverlayProducer::produce(framework::Event &event) {
   // inclusive interval
   int start_bunch = -n_earlier_;
   int end_bunch = n_later_;
+
+  // this is the event index number assigned to overlay sample hits and
+  // particles for track ID encoding
+  unsigned overlay_event_index = 1;
 
   // TODO -- figure out if we should also randomly shift the time of the sim
   // event (likely only needed if time bias gets picked up by BDT or ML by way
@@ -297,8 +326,17 @@ void OverlayProducer::produce(framework::Event &event) {
         for (ldmx::SimCalorimeterHit &overlay_hit : overlay_hits) {
           ldmx_log(trace) << overlay_hit;
 
-          const float overlay_time = overlay_hit.getTime() + time_offset;
-          overlay_hit.setTime(overlay_time);
+          // update relevant parameters with overlay modifications
+          overlay_hit.setTime(overlay_hit.getTime() + time_offset);
+          overlay_hit.setPreStepTime(overlay_hit.getPreStepTime() +
+                                     time_offset);
+          overlay_hit.setPostStepTime(overlay_hit.getPostStepTime() +
+                                      time_offset);
+          overlay_hit.encodeTracks(
+              [this](int id, unsigned enc, unsigned idx) {
+                return encodeTrack(id, enc, idx);
+              },
+              track_id_encoding_, overlay_event_index);
 
           if (needs_contribs_added) {  // special treatment for (for now only)
                                        // ecal
@@ -311,27 +349,18 @@ void OverlayProducer::produce(framework::Event &event) {
               ldmx_log(trace)
                   << "No existing simhit found for ID " << overlay_hit_id
                   << "; copying overlay hit to output collection";
-              this_coll_hit_map[overlay_hit_id] = ldmx::SimCalorimeterHit();
-              this_coll_hit_map[overlay_hit_id].setID(overlay_hit_id);
-              std::vector<float> hit_pos = overlay_hit.getPosition();
-              this_coll_hit_map[overlay_hit_id].setPosition(hit_pos[0], hit_pos[1],
-                                                  hit_pos[2]);
-              std::vector<float> pre_step_pos =
-                  overlay_hit.getPreStepPosition();
-              this_coll_hit_map[overlay_hit_id].setPreStepPosition(
-                  pre_step_pos[0], pre_step_pos[1], pre_step_pos[2]);
-              std::vector<float> post_step_pos =
-                  overlay_hit.getPostStepPosition();
-              this_coll_hit_map[overlay_hit_id].setPostStepPosition(
-                  post_step_pos[0], post_step_pos[1], post_step_pos[2]);
-              this_coll_hit_map[overlay_hit_id].setEdep(overlay_hit.getEdep());
-              this_coll_hit_map[overlay_hit_id].setPathLength(
-                  overlay_hit.getPathLength());
-              this_coll_hit_map[overlay_hit_id].setPreStepTime(
-                  overlay_hit.getPreStepTime() + time_offset);
-              this_coll_hit_map[overlay_hit_id].setPostStepTime(
-                  overlay_hit.getPostStepTime() + time_offset);
-              this_coll_hit_map[overlay_hit_id].setVelocity(overlay_hit.getVelocity());
+              auto &output_hit = this_coll_hit_map[overlay_hit_id];
+              output_hit = overlay_hit;  // copy hit
+
+              // we need to do some backflips to get the contribs correct later
+              auto id = output_hit.getID();
+              auto pos = output_hit.getPosition();
+              auto time = output_hit.getTime();
+              output_hit.clear();  // with the below adjustments, this will only
+                                   // clear contribs from the output_hit
+              output_hit.setID(id);
+              output_hit.setPosition(pos[0], pos[1], pos[2]);
+              output_hit.setTime(time);
             }  // if overlay_hit_id not present
 
             // add the overlay hit contribs to existing hit,
@@ -343,18 +372,19 @@ void OverlayProducer::produce(framework::Event &event) {
             for (int i = 0; i < n_contribs; i++) {
               ldmx::SimCalorimeterHit::Contrib contrib{
                   overlay_hit.getContrib(i)};
-              int incident_id = contrib.incident_id_ + track_id_increment;
-              int track_id = contrib.track_id_ + track_id_increment;
-              float time = contrib.time_ + time_offset;
-              this_coll_hit_map[overlay_hit_id].addContrib(incident_id, track_id,
-                                                 contrib.pdg_code_,
-                                                 contrib.edep_, time);
+              // tracks were encoded in-place above, so we only need to worry
+              // about times
+              this_coll_hit_map[overlay_hit_id].addContrib(
+                  contrib.incident_id_, contrib.track_id_, contrib.pdg_code_,
+                  contrib.edep_, contrib.time_ + time_offset);
             }  // loop over contribs in overlay_hit
-            ldmx_log(trace) << "There are now "
-                            << this_coll_hit_map[overlay_hit_id].getNumberOfContribs()
-                            << " total contributors in the output collection";
+            ldmx_log(trace)
+                << "There are now "
+                << this_coll_hit_map[overlay_hit_id].getNumberOfContribs()
+                << " total contributors in the output collection";
           }  // if add overlay as contribs
           else {
+            // no need to change contrib timestamps here
             calo_collection_map[out_coll_name].push_back(overlay_hit);
 
             ldmx_log(trace) << "Adding non-Ecal overlay hit to outhit vector "
@@ -386,13 +416,16 @@ void OverlayProducer::produce(framework::Event &event) {
         for (auto &overlay_hit : overlay_tracker_hits) {
           auto overlay_time{overlay_hit.getTime() + time_offset};
           overlay_hit.setTime(overlay_time);
-          auto overlay_track_id{overlay_hit.getTrackID() + track_id_increment};
+          auto overlay_track_id{encodeTrack(overlay_hit.getTrackID(),
+                                            track_id_encoding_,
+                                            overlay_event_index)};
           overlay_hit.setTrackID(overlay_track_id);
-          tracker_collection_map[out_coll_name_tracker].push_back(overlay_hit);
 
           ldmx_log(trace) << overlay_hit;
           ldmx_log(trace) << "Adding tracker overlay hit to outhit vector "
                           << out_coll_name_tracker;
+
+          tracker_collection_map[out_coll_name_tracker].push_back(overlay_hit);
         }  // over overlay tracker simhit collection
 
         ldmx_log(debug) << "Nhits in overlay collection "
@@ -410,46 +443,24 @@ void OverlayProducer::produce(framework::Event &event) {
                         << overlay_particles.size();
 
         std::string out_coll_name_particles{coll + out_coll_postfix_};
+        auto &output_map = particle_collection_map[out_coll_name_particles];
 
         ldmx_log(trace) << "in loop: printing overlay event: ";
 
         for (auto &[track_id, particle] : overlay_particles) {
-          int new_track_id = track_id + track_id_increment;
-          // need to increment all the track ids which requires
-          // copying each variable individually
-          ldmx::SimParticle new_particle;
-          new_particle.setEnergy(particle.getEnergy());
-          new_particle.setPdgID(particle.getPdgID());
-          new_particle.setGenStatus(particle.getGenStatus());
-          new_particle.setTime(particle.getTime() + time_offset);
-          std::vector<double> vertex = particle.getVertex();
-          new_particle.setVertex(vertex[0], vertex[1], vertex[2]);
-          new_particle.setVertexVolume(particle.getVertexVolume());
-          new_particle.setInteractionMaterial(
-              particle.getInteractionMaterial());
-          std::vector<double> end_point = particle.getEndPoint();
-          new_particle.setEndPoint(end_point[0], end_point[1], end_point[2]);
-          std::vector<double> momentum = particle.getMomentum();
-          new_particle.setMomentum(momentum[0], momentum[1], momentum[2]);
-          new_particle.setMass(particle.getMass());
-          new_particle.setCharge(particle.getCharge());
-          new_particle.setProcessType(particle.getProcessType());
-          std::vector<double> end_point_momentum =
-              particle.getEndPointMomentum();
-          new_particle.setEndPointMomentum(end_point_momentum[0],
-                                           end_point_momentum[1],
-                                           end_point_momentum[2]);
-          for (int &id : particle.getDaughters()) {
-            new_particle.addDaughter(id + track_id_increment);
-          }
-          for (int &id : particle.getParents()) {
-            new_particle.addParent(id + track_id_increment);
-          }
-          particle_collection_map[out_coll_name_particles].emplace(
-              new_track_id, new_particle);
+          int new_track_id =
+              encodeTrack(track_id, track_id_encoding_, overlay_event_index);
+
+          output_map[new_track_id] = particle;
+          output_map[new_track_id].encodeTracks(
+              [this](int id, unsigned enc, unsigned idx) {
+                return encodeTrack(id, enc, idx);
+              },
+              track_id_encoding_, overlay_event_index);
+          output_map[new_track_id].setTime(particle.getTime() + time_offset);
 
           ldmx_log(trace) << "Track ID: " << new_track_id << " --- "
-                          << new_particle;
+                          << output_map[new_track_id];
           ldmx_log(trace) << "Adding sim particle to output map "
                           << out_coll_name_particles;
         }  // over overlay sim particles collection
@@ -520,6 +531,50 @@ void OverlayProducer::produce(framework::Event &event) {
 
   return;
 }  // end produce()
+
+int OverlayProducer::encodeTrack(int track_id,
+                                 const unsigned int encoding_version,
+                                 const unsigned int event_index) {
+  ldmx_log(trace) << "Encoding track ID " << track_id
+                  << " according to version " << encoding_version;
+  int encoded_id;
+
+  // check if the encoding_version will overflow into the int sign bit
+  if (encoding_version > 15) {
+    EXCEPTION_RAISE("TrackEncodingError",
+                    "Track ID encoding version " +
+                        std::to_string(encoding_version) +
+                        " has exceeded version maximum value of 15");
+  }
+
+  // encode Track ID according to provided version
+  switch (encoding_version) {
+    case (unsigned)0: {  // need braces for variable init scope control
+      ldmx_log(trace) << "No encoding applied";
+      encoded_id = track_id;
+      break;
+    }
+    case (unsigned)1: {
+      // create bitwise masks for encoding from version number and event index
+      unsigned version_mask = (encoding_version << 27);
+      unsigned index_mask = (event_index << 24);
+
+      // encode track ID using bitwise OR
+      encoded_id = track_id | version_mask | index_mask;
+      ldmx_log(trace) << "Encoding successful! encoded_id = " << encoded_id
+                      << ", with bit representation "
+                      << std::bitset<32>(encoded_id);
+      break;
+    }
+    default: {  // version number has no associated encoding scheme
+      ldmx_log(warn) << "Track ID encoding version " << encoding_version
+                     << " has no definition! No encoding will be applied";
+      encoded_id = track_id;
+    }
+  }
+
+  return encoded_id;
+}
 
 void OverlayProducer::onProcessStart() {
   // replace by this line once the corresponding tweak to EventFile is ready:

--- a/SimCore/include/SimCore/Event/SimCalorimeterHit.h
+++ b/SimCore/include/SimCore/Event/SimCalorimeterHit.h
@@ -8,6 +8,9 @@
 #ifndef SIMCORE_EVENT_SIMCALORIMETERHIT_H_
 #define SIMCORE_EVENT_SIMCALORIMETERHIT_H_
 
+// C++
+#include <functional>  // for track ID encodings
+
 // ROOT
 #include "TObject.h"  //For ClassDef
 
@@ -275,6 +278,18 @@ class SimCalorimeterHit {
    * @param time The time of the contribution [ns].
    */
   void updateContrib(int i, float edep, float time);
+
+  /**
+   * Encodes all Track IDs in the SimCalorimeterHit object according
+   * to the schema provided in the 'encodeFunc' passed to this method.
+   * @param encodeFunc The track ID encoding function to be called.
+   * @param encoding_version The version number for the track ID bitwise
+   * encoding schema. Possible values range over [0, 15].
+   * @param event_index The sample event index to assign the track ID.
+   */
+  void encodeTracks(
+      std::function<int(int, unsigned int, unsigned int)> encodeFunc,
+      const unsigned int encoding_version, const unsigned int event_index = 0);
 
   /**
    * Sort by time of hit

--- a/SimCore/include/SimCore/Event/SimParticle.h
+++ b/SimCore/include/SimCore/Event/SimParticle.h
@@ -9,6 +9,7 @@
 /*~~~~~~~~~~~~~~~~*/
 /*   C++ StdLib   */
 /*~~~~~~~~~~~~~~~~*/
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -299,6 +300,18 @@ class SimParticle {
   void addParent(const int& parent_track_id) {
     parents_.push_back(parent_track_id);
   }
+
+  /**
+   * Encodes all Track IDs in the SimParticle object according
+   * to the schema provided in the 'encodeFunc' passed to this method.
+   * @param encodeFunc The track ID encoding function to be called.
+   * @param encoding_version The version number for the track ID bitwise
+   * encoding schema. Possible values range over [0, 15].
+   * @param event_index The sample event index to assign the track ID.
+   */
+  void encodeTracks(
+      std::function<int(int, unsigned int, unsigned int)> encodeFunc,
+      const unsigned int encoding_version, const unsigned int event_index = 0);
 
   /**
    * Get the creator process type of this particle.

--- a/SimCore/src/SimCore/Event/SimCalorimeterHit.cxx
+++ b/SimCore/src/SimCore/Event/SimCalorimeterHit.cxx
@@ -16,6 +16,7 @@ void SimCalorimeterHit::clear() {
   pdg_code_contribs_.clear();
   edep_contribs_.clear();
   time_contribs_.clear();
+  origin_contribs_.clear();
 
   n_contribs_ = 0;
   id_ = 0;
@@ -89,4 +90,18 @@ void SimCalorimeterHit::updateContrib(int i, float edep, float time) {
   }
   edep_ += edep;
 }
+
+void SimCalorimeterHit::encodeTracks(
+    std::function<int(int, unsigned int, unsigned int)> encodeFunc,
+    const unsigned int encoding_version, const unsigned int event_index) {
+  for (int i_contrib = 0; i_contrib < this->n_contribs_; i_contrib++) {
+    this->track_id_contribs_[i_contrib] = encodeFunc(
+        this->track_id_contribs_[i_contrib], encoding_version, event_index);
+    this->incident_id_contribs_[i_contrib] = encodeFunc(
+        this->incident_id_contribs_[i_contrib], encoding_version, event_index);
+    this->origin_contribs_[i_contrib] = encodeFunc(
+        this->origin_contribs_[i_contrib], encoding_version, event_index);
+  }
+}
+
 }  // namespace ldmx

--- a/SimCore/src/SimCore/Event/SimParticle.cxx
+++ b/SimCore/src/SimCore/Event/SimParticle.cxx
@@ -118,4 +118,16 @@ SimParticle::ProcessType SimParticle::findProcessType(
     return ProcessType::unknown;
   }
 }
+
+void SimParticle::encodeTracks(
+    std::function<int(int, unsigned int, unsigned int)> encodeFunc,
+    const unsigned int encoding_version, const unsigned int event_index) {
+  for (auto& daughter_track : this->daughters_) {
+    daughter_track = encodeFunc(daughter_track, encoding_version, event_index);
+  }  // over daughters
+  for (auto& parent_track : this->parents_) {
+    parent_track = encodeFunc(parent_track, encoding_version, event_index);
+  }  // over parents
+}
+
 }  // namespace ldmx

--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -38,7 +38,16 @@ std::tuple<int, const ldmx::SimParticle *> getRecoil(
   // only get here if recoil electron was not "produced" by dark brem
   //   in this case (bkgd), we interpret the primary electron as also the recoil
   //   electron
-  return {1, &(particleMap.at(1))};
+  if (particleMap.find(1) != particleMap.end()) {
+    return {1, &(particleMap.at(1))};
+  } else {
+    // need to account for overlay tracks, which replace track ID
+    // 1 with 134217729 in the main sample and with 150994945 in the
+    // pileup
+    // this code right now is decidedly NOT future proof and only handles a single
+    // encoding version
+    return {134217729, &(particleMap.at(134217729))};
+  }
 }
 
 // Search the recoil electrons daughters for a photon

--- a/Tools/src/Tools/AnalysisUtils.cxx
+++ b/Tools/src/Tools/AnalysisUtils.cxx
@@ -44,8 +44,8 @@ std::tuple<int, const ldmx::SimParticle *> getRecoil(
     // need to account for overlay tracks, which replace track ID
     // 1 with 134217729 in the main sample and with 150994945 in the
     // pileup
-    // this code right now is decidedly NOT future proof and only handles a single
-    // encoding version
+    // this code right now is decidedly NOT future proof and only handles a
+    // single encoding version
     return {134217729, &(particleMap.at(134217729))};
   }
 }

--- a/Tracking/python/full_tracking_sequence.py
+++ b/Tracking/python/full_tracking_sequence.py
@@ -239,11 +239,11 @@ def setOverlay(pass_name:str):
         params = vars(proc) # Python variable assignments are references by default,
                             # so this works to update the processor class variables
         for key, value in params.items():
-            if str(key) in ['input_pass_name', 'track_collection_event_passname', 
-                            'track_passname', 'meas_collection_event_passname', 'meas_passname', 
-                            'measurement_passname', 'truth_events_passname', 'truth_passname', 
-                            'track_collection_events_passname', 'input_tagger_pass_name', 
-                            'input_recoil_pass_name', 'input_collection_events_passname', 
+            if str(key) in ['input_pass_name', 'track_collection_event_passname',
+                            'track_passname', 'meas_collection_event_passname', 'meas_passname',
+                            'measurement_passname', 'truth_events_passname', 'truth_passname',
+                            'track_collection_events_passname', 'input_tagger_pass_name',
+                            'input_recoil_pass_name', 'input_collection_events_passname',
                             'tagger_trks_event_collection_passname']:
                 params[key] = pass_name
                 continue

--- a/Tracking/python/full_tracking_sequence.py
+++ b/Tracking/python/full_tracking_sequence.py
@@ -229,7 +229,8 @@ def setOverlay(pass_name:str):
     collection_names_to_update = [ # first, collections that are explicitly overlaid in the OverlayProducer
         "TriggerPad1SimHits", "TriggerPad2SimHits", "TriggerPad3SimHits",
         "TargetSimHits", "EcalSimHits", "HcalSimHits", "TaggerSimHits",
-        "RecoilSimHits", "EcalScoringPlaneHits", "TargetScoringPlaneHits"
+        "RecoilSimHits", "EcalScoringPlaneHits", "TargetScoringPlaneHits",
+        "SimParticles"
     ]
     overlay_str = 'Overlay'
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1954 by implemented track ID bitwise encoding in the OverlayProducer to ensure that tracks have unique IDs in the overlay collections. The way this works at present is that in the track ID 'int' value, the first four bits after the sign are reserved for the encoding version (0 for no encoding to match up with the 2-electron gun, and 1 for this version). In version 1 the next three bits encode the event index (0 for main events, 1 for overlay events). 

In the process this PR also introduces SimParticles overlay to properly enable the DQMs for 2e samples, following the same track ID encoding steps.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

As expected, there are now 2 tracks everywhere in the it_pileup validation now that the duplicate track IDs are not causing errors in the overlay. The number of straight tracks and hits in the detector has also increased, understandably. (All plots below are from the it_pileup validation.)

RecoilDQM_N_tracks:
![RecoilDQM_N_tracks.pdf](https://github.com/user-attachments/files/25997750/RecoilDQM_N_tracks.pdf)

EcalMipTrackingFeatures_n_straight_tracks:
![EcalMipTrackingFeatures_n_straight_tracks.pdf](https://github.com/user-attachments/files/25997759/EcalMipTrackingFeatures_n_straight_tracks.pdf)

EcalDigiVerify_num_sim_hits_per_cell:
![EcalDigiVerify_num_sim_hits_per_cell.pdf](https://github.com/user-attachments/files/25997765/EcalDigiVerify_num_sim_hits_per_cell.pdf)


