### PR TITLE
OverlayProducer contribs collections identification

### DIFF
--- a/Biasing/test/resim_ecal_conv_deep.py
+++ b/Biasing/test/resim_ecal_conv_deep.py
@@ -15,7 +15,7 @@ det = 'ldmx-det-v14-8gev'
 # Please make sure that the simulator here matches the simulator in the original config
 #mysim = ecal.deep_photo_nuclear(det, generators.single_8gev_e_upstream_tagger(),
 #bias_threshold = 5010., processes=['conv','phot)'], ecal_min_z = 300.)
-mysim = ecal.deep_photo_nuclear(det, generators.single_8gev_e_upstream_tagger(), 
+mysim = ecal.deep_photo_nuclear(det, generators.single_8gev_e_upstream_tagger(),
     bias_threshold = 3000., processes=['conv','phot)'], ecal_min_z = 400.)
 mysim.description = "ECal Deep Donversion Test Re-Simulation"
 #mysim.actions.extend([filters.TargetBremFilter()]),

--- a/Recon/include/Recon/OverlayProducer.h
+++ b/Recon/include/Recon/OverlayProducer.h
@@ -2,6 +2,7 @@
 #define RECON_OVERLAYPRODUCER_H
 
 //---< C++ StdLib >---//
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
@@ -96,6 +97,11 @@ class OverlayProducer : public framework::Producer {
    * combining sim and pileup
    */
   std::vector<std::string> tracker_collections_;
+
+  /**
+   * List of SimCalorimeterHit collections which keep track of hit contribs.
+   */
+  std::vector<std::string> contrib_collections_;
 
   /**
    * Pileup overlay events input pass name

--- a/Recon/include/Recon/OverlayProducer.h
+++ b/Recon/include/Recon/OverlayProducer.h
@@ -15,6 +15,7 @@
 #include "Framework/Configure/Parameters.h"
 #include "Framework/EventFile.h"
 #include "Framework/EventProcessor.h"
+#include "Framework/Exception/Exception.h"
 #include "Framework/RandomNumberSeedService.h"
 #include "SimCore/Event/SimCalorimeterHit.h"
 #include "SimCore/Event/SimTrackerHit.h"

--- a/Recon/python/overlay.py
+++ b/Recon/python/overlay.py
@@ -70,6 +70,7 @@ class OverlayProducer(ldmxcfg.Producer) :
         self.calo_collections =  ["TriggerPad1SimHits", "TriggerPad2SimHits", "TriggerPad3SimHits",
                                    "TargetSimHits", "EcalSimHits", "HcalSimHits"]
         self.tracker_collections = [ "TaggerSimHits", "RecoilSimHits" ]
+        self.contrib_collections = [ "EcalSimHits", "HcalSimHits" ]
         self.out_coll_postfix = "Overlay"
         self.poisson_mu = 2.
         self.do_poisson_in_time = False

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -12,6 +12,8 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
       parameters.get<std::vector<std::string>>("calo_collections");
   tracker_collections_ =
       parameters.get<std::vector<std::string>>("tracker_collections");
+  contrib_collections_ =
+      parameters.get<std::vector<std::string>>("contrib_collections");
   sim_passname_ = parameters.get<std::string>("sim_passname");
   overlay_passname_ = parameters.get<std::string>("overlay_passname");
   out_coll_postfix_ = parameters.get<std::string>("out_coll_postfix");
@@ -95,16 +97,19 @@ void OverlayProducer::produce(framework::Event &event) {
   // get the calo hits_ collections that we want to overlay, by looping over
   // the list of collections passed to the producer : calo_collections_
   for (const auto &coll_name : calo_collections_) {
-    // for now, Ecal and only Ecal uses contribs instead of multiple
-    // simhits_calo per channel, meaning, it requires special treatment
-    auto needs_contribs_added{
-        coll_name.find("Ecal") != std::string::npos ? true : false};
+    // search for the collection name in the list of collections that
+    // need contribs to be added, contrib_collections_
+    bool needs_contribs_added{std::find(contrib_collections_.begin(),
+                                        contrib_collections_.end(),
+                                        coll_name) != contrib_collections_.end()
+                                  ? true
+                                  : false};
 
-    // start out by just copying the sim hits_, unaltered.
+    // start out by just copying the sim hits, unaltered.
     auto simhits_calo =
         event.getCollection<ldmx::SimCalorimeterHit>(coll_name, sim_passname_);
-    // but don't copy ecal hits_ immediately: for them, wait until overlay
-    // contribs have been added. then add everything through the hit_map
+    // but don't copy contrib using hits immediately: for them, wait until
+    // overlay contribs have been added. then add everything through the hit_map
     if (!needs_contribs_added) {
       calo_collection_map[coll_name + out_coll_postfix_] = simhits_calo;
     }
@@ -117,6 +122,7 @@ void OverlayProducer::produce(framework::Event &event) {
     // we don't need to touch the hard process sim hits_, really... but we
     // might need the simhits in the hit map.
     if (needs_contribs_added) {
+      ldmx_log(trace) << "Collection " << coll_name << "needs contribs added";
       for (const ldmx::SimCalorimeterHit &simhit : simhits_calo) {
         ldmx_log(trace) << simhit;
         // this copies the hit, its ID and its coordinates directly
@@ -220,11 +226,13 @@ void OverlayProducer::produce(framework::Event &event) {
 
       // again get the calo hits_ collections that we want to overlay
       for (uint i_coll = 0; i_coll < calo_collections_.size(); i_coll++) {
-        // for now, Ecal and only Ecal uses contribs
-        bool needs_contribs_added = false;
-        if (strstr(calo_collections_[i_coll].c_str(), "Ecal")) {
-          needs_contribs_added = true;
-        }
+        // search for the collection name in the list of collections that
+        // need contribs to be added, contrib_collections_
+        bool needs_contribs_added{
+            std::find(contrib_collections_.begin(), contrib_collections_.end(),
+                      calo_collections_[i_coll]) != contrib_collections_.end()
+                ? true
+                : false};
 
         std::vector<ldmx::SimCalorimeterHit> overlay_hits =
             overlay_event_.getCollection<ldmx::SimCalorimeterHit>(

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -88,7 +88,7 @@ void OverlayProducer::produce(framework::Event &event) {
       calo_collection_map;
   std::map<std::string, std::vector<ldmx::SimTrackerHit>>
       tracker_collection_map;
-  std::map<int, ldmx::SimCalorimeterHit> hit_map;
+  std::map<std::string, std::map<int, ldmx::SimCalorimeterHit>> hit_map;
 
   // start by copying over all the collections from the sim event
 
@@ -126,7 +126,7 @@ void OverlayProducer::produce(framework::Event &event) {
       for (const ldmx::SimCalorimeterHit &simhit : simhits_calo) {
         ldmx_log(trace) << simhit;
         // this copies the hit, its ID and its coordinates directly
-        hit_map[simhit.getID()] = simhit;
+        hit_map[coll_name + out_coll_postfix_][simhit.getID()] = simhit;
 
       }  // over calo simhit collection
     }  // if needContribs
@@ -254,19 +254,22 @@ void OverlayProducer::produce(framework::Event &event) {
 
           if (needs_contribs_added) {  // special treatment for (for now only)
                                        // ecal
+            auto &this_coll_hit_map{
+                hit_map[calo_collections_[i_coll] + out_coll_postfix_]};
             int overlay_hit_id = overlay_hit.getID();
-            if (hit_map.find(overlay_hit_id) ==
-                hit_map.end()) {  // there wasn't already a simhit in this id
-              hit_map[overlay_hit_id] = ldmx::SimCalorimeterHit();
-              hit_map[overlay_hit_id].setID(overlay_hit_id);
+            if (this_coll_hit_map.find(overlay_hit_id) ==
+                this_coll_hit_map
+                    .end()) {  // there wasn't already a simhit in this id
+              this_coll_hit_map[overlay_hit_id] = ldmx::SimCalorimeterHit();
+              this_coll_hit_map[overlay_hit_id].setID(overlay_hit_id);
               std::vector<float> hit_pos = overlay_hit.getPosition();
-              hit_map[overlay_hit_id].setPosition(hit_pos[0], hit_pos[1],
-                                                  hit_pos[2]);
+              this_coll_hit_map[overlay_hit_id].setPosition(
+                  hit_pos[0], hit_pos[1], hit_pos[2]);
             }
             // add the overlay hit (as a) contrib
             // incidentID = -1000, trackID = -1000, pdgCode = 0  <-- these are
             // set in the header for now but could be parameters
-            hit_map[overlay_hit_id].addContrib(
+            this_coll_hit_map[overlay_hit_id].addContrib(
                 overlay_incident_id_, overlay_track_id_, overlay_pdg_code_,
                 overlay_hit.getEdep(), overlay_time);
           }  // if add overlay as contribs

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -320,35 +320,32 @@ void OverlayProducer::produce(framework::Event &event) {
     }  // over overlay events
   }  // over bunches
 
-  // after all events are done, the ecal hit_map is final and can be written
-  // to the event output
-  for (uint i_coll = 0; i_coll < calo_collections_.size(); i_coll++) {
-    // loop through collection names to find the right collection name
-    // add overlaid ecal hits_ as contribs/from hit_map rather than as copied
-    // simhits
-    if (strstr(calo_collections_[i_coll].c_str(), "Ecal")) {
-      ldmx_log(trace) << "Hits in hit_map after overlay of "
-                      << calo_collections_[i_coll] << "Overlay :";
+  // after all events are done, the contrib-using collections' hit_maps are
+  // final and can be written to the event output
+  for (uint i_coll = 0; i_coll < contrib_collections_.size(); i_coll++) {
+    // for each SimCalorimeterHit collection that uses contribs, add overlaid
+    // hits_ as contribs/from hit_map rather than as copied simhits
+    ldmx_log(trace) << "Hits in hit_map after overlay of "
+                    << contrib_collections_[i_coll] << "Overlay :";
 
-      for (auto &map_hit : hit_map) {
-        ldmx_log(trace) << map_hit.second;
+    for (auto &map_hit :
+         hit_map[contrib_collections_[i_coll] + out_coll_postfix_]) {
+      ldmx_log(trace) << map_hit.second;
 
-        if (calo_collection_map.find(calo_collections_[i_coll] +
-                                     out_coll_postfix_) ==
-            calo_collection_map.end()) {
-          ldmx_log(debug) << "Adding first hit from hit map as first outhit "
-                             "vector to calo_collection_map";
-          calo_collection_map[calo_collections_[i_coll] + out_coll_postfix_] = {
-              map_hit.second};
-        } else {
-          calo_collection_map[calo_collections_[i_coll] + out_coll_postfix_]
-              .push_back(map_hit.second);
-        }
-      }  // over hit_map
-      break;  // for now we only have one hit_map: for Ecal. so no need
-              // looking further after we got a match
-    }  // isEcal
-  }  // second loop over collections, to collect hits_ from hit_map
+      if (calo_collection_map.find(contrib_collections_[i_coll] +
+                                   out_coll_postfix_) ==
+          calo_collection_map.end()) {
+        ldmx_log(debug) << "Adding first hit from hit map as first outhit "
+                           "vector to calo_collection_map";
+        calo_collection_map[contrib_collections_[i_coll] + out_coll_postfix_] =
+            {map_hit.second};
+      } else {
+        calo_collection_map[contrib_collections_[i_coll] + out_coll_postfix_]
+            .push_back(map_hit.second);
+      }
+    }  // over hit_map
+  }  // second loop over contrib using collections, to collect hits_ from
+     // hit_map
 
   // done collecting hits_.
 

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -122,7 +122,7 @@ void OverlayProducer::produce(framework::Event &event) {
     // we don't need to touch the hard process sim hits_, really... but we
     // might need the simhits in the hit map.
     if (needs_contribs_added) {
-      ldmx_log(trace) << "Collection " << coll_name << "needs contribs added";
+      ldmx_log(trace) << "Collection " << coll_name << " needs contribs added";
       for (const ldmx::SimCalorimeterHit &simhit : simhits_calo) {
         ldmx_log(trace) << simhit;
         // this copies the hit, its ID and its coordinates directly

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -55,6 +55,18 @@ void OverlayProducer::configure(framework::config::Parameters &parameters) {
                   << "\n\t startEventMin = " << start_event_min_
                   << "\n\t startEventMax = " << start_event_max_;
 
+  // given how the contrib collection specification is setup, it's possible for
+  // spelling errors to cause doom here, so we want to flag those
+  for (auto coll_name : contrib_collections_) {
+    if (std::find(calo_collections_.begin(), calo_collections_.end(),
+                  coll_name) == calo_collections_.end()) {
+      EXCEPTION_RAISE("CollNameMismatch",
+                      "The contrib-using collection " + coll_name +
+                          " does not match any SimCalorimeterHit collection in "
+                          "'calo_collections_'! Please check your spelling");
+    }
+  }
+
   return;
 }  // end configure()
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
Previously, the SimCalorimeterHit collections only used contribs in the Ecal, so there was a hardcoded collection name parsing line in the OverlayProducer which determined if the word "Ecal" was in the collection - if so, then contribs were added separately. Now, however, both the HCal and ECal use contribs and it would be better if these weren't hardcoded into the producer. 

This PR instead creates a variable in the Python configuration called `contrib_collections_`, which contains a list of collection names that use contribs (by default, these are "EcalSimHits" and "HcalSimHits"). Instead of parsing the collection name, now the OverlayProducer checks whether the collection name being overlaid is present in the `contrib_collections_` list. 

This resolves #1105. 

(There's also a random config that was lumped up in the ruff check, so I've included that as well, but I can discard it if need be.)

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Below are the trace level debug printouts I added when collections are using contribs. We can see that both the Ecal and Hcal sim hits collections use the contribs, as desired.

<img width="930" height="290" alt="Screenshot 2026-02-19 at 11 44 13" src="https://github.com/user-attachments/assets/4b3c7151-3227-4426-b2b0-75284e2f83a8" />

<img width="998" height="254" alt="Screenshot 2026-02-19 at 11 43 58" src="https://github.com/user-attachments/assets/d3c16930-61b3-4d64-9b48-635be5e04c56" />
