### PR TITLE
Add tspads+materials into the v15-lyso geom

### DIFF
--- a/Detectors/data/ldmx-det-v15-8gev/constants.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/constants.gdml
@@ -10,7 +10,8 @@
 
 <!-- 
     Target
---> 
+-->
+
 <!-- position -->
 <constant name="target_z" value="0.0*mm" />
 <!-- Tungsten X0 = .3504 cm.  Target thickeness = .1X0 -->
@@ -179,6 +180,12 @@ subtracted here to make them positive lengths.
 <constant name="trigger_pad2_actual_z"
     value="ts_center_z + (trig_scint_area_envelope_z/2 - trigger_pad_thickness/2)" />
 
+<!-- Target parent volume dimensions -->
+<!-- Moved here due to dependence on other constants-->>
+<constant name="target_area_envelope_x" value="magnet_gap_dx - 5" />
+<constant name="target_area_envelope_y" value="magnet_gap_dy - 5" />
+<constant name="target_area_envelope_z" 
+          value="2*(target_thickness/2 + 2*clearance + + trigger_gap_from_target + trigger_pad_thickness)" />
 
 <!--
    HCal

--- a/Detectors/data/ldmx-det-v15-8gev/materials.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/materials.gdml
@@ -44,6 +44,9 @@ use "glue" instead of listing the chemical formula.
 <element Z="11" formula="Na" name="Na">
   <atom type="A" unit="g/mol" value="22.9898"/>
 </element>
+<element Z="13" formula="Al" name="Al">
+  <atom type="A" unit="g/mol" value="26.982"/>
+</element>
 <element Z="14" formula="Si" name="Si">
   <atom type="A" unit="g/mol" value="28.0854"/>
 </element>

--- a/Detectors/data/ldmx-det-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-det-v15-8gev/target.gdml
@@ -8,15 +8,8 @@
 
   <define>
 
-    &constants;   
-    
+    &constants;       
     <variable name="x" value="1"/>
-
-    <!-- Parent volume dimensions --> 
-    <constant name="target_area_envelope_x" value="magnet_gap_dx - 5" />
-    <constant name="target_area_envelope_y" value="magnet_gap_dy - 5" />
-    <constant name="target_area_envelope_z" 
-              value="2*(target_thickness/2 + 2*clearance + + trigger_gap_from_target + trigger_pad_thickness)" />
 
   </define>
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/constants.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/constants.gdml
@@ -136,7 +136,7 @@ subtracted here to make them positive lengths.
     <!-- target_area_box-->
 <constant name="target_area_envelope_x" value="target_array2_dx" />
 <constant name="target_area_envelope_y" value="target_array2_dy" />
-<constant name="target_area_envelope_z" value="3 * (target_thickness/2 + trigger_gap_with_target + trigger_pad_thickness)" />
+<constant name="target_area_envelope_z" value="2.5 * (target_thickness/2 + trigger_gap_with_target + trigger_pad_thickness)" />
 
 <!--
   Tracker common variables 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/constants.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/constants.gdml
@@ -10,7 +10,7 @@
 
 <!-- 
     Target
---> 
+-->
 
 <!-- Target dimensions -->
 
@@ -80,21 +80,33 @@
 <constant name="trigger_pad_dim_x"          value="target_dim_x" />
 <constant name="trigger_pad_dim_y"          value="target_dim_y" />
 <constant name="trigger_bar_dx"             value="30"/>
-<constant name="trigger_bar_dy"             value="3.05"/>   
+<constant name="trigger_bar_dy"             value="3.0"/>   
 <constant name="number_of_bars"             value="24"/>
+<constant name="sipm_thickness"             value="0.05*mm"/>
+<constant name="sipm_dy"                    value="2*mm"/>
+<constant name="sipm_dz"                    value="2*mm"/>
 
 <constant name="trigger_pad_offset"    
           value="(target_dim_y - (number_of_bars*trigger_bar_dy + (number_of_bars - 1)*trigger_pad_bar_gap))/2" />
 
-<!-- Trigger pad distance from the target is -2.4262 --> 
+<!-- Trigger pad setup --> 
+<constant name="trigger_gap_from_target"
+          value="1.4248*mm" />
 <constant name="trig_scint_pad12_separation"
           value="60"/>
+<!--Trigger pad x follows the beam curve and is determined a priori
+    If the z values of the trigger pads change, these must be recalculated-->
+<constant name="trigger_pad1_x"      
+          value="-21.5*mm" />
+<constant name="trigger_pad2_x"      
+          value="-19*mm" />
+
 <constant name="trigger_pad1_z"
           value="- trig_scint_pad12_separation - trigger_pad_thickness/2 - clearance" />
 <constant name="trigger_pad2_z"    
           value="-(trigger_pad_thickness/2) - clearance" />
 <constant name="trigger_pad3_z"      
-          value="target_z - (target_thickness/2) - (trigger_pad_thickness/2) - trigger_gap_with_target - clearance" />
+          value="target_z - (target_thickness/2) - (trigger_pad_thickness/2) - trigger_gap_from_target - clearance" />
 
 <!-- Parent volume dimensions --> 
 <constant name="trig_scint_area_envelope_x" value="magnet_gap_dx - 5" />
@@ -102,10 +114,29 @@
 <constant name="trig_scint_area_envelope_z" 
           value="-trigger_pad1_z + trigger_pad_thickness + 2*clearance"/>
 
+
+<!-- Light-pipe bar dimensions for TS-->
+
+<!--
+The distance between TSPad3 and the SiPMs is the shortest, and the other
+two sets of light pipes have length added equal to the displacement due to beam curvature. The displacements are stored as negative values, so are
+subtracted here to make them positive lengths.
+-->
+<constant name="trigger_light_pipe3_dx"        value="36.24*mm"/>
+<constant name="trigger_light_pipe2_dx"        value="trigger_light_pipe3_dx - trigger_pad2_x"/>
+<constant name="trigger_light_pipe1_dx"        value="trigger_light_pipe3_dx - trigger_pad1_x"/>
+<!--The dy and thickness of the light pipes should match that of the scintillator bars-->
+<constant name="trigger_light_pipe_dy"         value="trigger_bar_dy"/>
+<constant name="trigger_light_pipe_thickness"  value="trigger_pad_bar_thickness"/>
+
+<constant name="tspad1_envelope_x"             value="trigger_bar_dx + trigger_light_pipe1_dx + sipm_thickness"/> 
+<constant name="tspad2_envelope_x"             value="trigger_bar_dx + trigger_light_pipe2_dx + sipm_thickness"/> 
+<constant name="tspad3_envelope_x"             value="trigger_bar_dx + trigger_light_pipe3_dx + sipm_thickness"/>
+
     <!-- target_area_box-->
 <constant name="target_area_envelope_x" value="target_array2_dx" />
 <constant name="target_area_envelope_y" value="target_array2_dy" />
-<constant name="target_area_envelope_z" value="2 * (target_thickness/2 + trigger_gap_with_target + trigger_pad_thickness)" />
+<constant name="target_area_envelope_z" value="3 * (target_thickness/2 + trigger_gap_with_target + trigger_pad_thickness)" />
 
 <!--
   Tracker common variables 
@@ -355,7 +386,6 @@ when defining GDML variables, so this needs to be precomputed.
 
 <!--
 The thickness of the strongback aluminum bar holding up the bilayer
-
 there are only two thicknesses but since it varies _at all_ across
 bilayers, we need to list them all explicitly so we can just reference
 them in the bilayer loop

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/detector.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/detector.gdml
@@ -2,6 +2,7 @@
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
 <!ENTITY materials SYSTEM "materials.gdml">
+
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
@@ -113,233 +114,9 @@
     <rotation name="flip" unit="deg" x="0" y="180" z="0"/>
   </define>
 
-  <materials>
-    <!-- alimunum for support box -->
-    <material Z="13" name="G4_Al0x2705780" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="166"/>
-      <D unit="g/cm3" value="2.699"/>
-      <atom unit="g/mole" value="26.9815"/>
-    </material>
-
-    <!-- PCB mixture -->
-    <isotope N="63" Z="29" name="Cu630x271bbf0">
-      <atom unit="g/mole" value="62.9296"/>
-    </isotope>
-    <isotope N="65" Z="29" name="Cu650x271bc60">
-      <atom unit="g/mole" value="64.9278"/>
-    </isotope>
-    <element name="Cu0x271b990">
-      <fraction n="0.6917" ref="Cu630x271bbf0"/>
-      <fraction n="0.3083" ref="Cu650x271bc60"/>
-    </element>
-    <isotope N="16" Z="8" name="O160x271e090">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O170x271e400">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O180x271e490">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O0x271e1a0">
-      <fraction n="0.99757" ref="O160x271e090"/>
-      <fraction n="0.00038" ref="O170x271e400"/>
-      <fraction n="0.00205" ref="O180x271e490"/>
-    </element>
-    <isotope N="23" Z="11" name="Na230x2725ef0">
-      <atom unit="g/mole" value="22.9898"/>
-    </isotope>
-    <element name="Na0x2725c90">
-      <fraction n="1" ref="Na230x2725ef0"/>
-    </element>
-    <isotope N="28" Z="14" name="Si280x271c4f0">
-      <atom unit="g/mole" value="27.9769"/>
-    </isotope>
-    <isotope N="29" Z="14" name="Si290x271c560">
-      <atom unit="g/mole" value="28.9765"/>
-    </isotope>
-    <isotope N="30" Z="14" name="Si300x271c5f0">
-      <atom unit="g/mole" value="29.9738"/>
-    </isotope>
-    <element name="Si0x271c2c0">
-      <fraction n="0.922296077703922" ref="Si280x271c4f0"/>
-      <fraction n="0.0468319531680468" ref="Si290x271c560"/>
-      <fraction n="0.0308719691280309" ref="Si300x271c5f0"/>
-    </element>
-    <isotope N="40" Z="20" name="Ca400x2726160">
-      <atom unit="g/mole" value="39.9626"/>
-    </isotope>
-    <isotope N="42" Z="20" name="Ca420x27261d0">
-      <atom unit="g/mole" value="41.9586"/>
-    </isotope>
-    <isotope N="43" Z="20" name="Ca430x2726240">
-      <atom unit="g/mole" value="42.9588"/>
-    </isotope>
-    <isotope N="44" Z="20" name="Ca440x27262e0">
-      <atom unit="g/mole" value="43.9555"/>
-    </isotope>
-    <isotope N="46" Z="20" name="Ca460x2726350">
-      <atom unit="g/mole" value="45.9537"/>
-    </isotope>
-    <isotope N="48" Z="20" name="Ca480x2726390">
-      <atom unit="g/mole" value="47.9525"/>
-    </isotope>
-    <element name="Ca0x2725f30">
-      <fraction n="0.96941" ref="Ca400x2726160"/>
-      <fraction n="0.00647" ref="Ca420x27261d0"/>
-      <fraction n="0.00135" ref="Ca430x2726240"/>
-      <fraction n="0.02086" ref="Ca440x27262e0"/>
-      <fraction n="4e-05" ref="Ca460x2726350"/>
-      <fraction n="0.00187" ref="Ca480x2726390"/>
-    </element>
-    <material name="FR40x27264f0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="201.221278976803"/>
-      <D unit="g/cm3" value="5.68"/>
-      <fraction n="0.5" ref="Cu0x271b990"/>
-      <fraction n="0.22990022990023" ref="O0x271e1a0"/>
-      <fraction n="0.0482205482205482" ref="Na0x2725c90"/>
-      <fraction n="0.168276668276668" ref="Si0x271c2c0"/>
-      <fraction n="0.0536025536025536" ref="Ca0x2725f30"/>
-    </material>
-
-    <!-- glue mixture -->
-    <isotope N="12" Z="6" name="C120x271ddf0">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C130x271de60">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C0x271db90">
-      <fraction n="0.9893" ref="C120x271ddf0"/>
-      <fraction n="0.0107" ref="C130x271de60"/>
-    </element>
-    <isotope N="1" Z="1" name="H10x271f760">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H20x271f7d0">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H0x271f530">
-      <fraction n="0.999885" ref="H10x271f760"/>
-      <fraction n="0.000115" ref="H20x271f7d0"/>
-    </element>
-    <material name="Glue0x272cce0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="73.3297495741215"/>
-      <D unit="g/cm3" value="0.845"/>
-      <fraction n="0.84491305" ref="C0x271db90"/>
-      <fraction n="0.042542086" ref="H0x271f530"/>
-      <fraction n="0.11254487" ref="O0x271e1a0"/>
-    </material>
-
-    <!-- sensitive silicon -->
-    <material name="G4_Si0x271c1c0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="173"/>
-      <D unit="g/cm3" value="2.33"/>
-      <fraction n="1" ref="Si0x271c2c0"/>
-    </material>
-
-    <!-- 
-    carbon+epoxy composite material for cooling plane 
+  
     
-    - taking the Epoxy mixture from the PDG values for
-      Epotek-301
-      https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
-    - the MEE value is pretty much made up at this point,
-      assuming it is the same as pure carbon which seems
-      to be an ok assumption since a majority of the epoxy
-      is carbon as well
-    - the epoxy to C-fiber ratio is 0.955 _by weight_
-
-    Fractions calculated by doing
-      C = 1+PDGFrac / 1.955
-      H = PDGFrac / 1.955
-      O = PDGFrac / 1.955
-      N = PDGFrac / 1.955
-    where PDGFrac is that material's mass fraction in the PDG
-    material linked above which we convert to molar fraction
-    by converting each fraction to moles individually and then
-    dividing by the sum.
-    -->
-    <material name="CarbonEpoxyComposite" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="1.439"/>
-      <fraction n="0.624883102" ref="C0x271db90"/>
-      <fraction n="0.308001109" ref="H0x271f530"/>
-      <fraction n="0.064281977" ref="O0x271e1a0"/>
-      <fraction n="0.002833811" ref="G4_AIR0x271da60"/><!--ref="N140x271e0d0"/>-->
-    </material>
-
-    <!-- air for gaps -->
-    <isotope N="14" Z="7" name="N140x271e0d0">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N150x271e140">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N0x271dea0">
-      <fraction n="0.99632" ref="N140x271e0d0"/>
-      <fraction n="0.00368" ref="N150x271e140"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar360x271e730">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar380x271e7c0">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar400x271e850">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar0x271e500">
-      <fraction n="0.003365" ref="Ar360x271e730"/>
-      <fraction n="0.000632" ref="Ar380x271e7c0"/>
-      <fraction n="0.996003" ref="Ar400x271e850"/>
-    </element>
-    <material name="G4_AIR0x271da60" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C0x271db90"/>
-      <fraction n="0.755267755267755" ref="N0x271dea0"/>
-      <fraction n="0.231781231781232" ref="O0x271e1a0"/>
-      <fraction n="0.0128270128270128" ref="Ar0x271e500"/>
-    </material>
-
-    <!-- Tungsten for absorber -->
-    <isotope N="180" Z="74" name="W1800x270c100">
-      <atom unit="g/mole" value="179.947"/>
-    </isotope>
-    <isotope N="182" Z="74" name="W1820x270c170">
-      <atom unit="g/mole" value="181.948"/>
-    </isotope>
-    <isotope N="183" Z="74" name="W1830x270c210">
-      <atom unit="g/mole" value="182.95"/>
-    </isotope>
-    <isotope N="184" Z="74" name="W1840x270c2b0">
-      <atom unit="g/mole" value="183.951"/>
-    </isotope>
-    <isotope N="186" Z="74" name="W1860x270c2f0">
-      <atom unit="g/mole" value="185.954"/>
-    </isotope>
-    <element name="W0x270bea0">
-      <fraction n="0.0012" ref="W1800x270c100"/>
-      <fraction n="0.265" ref="W1820x270c170"/>
-      <fraction n="0.1431" ref="W1830x270c210"/>
-      <fraction n="0.3064" ref="W1840x270c2b0"/>
-      <fraction n="0.2843" ref="W1860x270c2f0"/>
-    </element>
-    <material name="G4_W0x270bda0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="727"/>
-      <D unit="g/cm3" value="19.3"/>
-      <fraction n="1" ref="W0x270bea0"/>
-    </material>
-
-  </materials>
+  
 
   <solids>
     <!--
@@ -519,22 +296,22 @@
     </assembly>
 
     <volume name="PCB_volume">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="PCB_hexagon"/>
     </volume>
   
     <volume name="Glue_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Glue"/>
       <solidref ref="Glue_hexagon"/>
     </volume>
   
     <volume name="Si_volume">
-      <materialref ref="G4_Si0x271c1c0"/>
+      <materialref ref="Silicon"/>
       <solidref ref="Si_hexagon"/>
     </volume>
   
     <volume name="GlueThick_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Silicon"/>
       <solidref ref="GlueThick_hexagon"/>
     </volume>
 
@@ -547,16 +324,16 @@
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
     <loop for="bilayer" from="1" to="num_bilayers-1" step="1">
       <volume name="strongback_bar_volume[bilayer]">
-        <materialref ref="G4_Al0x2705780" />
+        <materialref ref="Aluminum" />
         <solidref ref="strongback_bar[bilayer]" />
       </volume>
       <volume name="W_front_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_front_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
       <volume name="W_cooling_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_cooling_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
@@ -599,7 +376,7 @@
                           Back Tolerance Gap
     -->
     <volume name="em_calorimeters">
-      <materialref ref="G4_AIR"/>
+      <materialref ref="Air"/>
       <solidref ref="ECal_box"/>
 
       <!--

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard5_assembly.gdml
@@ -275,7 +275,7 @@
 
   <structure>
     <volume name="nohole_motherboard5_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard5_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard6_assembly.gdml
@@ -361,7 +361,7 @@
 
   <structure>
     <volume name="nohole_motherboard6_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard6_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_support_box.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_support_box.gdml
@@ -1480,7 +1480,7 @@
 
   <structure>
     <volume name="support_box">
-      <materialref ref="G4_Al0x2705780"/>
+      <materialref ref="Aluminum"/>
       <solidref ref="support_box-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/hcal.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/hcal.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
@@ -44,119 +45,9 @@
                   ecal_side_dy/2.0-hcal_scintWidth/2.0"/>
   </define>
     
-  <materials>
-    <isotope N="16" Z="8" name="O16">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O17">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O18">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O">
-      <fraction n="0.99757" ref="O16"/>
-      <fraction n="0.00038" ref="O17"/>
-      <fraction n="0.00205" ref="O18"/>
-    </element>
-    <isotope N="12" Z="6" name="C12">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C13">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C">
-      <fraction n="0.9893" ref="C12"/>
-      <fraction n="0.0107" ref="C13"/>
-    </element>
-    <isotope N="1" Z="1" name="H1">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H2">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H">
-      <fraction n="0.999885" ref="H1"/>
-      <fraction n="0.000115" ref="H2"/>
-    </element>
-    <material name="G4_C" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="2"/>
-      <fraction n="1" ref="C"/>
-    </material>
-    <isotope N="14" Z="7" name="N14">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N15">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N">
-      <fraction n="0.99632" ref="N14"/>
-      <fraction n="0.00368" ref="N15"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar36">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar38">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar40">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar">
-      <fraction n="0.003365" ref="Ar36"/>
-      <fraction n="0.000632" ref="Ar38"/>
-      <fraction n="0.996003" ref="Ar40"/>
-    </element>
-    <material name="G4_AIR" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C"/>
-      <fraction n="0.755267755267755" ref="N"/>
-      <fraction n="0.231781231781232" ref="O"/>
-      <fraction n="0.0128270128270128" ref="Ar"/>
-    </material>
-    <isotope N="55" Z="25" name="Mn55">
-      <atom unit="g/mole" value="54.938"/>
-    </isotope>
-    <element name="Mn">
-      <fraction n="1" ref="Mn55"/>
-    </element>
-    <isotope N="54" Z="26" name="Fe54">
-      <atom unit="g/mole" value="53.9396"/>
-    </isotope>
-    <isotope N="56" Z="26" name="Fe56">
-      <atom unit="g/mole" value="55.9349"/>
-    </isotope>
-    <isotope N="57" Z="26" name="Fe57">
-      <atom unit="g/mole" value="56.9354"/>
-    </isotope>
-    <isotope N="58" Z="26" name="Fe58">
-      <atom unit="g/mole" value="57.9333"/>
-    </isotope>
-    <element name="Fe">
-      <fraction n="0.05845" ref="Fe54"/>
-      <fraction n="0.91754" ref="Fe56"/>
-      <fraction n="0.02119" ref="Fe57"/>
-      <fraction n="0.00282" ref="Fe58"/>
-    </element>
-    <material name="Steel" state="solid">
-       <T unit="K" value="293.15"/>
-       <D unit="g/cm3" value="7.87"/>
-       <fraction n="0.9843" ref="G4_Fe"/>
-       <fraction n="0.014" ref="G4_Mn"/>
-       <fraction n="0.0017" ref="G4_C"/>
-    </material>
-    <material name="Scintillator" state="solid">
-       <T unit="K" value="293.15"/>
-       <!-- <MEE unit="eV" value="64.7494480275643"/> -->
-       <D unit="g/cm3" value="1.032"/>
-       <fraction n="0.91512109"  ref="G4_C"/>
-       <fraction n="0.084878906" ref="G4_H"/>
-    </material>
-  </materials>
+  
+    
+  
 
 
   <solids>
@@ -240,7 +131,7 @@
       
       <!-- - - - - - - - -  FULL HCAL STRUCTURES - - - - - - - -  -->
     <volume name="hadronic_calorimeter">
-      <materialref ref="G4_AIR" />
+      <materialref ref="Air" />
       <solidref ref="hadron_calorimeter_Box" />
       <!-- BACK HCAL  -->
         <!-- Note the step size of 2  -->

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/magnet.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/magnet.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -3455,24 +3456,9 @@
         <rotation name="identity" unit="radian" z="0" x="0" y="0" />
     </define>
 
-    <materials>
-        <element Z="1" formula="H" name="H">
-            <atom type="A" unit="g/mol" value="1.00794"/>
-        </element>
-        <material name="Vacuum" state="gas">
-            <MEE unit="eV" value="19.2"/>
-            <D unit="g/cm3" value="9.99999473841014e-09"/>
-            <fraction n="1" ref="H"/>
-        </material>
-        <material name="Fe" Z="26.0">
-            <D value="7.874" />
-            <atom value="55.845" />
-        </material>
-        <material name="Cu" Z="29.0">
-            <D value="8.96" />
-            <atom value="63.546" />
-        </material>
-    </materials>
+    
+      
+    
 
     <solids>
         <box aunit="radian" lunit="mm" name="magnet_box" x="magnet_box_x" y="magnet_box_y" z="magnet_box_z" />
@@ -10224,43 +10210,43 @@
     
     <structure>
         <volume name="coil_1_vol" >
-            <materialref ref="Cu" />
+            <materialref ref="Copper" />
             <solidref ref="coil_1" />
         </volume>
         <volume name="coil_2_vol" >
-            <materialref ref="Cu" />
+            <materialref ref="Copper" />
             <solidref ref="coil_2" />
         </volume>
         <volume name="shim_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="shim_right_box" />
         </volume>
         <volume name="shim_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="shim_left_box" />
         </volume>
         <volume name="corner_iron_block_top_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_left_box" />
         </volume>
         <volume name="corner_iron_block_top_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_right_box" />
         </volume>
         <volume name="corner_iron_block_bot_left" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_left_box" />
         </volume>
         <volume name="corner_iron_block_bot_right" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_right_box" />
         </volume>
         <volume name="center_iron_block_top" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="center_iron_block_top_box" />
         </volume>
         <volume name="center_iron_block_bot" >
-            <materialref ref="Fe" />
+            <materialref ref="Iron" />
             <solidref ref="center_iron_block_bot_box" />
         </volume>
         <volume name="ldmx_magnet" >

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/makeTSassemblyfiles.py
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/makeTSassemblyfiles.py
@@ -1,0 +1,213 @@
+import sys
+import os
+
+abspath = os.path.abspath(__file__)
+dname = os.path.dirname(abspath)
+os.chdir(dname)
+
+'''
+
+Author: CJ Barton / Lund University group
+Added to ldmx-sw Feb 2026
+Github PR 1888
+Github issues 1760 & 1761
+
+Script which automatically generates GDML files for the TS pads and their associated instruments.
+Currently, 'associated instruments' are the SiPMs and the light pipes.
+
+This script exists because of an incompatibility between the ldmx-sw design and Geant4/GDML.
+
+In ldmx-sw, although the geometries are identical for the TS pads, the 3 TS pads in the baseline
+are considered distinct entities (TSPad1, TSPad2, TSPad3). These entities have their own
+hit collections, processors etc. and are hard-coded with distinct names in sensitive_detectors.py.
+The geometry implementation is done in 3 loops across 2 files (trig_scint.gdml for TSPad1/2
+and target.gdml for TSPad3). This means that any time a change needs to be made to the dimensions
+or components of the TSPads, it must be changed 3 times.
+
+Originally, this was envisioned as solvable by the <assembly> object in GDML. However, assemblies
+are intended to only define physical volume configurations, and don't account for things like
+material etc. naturally. In addition, they aren't intended to have their own envelopes. For these
+reasons, a 'module' approach is taken instead, much like in detector.gdml. There's no problem with
+having nested modules, so long as the nested module is contained entirely within the parent.
+
+This script is a compromise, to collect all of the parameters relevant to the TSPads in
+one location while maintaining the distinct definitions for the logical volumes in each pad.
+Three submodules will be generated, which are then imported into their respective modules.
+
+It should be noted that this script is only concerned with differentiating TSPads+instruments.
+External factors, like where to place them in the world or the definitions of the materials,
+should still be defined elsewhere, for example in the constants.gdml or materials.gdml files.
+'''
+
+#Material variable names (material definitions should be found in materials.gdml)
+scintillator_mat ="Polyvinyltoluene"
+lightpipe_mat    ="AcrylicPMMA" 
+sipm_mat         ="Silicon"
+
+#To streamline TargetDarkBremFilter.cxx, TSPad3 and its components are considered part of
+#the 'target' G4Region, whereas TSPad1/2 are in the 'trig_scint' region.
+region_name = ["trig_scint","trig_scint","target"]
+
+for i in range(3):
+
+    #Variables that must change between iterations
+    filename = f"tspad{i+1}_assembly.gdml"
+    scintillator_lvname=f"trigger_pad{i+1}_bar_volume"
+    lightpipe_lvname=f"tspad{i+1}_lightpipe_volume"
+    sipm_lvname=f"tspad{i+1}_sipm_volume"
+
+    with open(filename,"w") as f:
+        f.write(f'''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE gdml [
+<!ENTITY constants SYSTEM "constants.gdml">
+]>
+
+
+<!--
+The trigger scintillator pads comprise of, at this time (Oct 2025):
+2X24 PVT scintillator bars
+2X24 PMMA light pipes
+2X24 SiPM arrays (1 SiPM per bar)
+
+For now all vertical surfaces are flush with no space left in between
+Horizontal surfaces have gaps (the spaces between the bars)
+
+Todo: add the plastic casing, add the metal feet which attach the bars
+to the housing, and maybe see if the visattributes can be reworked
+-->
+
+
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+
+  
+  <define>
+    &constants;    
+    <variable name="x" value="1"/>
+  </define>
+
+  
+  <solids>
+    <!--The envelope encompassing the assembly-->
+    <box lunit="mm" name="one_pad_box{i+1}" x="tspad{i+1}_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <!--The scintillator bar dimensions (same for each pad)-->
+    <box lunit="mm" name="trigger_bar_box{i+1}" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+        <!--The light pipe dimensions (different for each TSPad)-->
+    <box lunit="mm" name="trigger_light_pipe_box{i+1}" x="trigger_light_pipe{i+1}_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <!--SiPM dimensions-->    
+    <box lunit="mm" name="trigger_sipm_box{i+1}" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+  </solids>
+
+  
+  <structure>
+
+    <!--TS pad is made of polyvinyl toluene-->
+    <volume name="{scintillator_lvname}">
+      <materialref ref="{scintillator_mat}"/>
+      <solidref ref="trigger_bar_box{i+1}"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--TS light guides are made of acrylic PMMA-->
+    <volume name="{lightpipe_lvname}">
+      <materialref ref="{lightpipe_mat}"/>
+      <solidref ref="trigger_light_pipe_box{i+1}"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--I'll let you guess what the SiPMs are made of :^)
+	The model is the Hamamatsu S13360-2050VE-->
+    <volume name="{sipm_lvname}">
+      <materialref ref="{sipm_mat}"/>
+      <solidref ref="trigger_sipm_box{i+1}"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+    
+    <volume name="tspad{i+1}_volume">
+      <materialref ref="Vacuum"/>
+      <solidref ref="one_pad_box{i+1}" />
+
+      <loop for="x" from="1" to="number_of_bars" step="1">
+
+        <!--
+        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
+        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
+        along the +x edge of the TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this one is the most legible.
+        -->
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="{sipm_lvname}" />
+          <position name="trigger_sipm_layer1_pos" unit="mm" 
+          	    x="(tspad{i+1}_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="{sipm_lvname}" />
+          <position name="trigger_sipm_layer2_pos" unit="mm" 
+          	    x="(tspad{i+1}_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="{lightpipe_lvname}" />
+          <position name="trigger_pad_pipe_layer1_pos" unit="mm" 
+          	    x="(tspad{i+1}_envelope_x-trigger_light_pipe{i+1}_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="{lightpipe_lvname}" />
+          <position name="trigger_pad_pipe_layer2_pos" unit="mm" 
+          	    x="(tspad{i+1}_envelope_x-trigger_light_pipe{i+1}_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+          <volumeref ref="{scintillator_lvname}" />
+          <position name="trigger_pad_bar_layer1_pos" unit="mm"
+		    x="(tspad{i+1}_envelope_x-trigger_bar_dx-2*trigger_light_pipe{i+1}_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x - 1">
+          <volumeref ref="{scintillator_lvname}" />
+          <position name="trigger_pad_bar_layer2_pos" unit="mm"
+		    x="(tspad{i+1}_envelope_x-trigger_bar_dx-2*trigger_light_pipe{i+1}_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+      </loop>
+
+      <auxiliary auxtype="Region" auxvalue="{region_name[i]}" />
+      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+
+    </volume>
+  </structure> 
+
+  
+  <setup name="Default" version="1.0">
+    <world ref="tspad{i+1}_volume"/>
+  </setup>
+
+</gdml>
+''')
+

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/materials.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/materials.gdml
@@ -1,6 +1,36 @@
+<!--
+This file is organized in the following way:
+
+Element definitions
+Pure (one element) material definitions
+Composite material definitions
+
+We don't currently have any enriched elements in LDMX, but
+if we did, I would add those between the element definitions
+and the pure material definitions. And don't worry about the
+isotopic composition of the natural elements - GDML is at
+least smart enough to assign those abundances automatically
+
+Both the elements and the pure materials are organized by
+Z number in ascending order. Also, not all elements have
+corresponding pure materials defined (but most do). If you
+add more, please try to keep the ordering correct!
+
+Lastly, the naming conventions are as follows:
+Element definitions should use the element's abbreviation
+as seen on the periodic table. Pure elemental materials
+should have the formal name listed on the periodic table
+(I guess we'll use the US standard named like 'aluminum'
+instead of 'aluminium' because Geant4 is US-based and
+uses those standards). Composite materials can have
+whatever name you want, but I would recommend using
+names that are coloquially understandable, like how we
+use "glue" instead of listing the chemical formula.
+
+-->
 
 <element Z="1" formula="H" name="H">
-  <atom type="A" unit="g/mol" value="1.00794"/>
+  <atom type="A" unit="g/mol" value="1.00782"/>
 </element>
 <element Z="6" formula="C" name="C">
   <atom type="A" unit="g/mol" value="12.0107"/>
@@ -11,14 +41,108 @@
 <element Z="8" formula="O" name="O">
   <atom type="A" unit="g/mol" value="15.9994"/>
 </element>
+<element Z="11" formula="Na" name="Na">
+  <atom type="A" unit="g/mol" value="22.9898"/>
+</element>
+<element Z="13" formula="Al" name="Al">
+  <atom type="A" unit="g/mol" value="26.982"/>
+</element>
+<element Z="14" formula="Si" name="Si">
+  <atom type="A" unit="g/mol" value="28.0854"/>
+</element>
 <element Z="18" formula="Ar" name="Ar">
   <atom type="A" unit="g/mol" value="39.9477"/>
 </element>
+<element Z="20" formula="Ca" name="Ca">
+  <atom type="A" unit="g/mol" value="40.08"/>
+</element>
+<element Z="25" formula="Mn" name="Mn">
+  <atom type="A" unit="g/mol" value="54.938"/>
+</element>
+<element Z="26" formula="Fe" name="Fe">
+  <atom type="A" unit="g/mol" value="55.845"/>
+</element>
+<element Z="29" formula="Cu" name="Cu">
+  <atom type="A" unit="g/mol" value="63.546"/>
+</element>           
+<element Z="39" formula="Y" name="Y">
+  <atom type="A" unit="g/mol" value="88.906"/>
+</element>
+<element Z="71" formula="Lu" name="Lu">
+  <atom type="A" unit="g/mol" value="174.967"/>
+</element>           
 <element Z="74" formula="W" name="W">
   <atom type="A" unit="g/mol" value="183.842"/>
-</element> 
+</element>           
+
+<material name="Hydrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="13.6"/>
+  <D unit="g/cm3" value="0.0000899"/>
+  <fraction n="1" ref="H"/>
+</material>
+<material name="Carbon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="81"/>
+  <D unit="g/cm3" value="1.99999894768203"/>
+  <fraction n="1" ref="C"/>
+</material>
+<material name="Nitrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="82.0"/>
+  <D unit="g/cm3" value="0.00125"/>
+  <fraction n="1" ref="N"/>
+</material>
+<material name="Oxygen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="95.0"/>
+  <D unit="g/cm3" value="0.001429"/>
+  <fraction n="1" ref="O"/>
+</material>
+<material name="Aluminum" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="166"/>
+  <D unit="g/cm3" value="2.699"/>
+  <fraction n="1" ref="Al"/>
+</material>
+<material name="Silicon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="173"/>
+  <D unit="g/cm3" value="2.32999877404956"/>
+  <fraction n="1" ref="Si"/>
+</material>
+<material name="Argon" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="188"/>
+  <D unit="g/cm3" value="0.00178"/>
+  <fraction n="1" ref="Ar"/>
+</material>
+<material name="Iron" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="286.0"/>
+  <D unit="g/cm3" value="7.874"/>
+  <fraction n="1" ref="Fe"/>
+</material>
+<material name="Copper" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="322"/>
+  <D unit="g/cm3" value="8.96"/>
+  <fraction n="1" ref="Cu"/>
+</material>
+<material name="Tungsten" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="727.0"/>
+  <D unit="g/cm3" value="19.25"/>
+  <fraction n="1" ref="W"/>
+</material>
 
 
+<material name="Vacuum" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="19.2"/>
+  <D unit="g/cm3" value="9.99999473841014e-09"/>
+  <fraction n="1" ref="H"/>
+</material>
 <material name="Air" state="gas">
   <MEE unit="eV" value="85.643664635028"/>
   <D unit="g/cm3" value="0.00119999936860922"/>
@@ -26,21 +150,102 @@
   <fraction n="0.234" ref="O"/>
   <fraction n="0.012" ref="Ar"/>
 </material>
-<material name="Carbon" state="solid">
+<material name="FR4" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="201.221278976803"/>
+  <D unit="g/cm3" value="5.68"/>
+  <fraction n="0.5"                ref="Cu"/>
+  <fraction n="0.22990022990023"   ref="O"/>
+  <fraction n="0.0482205482205482" ref="Na"/>
+  <fraction n="0.168276668276668"  ref="Si"/>
+  <fraction n="0.0536025536025536" ref="Ca"/>
+</material>
+<material name="Glue" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="73.3297495741215"/>
+  <D unit="g/cm3" value="0.845"/>
+  <fraction n="0.84491305" ref="C"/>
+  <fraction n="0.042542086" ref="H"/>
+  <fraction n="0.11254487" ref="O"/>
+</material>
+<!-- 
+     carbon+epoxy composite material for cooling plane 
+     
+     - taking the Epoxy mixture from the PDG values for
+     Epotek-301
+     https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
+     - the MEE value is pretty much made up at this point,
+     assuming it is the same as pure carbon which seems
+     to be an ok assumption since a majority of the epoxy
+     is carbon as well
+     - the epoxy to C-fiber ratio is 0.955 _by weight_
+     
+     Fractions calculated by doing
+     C = 1+PDGFrac / 1.955
+     H = PDGFrac / 1.955
+     O = PDGFrac / 1.955
+     N = PDGFrac / 1.955
+     where PDGFrac is that material's mass fraction in the PDG
+     material linked above which we convert to molar fraction
+     by converting each fraction to moles individually and then
+     dividing by the sum.
+-->
+<material name="CarbonEpoxyComposite" state="solid">
+  <T unit="K" value="293.15"/>
   <MEE unit="eV" value="81"/>
-  <D unit="g/cm3" value="1.99999894768203"/>
-  <fraction n="1" ref="C"/>
+  <D unit="g/cm3" value="1.439"/>
+  <fraction n="0.624883102" ref="C"/>
+  <fraction n="0.308001109" ref="H"/>
+  <fraction n="0.064281977" ref="O"/>
+  <fraction n="0.002833811" ref="Air"/>
 </material>
-<element Z="14" formula="Si" name="Si">
-  <atom type="A" unit="g/mol" value="28.0854"/>
-</element>
-<material name="Silicon" state="solid">
-  <MEE unit="eV" value="173"/>
-  <D unit="g/cm3" value="2.32999877404956"/>
-  <fraction n="1" ref="Si"/>
+<material name="Steel" state="solid">
+  <T unit="K" value="293.15"/>
+  <D unit="g/cm3" value="7.87"/>
+  <fraction n="0.9843" ref="Fe"/>
+  <fraction n="0.014" ref="Mn"/>
+  <fraction n="0.0017" ref="C"/>
 </material>
-<material name="Vacuum" state="gas">
-  <MEE unit="eV" value="19.2"/>
-  <D unit="g/cm3" value="9.99999473841014e-09"/>
-  <fraction n="1" ref="H"/>
+<material name="Scintillator" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="64.7494480275643"/>
+  <D unit="g/cm3" value="1.032"/>
+  <fraction n="0.91512109"  ref="C"/>
+  <fraction n="0.084878906" ref="H"/>
 </material>
+<material name="Polyvinyltoluene">
+  <D type="density" value="1.023" unit="g/cm3"/>
+  <!--Vinyltoluene chemical formula is C9H10-->
+  <composite n="9" ref="C"/>
+  <composite n="10" ref="H"/>
+</material>
+<material name="AcrylicPMMA" state="solid">
+  <MEE unit="eV" value="74.0"/>
+  <D unit="g/cm3" value="1.19"/>
+  <fraction n="0.534" ref="H"/>
+  <fraction n="0.333" ref="C"/>	
+  <fraction n="0.133" ref="O"/>
+</material>
+    <!-- LYSO target -->
+    <!--
+      Molar mass calculations:
+    - Lu: 1.86 × 174.967 = 325.44 g/mol
+    - Y: 0.2 × 88.906 = 17.78 g/mol
+    - Si: 1 × 28.085 = 28.09 g/mol
+    - O: 5 × 15.999 = 80.00 g/mol
+    - Total molar mass: 325.44 + 17.78 + 28.09 + 80.00 = 451.31 g/mol
+
+    Mass fraction calculations:
+    - Lu fraction: 325.44 / 451.31 = 0.7211
+    - Y fraction: 17.78 / 451.31 = 0.0394
+    - Si fraction: 28.09 / 451.31 = 0.0623
+    - O fraction: 80.00 / 451.31 = 0.1772
+    -->
+<material formula="Lu1.86Y0.2SiO5" name="LYSO" >
+  <D value="7.1" unit="g/cm3" />
+  <fraction n="0.7211" ref="Lu" />
+  <fraction n="0.0394" ref="Y"  />
+  <fraction n="0.0623" ref="Si" />
+  <fraction n="0.1772" ref="O"  />
+</material>
+

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/recoil.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/recoil.gdml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
+
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
       xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
@@ -65,9 +65,9 @@
                                                       stereo_angle
                                                      -stereo_angle" />
   </define>
-  <materials> 
-    &materials;
-  </materials>
+   
+    
+  
   <solids>
     <box lunit="mm" name="recoil_l14_active_sensor_box" 
          x="si_large_active_sensor_dx" y="si_large_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/scoring_planes.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/scoring_planes.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
     xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
@@ -152,12 +153,9 @@
 
   </define>
 
-  <materials>
-    <material name="Vacuum" Z="1" state="gas">
-      <D unit="g/cm3" value="1e-12"/>
-      <atom unit="g/mole" value="1" />
-    </material> 
-  </materials>
+  
+    
+  
 
   <solids>
     <box name="world_box" x="world_dim" y="world_dim" z="world_dim"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tagger.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tagger.gdml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
+
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -46,9 +46,9 @@
   
   
   </define>
-  <materials> 
-    &materials;
-  </materials>
+   
+    
+  
   <solids>
     <box lunit="mm" name="tagger_active_sensor_box" 
        x="si_active_sensor_dx" y="si_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
@@ -26,7 +26,7 @@
     <!-- Trigger Scintillator -->
     <box lunit="mm" name="trigger_bar_box" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" /> 
 
-    <box lunit="mm" name="target_area_box" x="target_area_envelope_x" y="target_area_envelope_y" z="target_area_envelope_z" />
+    <box lunit="mm" name="target_area_box" x="tspad3_envelope_x*2" y="target_area_envelope_y" z="target_area_envelope_z" />
 
 
   </solids>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -30,45 +31,9 @@
 
   </solids>
 
-  <materials>
-
-    <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
-
-    <!-- Scintillator -->
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
+  
     
-    <!-- LYSO target -->
-    <!--
-      Molar mass calculations:
-    - Lu: 1.86 × 174.967 = 325.44 g/mol
-    - Y: 0.2 × 88.906 = 17.78 g/mol
-    - Si: 1 × 28.085 = 28.09 g/mol
-    - O: 5 × 15.999 = 80.00 g/mol
-    - Total molar mass: 325.44 + 17.78 + 28.09 + 80.00 = 451.31 g/mol
-
-    Mass fraction calculations:
-    - Lu fraction: 325.44 / 451.31 = 0.7211
-    - Y fraction: 17.78 / 451.31 = 0.0394
-    - Si fraction: 28.09 / 451.31 = 0.0623
-    - O fraction: 80.00 / 451.31 = 0.1772
-    -->
-    <material formula="Lu1.86Y0.2SiO5" name="LYSO" >
-        <D value="7.1" unit="g/cm3" />
-        <fraction n="0.7211" ref="Lu" />
-        <fraction n="0.0394" ref="Y"  />
-        <fraction n="0.0623" ref="Si" />
-        <fraction n="0.1772" ref="O"  />
-    </material>
-
-  </materials>
+  
 
   <structure>
     <!-- LYSO target -->

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
@@ -89,22 +89,11 @@
       <materialref ref="Vacuum"/>
       <solidref ref="target_area_box" />
 
-      <loop for="x" from="1" to="number_of_bars" step="1">
-        <physvol copynumber="2*x-2">
-          <volumeref ref="trigger_pad3_bar_volume" />
-          <position name="trigger_pad3_bar_layer1_pos" unit="mm" x="0" 
-                y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
-                z="trigger_pad3_z - trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
-          <rotationref ref="identity" />
-        </physvol>
-        <physvol copynumber="2*x - 1">
-          <volumeref ref="trigger_pad3_bar_volume" />
-          <position name="trigger_pad3_bar_layer2_pos" unit="mm" x="0" 
-                y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
-                z="trigger_pad3_z + trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
-          <rotationref ref="identity" />
-        </physvol>
-      </loop>
+            <physvol>
+        <file name="tspad3_assembly.gdml"/>
+        <position name="tspad3_pos" unit="mm" x="(tspad3_envelope_x-trigger_bar_dx)/2" y="0"
+		  z="trigger_pad3_z" />
+      </physvol>
 
       <physvol name="lvTarget_phys" copynumber="3">
         <volumeref ref="lvTarget"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/trig_scint.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/trig_scint.gdml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
+
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -22,22 +23,9 @@
   
   </solids>
 
-  <materials>
-
-      <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
+  
     
-    <!-- Scintillator -->
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
-
-  </materials>
+  
 
   <structure>
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad1_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad1_assembly.gdml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE gdml [
+<!ENTITY constants SYSTEM "constants.gdml">
+]>
+
+
+<!--
+The trigger scintillator pads comprise of, at this time (Oct 2025):
+2X24 PVT scintillator bars
+2X24 PMMA light pipes
+2X24 SiPM arrays (1 SiPM per bar)
+
+For now all vertical surfaces are flush with no space left in between
+Horizontal surfaces have gaps (the spaces between the bars)
+
+Todo: add the plastic casing, add the metal feet which attach the bars
+to the housing, and maybe see if the visattributes can be reworked
+-->
+
+
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+
+  
+  <define>
+    &constants;    
+    <variable name="x" value="1"/>
+  </define>
+
+  
+  <solids>
+    <!--The envelope encompassing the assembly-->
+    <box lunit="mm" name="one_pad_box1" x="tspad1_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <!--The scintillator bar dimensions (same for each pad)-->
+    <box lunit="mm" name="trigger_bar_box1" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+        <!--The light pipe dimensions (different for each TSPad)-->
+    <box lunit="mm" name="trigger_light_pipe_box1" x="trigger_light_pipe1_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <!--SiPM dimensions-->    
+    <box lunit="mm" name="trigger_sipm_box1" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+  </solids>
+
+  
+  <structure>
+
+    <!--TS pad is made of polyvinyl toluene-->
+    <volume name="trigger_pad1_bar_volume">
+      <materialref ref="Polyvinyltoluene"/>
+      <solidref ref="trigger_bar_box1"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--TS light guides are made of acrylic PMMA-->
+    <volume name="tspad1_lightpipe_volume">
+      <materialref ref="AcrylicPMMA"/>
+      <solidref ref="trigger_light_pipe_box1"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--I'll let you guess what the SiPMs are made of :^)
+	The model is the Hamamatsu S13360-2050VE-->
+    <volume name="tspad1_sipm_volume">
+      <materialref ref="Silicon"/>
+      <solidref ref="trigger_sipm_box1"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+    
+    <volume name="tspad1_volume">
+      <materialref ref="Vacuum"/>
+      <solidref ref="one_pad_box1" />
+
+      <loop for="x" from="1" to="number_of_bars" step="1">
+
+        <!--
+        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
+        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
+        along the +x edge of the TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this one is the most legible.
+        -->
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad1_sipm_volume" />
+          <position name="trigger_sipm_layer1_pos" unit="mm" 
+          	    x="(tspad1_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad1_sipm_volume" />
+          <position name="trigger_sipm_layer2_pos" unit="mm" 
+          	    x="(tspad1_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad1_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer1_pos" unit="mm" 
+          	    x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad1_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer2_pos" unit="mm" 
+          	    x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+          <volumeref ref="trigger_pad1_bar_volume" />
+          <position name="trigger_pad_bar_layer1_pos" unit="mm"
+		    x="(tspad1_envelope_x-trigger_bar_dx-2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x - 1">
+          <volumeref ref="trigger_pad1_bar_volume" />
+          <position name="trigger_pad_bar_layer2_pos" unit="mm"
+		    x="(tspad1_envelope_x-trigger_bar_dx-2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+      </loop>
+
+      <auxiliary auxtype="Region" auxvalue="trig_scint" />
+      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+
+    </volume>
+  </structure> 
+
+  
+  <setup name="Default" version="1.0">
+    <world ref="tspad1_volume"/>
+  </setup>
+
+</gdml>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad2_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad2_assembly.gdml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE gdml [
+<!ENTITY constants SYSTEM "constants.gdml">
+]>
+
+
+<!--
+The trigger scintillator pads comprise of, at this time (Oct 2025):
+2X24 PVT scintillator bars
+2X24 PMMA light pipes
+2X24 SiPM arrays (1 SiPM per bar)
+
+For now all vertical surfaces are flush with no space left in between
+Horizontal surfaces have gaps (the spaces between the bars)
+
+Todo: add the plastic casing, add the metal feet which attach the bars
+to the housing, and maybe see if the visattributes can be reworked
+-->
+
+
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+
+  
+  <define>
+    &constants;    
+    <variable name="x" value="1"/>
+  </define>
+
+  
+  <solids>
+    <!--The envelope encompassing the assembly-->
+    <box lunit="mm" name="one_pad_box2" x="tspad2_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <!--The scintillator bar dimensions (same for each pad)-->
+    <box lunit="mm" name="trigger_bar_box2" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+        <!--The light pipe dimensions (different for each TSPad)-->
+    <box lunit="mm" name="trigger_light_pipe_box2" x="trigger_light_pipe2_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <!--SiPM dimensions-->    
+    <box lunit="mm" name="trigger_sipm_box2" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+  </solids>
+
+  
+  <structure>
+
+    <!--TS pad is made of polyvinyl toluene-->
+    <volume name="trigger_pad2_bar_volume">
+      <materialref ref="Polyvinyltoluene"/>
+      <solidref ref="trigger_bar_box2"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--TS light guides are made of acrylic PMMA-->
+    <volume name="tspad2_lightpipe_volume">
+      <materialref ref="AcrylicPMMA"/>
+      <solidref ref="trigger_light_pipe_box2"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--I'll let you guess what the SiPMs are made of :^)
+	The model is the Hamamatsu S13360-2050VE-->
+    <volume name="tspad2_sipm_volume">
+      <materialref ref="Silicon"/>
+      <solidref ref="trigger_sipm_box2"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+    
+    <volume name="tspad2_volume">
+      <materialref ref="Vacuum"/>
+      <solidref ref="one_pad_box2" />
+
+      <loop for="x" from="1" to="number_of_bars" step="1">
+
+        <!--
+        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
+        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
+        along the +x edge of the TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this one is the most legible.
+        -->
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad2_sipm_volume" />
+          <position name="trigger_sipm_layer1_pos" unit="mm" 
+          	    x="(tspad2_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad2_sipm_volume" />
+          <position name="trigger_sipm_layer2_pos" unit="mm" 
+          	    x="(tspad2_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad2_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer1_pos" unit="mm" 
+          	    x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad2_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer2_pos" unit="mm" 
+          	    x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+          <volumeref ref="trigger_pad2_bar_volume" />
+          <position name="trigger_pad_bar_layer1_pos" unit="mm"
+		    x="(tspad2_envelope_x-trigger_bar_dx-2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x - 1">
+          <volumeref ref="trigger_pad2_bar_volume" />
+          <position name="trigger_pad_bar_layer2_pos" unit="mm"
+		    x="(tspad2_envelope_x-trigger_bar_dx-2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+      </loop>
+
+      <auxiliary auxtype="Region" auxvalue="trig_scint" />
+      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+
+    </volume>
+  </structure> 
+
+  
+  <setup name="Default" version="1.0">
+    <world ref="tspad2_volume"/>
+  </setup>
+
+</gdml>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad3_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad3_assembly.gdml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE gdml [
+<!ENTITY constants SYSTEM "constants.gdml">
+]>
+
+
+<!--
+The trigger scintillator pads comprise of, at this time (Oct 2025):
+2X24 PVT scintillator bars
+2X24 PMMA light pipes
+2X24 SiPM arrays (1 SiPM per bar)
+
+For now all vertical surfaces are flush with no space left in between
+Horizontal surfaces have gaps (the spaces between the bars)
+
+Todo: add the plastic casing, add the metal feet which attach the bars
+to the housing, and maybe see if the visattributes can be reworked
+-->
+
+
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+
+  
+  <define>
+    &constants;    
+    <variable name="x" value="1"/>
+  </define>
+
+  
+  <solids>
+    <!--The envelope encompassing the assembly-->
+    <box lunit="mm" name="one_pad_box3" x="tspad3_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <!--The scintillator bar dimensions (same for each pad)-->
+    <box lunit="mm" name="trigger_bar_box3" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+        <!--The light pipe dimensions (different for each TSPad)-->
+    <box lunit="mm" name="trigger_light_pipe_box3" x="trigger_light_pipe3_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <!--SiPM dimensions-->    
+    <box lunit="mm" name="trigger_sipm_box3" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+  </solids>
+
+  
+  <structure>
+
+    <!--TS pad is made of polyvinyl toluene-->
+    <volume name="trigger_pad3_bar_volume">
+      <materialref ref="Polyvinyltoluene"/>
+      <solidref ref="trigger_bar_box3"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--TS light guides are made of acrylic PMMA-->
+    <volume name="tspad3_lightpipe_volume">
+      <materialref ref="AcrylicPMMA"/>
+      <solidref ref="trigger_light_pipe_box3"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+
+    <!--I'll let you guess what the SiPMs are made of :^)
+	The model is the Hamamatsu S13360-2050VE-->
+    <volume name="tspad3_sipm_volume">
+      <materialref ref="Silicon"/>
+      <solidref ref="trigger_sipm_box3"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+    </volume>
+    
+    <volume name="tspad3_volume">
+      <materialref ref="Vacuum"/>
+      <solidref ref="one_pad_box3" />
+
+      <loop for="x" from="1" to="number_of_bars" step="1">
+
+        <!--
+        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
+        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
+        along the +x edge of the TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this one is the most legible.
+        -->
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad3_sipm_volume" />
+          <position name="trigger_sipm_layer1_pos" unit="mm" 
+          	    x="(tspad3_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad3_sipm_volume" />
+          <position name="trigger_sipm_layer2_pos" unit="mm" 
+          	    x="(tspad3_envelope_x-sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+	  <volumeref ref="tspad3_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer1_pos" unit="mm" 
+          	    x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x-1">
+          <volumeref ref="tspad3_lightpipe_volume" />
+          <position name="trigger_pad_pipe_layer2_pos" unit="mm" 
+          	    x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+
+	<physvol copynumber="2*x-2">
+          <volumeref ref="trigger_pad3_bar_volume" />
+          <position name="trigger_pad_bar_layer1_pos" unit="mm"
+		    x="(tspad3_envelope_x-trigger_bar_dx-2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset" 
+                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+        <physvol copynumber="2*x - 1">
+          <volumeref ref="trigger_pad3_bar_volume" />
+          <position name="trigger_pad_bar_layer2_pos" unit="mm"
+		    x="(tspad3_envelope_x-trigger_bar_dx-2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
+                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+          <rotationref ref="identity" />
+        </physvol>
+	
+      </loop>
+
+      <auxiliary auxtype="Region" auxvalue="target" />
+      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
+      <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
+
+    </volume>
+  </structure> 
+
+  
+  <setup name="Default" version="1.0">
+    <world ref="tspad3_volume"/>
+  </setup>
+
+</gdml>


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Resolves #1992 and incorporates changes from #1899 

While porting things from standard v15 to the lyso v15, I also noticed a couple minor issues in standard v15 (constants outside of the `constants.gdml` file and a missing element definition, which was being populated automatically by Geant4), and that's why there are changes in that directory as well.

I also tweaked the envelopes a bit; the TSPad3 envelope from v15 was too tall and the lyso target envelope was too slim, so I made the first shorter and the second thicker. I also had to greatly increase the width of the target envelope to account for the light pipes and SiPMs. These changes didn't affect the positions of the objects inside of the envelopes at all.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Hard to explicitly verify the materials change without doing some analysis, but everything compiles and there are no _new_ warnings when loading the .gdml files.

Running the upcoming `tspads.mac` through `g4-vis` shows that the geometry changes have taken effect:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dd7eed85-93fc-4926-a989-df8227658c42" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e265f997-b262-4f9a-b1a8-d14702acb875" />

(also, note that the TSPad1+2 envelope is still quite large - hence why it doesn't show up in the image along the beam direction)