### PR TITLE
Ignore products, mix improvements in keep-drop rules

### DIFF
--- a/Framework/include/Framework/Event.h
+++ b/Framework/include/Framework/Event.h
@@ -156,6 +156,17 @@ class Event {
   void addDrop(const std::string &exp);
 
   /**
+   * Add an ignore rule to the list of regex expressions to ignore on input.
+   *
+   * If a branch name matches one of the stored regex expressions, it will
+   * not be added to the list of known products when reading the input tree.
+   * This prevents processors from accessing these collections at all.
+   *
+   * @param exp regex to match
+   */
+  void addIgnore(const std::string &exp);
+
+  /**
    * Adds an object to the event bus
    *
    * @throws Exception if there is an underscore in the collection name.
@@ -504,6 +515,17 @@ class Event {
   bool shouldDrop(const std::string &collName) const;
 
   /**
+   * Check if a branch from the input tree should be ignored.
+   *
+   * Ignored branches are not added to the products list and are
+   * therefore inaccessible to processors.
+   *
+   * @param branchName name of branch
+   * @return true if the branch should be ignored (i.e. NOT loaded)
+   */
+  bool shouldIgnore(const std::string &branchName) const;
+
+  /**
    * Make a branch name from a collection and pass name.
    * @param collectionName The collection name.
    * @param passName The pass name.
@@ -569,6 +591,11 @@ class Event {
    * Regex of collection names to *not* store in event.
    */
   std::vector<regex_t> regex_drop_collections_;
+
+  /**
+   * Regex of branch names to not even read from the input tree.
+   */
+  std::vector<regex_t> regex_ignore_collections_;
 
   /**
    * Efficiency cache for empty pass name lookups.

--- a/Framework/include/Framework/EventFile.h
+++ b/Framework/include/Framework/EventFile.h
@@ -9,6 +9,7 @@
 //---< Framework >---//
 #include "Framework/Configure/Parameters.h"
 #include "Framework/Event.h"
+#include "Framework/Logger.h"
 
 //---< ROOT >---//
 #include "TFile.h"
@@ -335,6 +336,8 @@ class EventFile {
    * production
    */
   std::map<int, std::pair<bool, ldmx::RunHeader *>> run_map_;
+
+  enableLogging("EventFile")
 };
 }  // namespace framework
 

--- a/Framework/src/Framework/Event.cxx
+++ b/Framework/src/Framework/Event.cxx
@@ -10,6 +10,9 @@ Event::~Event() {
   for (regex_t& reg : regex_drop_collections_) {
     regfree(&reg);
   }
+  for (regex_t& reg : regex_ignore_collections_) {
+    regfree(&reg);
+  }
 }
 
 void Event::print() const {
@@ -24,6 +27,16 @@ void Event::addDrop(const std::string& exp) {
     regex_drop_collections_.push_back(reg);
   } else {
     EXCEPTION_RAISE("InvalidRegex", "The passed drop rule regex '" + exp +
+                                        "' is not a valid regex.");
+  }
+}
+
+void Event::addIgnore(const std::string& exp) {
+  regex_t reg;
+  if (!regcomp(&reg, exp.c_str(), REG_EXTENDED | REG_ICASE | REG_NOSUB)) {
+    regex_ignore_collections_.push_back(reg);
+  } else {
+    EXCEPTION_RAISE("InvalidRegex", "The passed ignore rule regex '" + exp +
                                         "' is not a valid regex.");
   }
 }
@@ -134,6 +147,7 @@ void Event::setInputTree(TTree* tree) {
       brname = branches->At(i)->GetName();
     }
     if (brname != ldmx::EventHeader::BRANCH) {
+      if (shouldIgnore(brname)) continue;
       size_t j = brname.find("_");
       auto br = dynamic_cast<TBranchElement*>(branches->At(i));
       // can't determine type if branch isn't
@@ -180,6 +194,13 @@ void Event::onEndOfFile() {
 
 bool Event::shouldDrop(const std::string& branch_name) const {
   for (const regex_t& exp : regex_drop_collections_) {
+    if (!regexec(&exp, branch_name.c_str(), 0, 0, 0)) return true;
+  }
+  return false;
+}
+
+bool Event::shouldIgnore(const std::string& branch_name) const {
+  for (const regex_t& exp : regex_ignore_collections_) {
     if (!regexec(&exp, branch_name.c_str(), 0, 0, 0)) return true;
   }
   return false;

--- a/Framework/src/Framework/EventFile.cxx
+++ b/Framework/src/Framework/EventFile.cxx
@@ -12,11 +12,12 @@ namespace framework {
 
 EventFile::EventFile(const framework::config::Parameters &params,
                      const std::string &filename, EventFile *parent,
-                     bool is_output_file, bool isSingleOutput, bool isLoopable)
+                     bool is_output_file, bool is_single_output,
+                     bool is_loopable)
     : file_name_(filename),
       is_output_file_(is_output_file),
-      is_single_output_(isSingleOutput),
-      is_loopable_(isLoopable),
+      is_single_output_(is_single_output),
+      is_loopable_(is_loopable),
       parent_(parent) {
   if (is_output_file_) {
     // we are writting out so open the file and make sure it is writable
@@ -89,8 +90,8 @@ EventFile::EventFile(const framework::config::Parameters &params,
 }
 
 EventFile::EventFile(const framework::config::Parameters &params,
-                     const std::string &filename, bool isLoopable)
-    : EventFile(params, filename, nullptr, false, false, isLoopable) {}
+                     const std::string &filename, bool is_loopable)
+    : EventFile(params, filename, nullptr, false, false, is_loopable) {}
 
 EventFile::EventFile(const framework::config::Parameters &params,
                      const std::string &filename)
@@ -98,8 +99,8 @@ EventFile::EventFile(const framework::config::Parameters &params,
 
 EventFile::EventFile(const framework::config::Parameters &params,
                      const std::string &filename, EventFile *parent,
-                     bool isSingleOutput)
-    : EventFile(params, filename, parent, true, isSingleOutput, false) {}
+                     bool is_single_output)
+    : EventFile(params, filename, parent, true, is_single_output, false) {}
 
 EventFile::~EventFile() {
   // Before an output file, the Event tree needs to be written.
@@ -159,6 +160,8 @@ void EventFile::addDrop(const std::string &rule) {
     // this branch will then be copied over into output tree and be active
   } else if (is_ignore) {
     // don't even read it from the input file
+    // pass regex (with dots) to event bus so setInputTree skips these branches
+    event_->addIgnore(srule);  // requires event_ to be set
     // root needs . removed otherwise it gets cranky
     srule.erase(std::remove(srule.begin(), srule.end(), '.'), srule.end());
     pre_clone_rules_.emplace_back(srule, false);

--- a/Framework/src/Framework/EventFile.cxx
+++ b/Framework/src/Framework/EventFile.cxx
@@ -1,3 +1,5 @@
+#include <regex.h>
+
 #include <ctime>
 
 #include "TTreeReader.h"
@@ -122,26 +124,23 @@ bool EventFile::isCorrupted() const {
 void EventFile::addDrop(const std::string &rule) {
   int offset;
   bool is_keep = false, is_drop = false, is_ignore = false;
-  size_t i = rule.find("keep");
-  if (i != std::string::npos) {
-    offset = i + 4;
+  // keywords must appear at the start of the rule string
+  if (rule.find("keep") == 0) {
+    offset = 4;
     is_keep = true;
-  }
-  i = rule.find("drop");
-  if (i != std::string::npos) {
-    offset = i + 4;
+  } else if (rule.find("drop") == 0) {
+    offset = 4;
     is_drop = true;
-  }
-  i = rule.find("ignore");
-  if (i != std::string::npos) {
-    offset = i + 6;
+  } else if (rule.find("ignore") == 0) {
+    offset = 6;
     is_ignore = true;
   }
 
-  // more than one of (keep,drop,ignore) was provided => not valid rule
+  // none of (keep,drop,ignore) was provided => not valid rule
   if (int(is_keep) + int(is_drop) + int(is_ignore) != 1) return;
 
   std::string srule = rule.substr(offset);
+  size_t i;
   for (i = srule.find_first_of(" \t\n\r"); i != std::string::npos;
        i = srule.find_first_of(" \t\n\r"))
     srule.erase(i, 1);
@@ -151,6 +150,24 @@ void EventFile::addDrop(const std::string &rule) {
 
   // add wild card at end for matching purposes
   if (srule.back() != '*') srule += ".*";  // add wildcard to back
+
+  // Guard: EventHeader must never be dropped or ignored
+  if (is_drop or is_ignore) {
+    regex_t guard_reg;
+    if (regcomp(&guard_reg, srule.c_str(),
+                REG_EXTENDED | REG_ICASE | REG_NOSUB) == 0) {
+      bool matches_event_header =
+          (regexec(&guard_reg, ldmx::EventHeader::BRANCH.c_str(), 0, 0, 0) ==
+           0);
+      regfree(&guard_reg);
+      if (matches_event_header) {
+        EXCEPTION_RAISE("BadRule",
+                        "Drop/ignore rule '" + rule +
+                            "' would affect EventHeader which is required by "
+                            "the framework and cannot be removed.");
+      }
+    }
+  }
 
   if (is_keep) {
     // turn both the input and output tree's on
@@ -164,6 +181,10 @@ void EventFile::addDrop(const std::string &rule) {
     event_->addIgnore(srule);  // requires event_ to be set
     // root needs . removed otherwise it gets cranky
     srule.erase(std::remove(srule.begin(), srule.end(), '.'), srule.end());
+    // warn if this rule drops all collections
+    if (srule == "*")
+      ldmx_log(fatal) << "Ignore rule '" << rule
+                      << "' will hide all input collections from processors.";
     pre_clone_rules_.emplace_back(srule, false);
     // these branches won't be copied over into output tree
   } else if (is_drop) {
@@ -173,6 +194,10 @@ void EventFile::addDrop(const std::string &rule) {
 
     // root needs . removed otherwise it gets cranky
     srule.erase(std::remove(srule.begin(), srule.end(), '.'), srule.end());
+    // warn if this rule drops all collections
+    if (srule == "*")
+      ldmx_log(fatal) << "Drop rule '" << rule
+                      << "' will drop all collections from the output file.";
     pre_clone_rules_.emplace_back(srule, false);
     // these branches won't be copied over into output tree
     // reactivate input branch after clone


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/2003
and
resolves https://github.com/LDMX-Software/ldmx-sw/issues/1297

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

I produced 20 events with the inclusive CI and then run this
```
p = ldmxcfg.Process("test2")
.
.
.
p.histogram_file = "hist2.root"
p.input_files = ["events.root"]
p.output_files = ["events2.root"]
p.keep = [ 'drop .*ScoringPlane.*', 'keep EcalScoring.*']
p.keep.append("ignore test")
```

--> No issues making the DQM plots from the `test2` processes. 
--> EcalScoringPlane is kept and no other ScoringPlane is kept


Docs PR is in https://github.com/LDMX-Software/ldmx-software.github.io/pull/65