### PR TITLE
Updated v15 with LYSO to new visualization standards.

### DIFF
--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/detector.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/detector.gdml
@@ -2,13 +2,15 @@
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
 <!ENTITY materials SYSTEM "materials.gdml">
-
+<!ENTITY visattributes SYSTEM "visattributes.gdml">
 ]>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
+
+  
   <define>
 
-    &constants;  
+    &constants;
 
     <!--
       Position of the tagger and recoil tracker envelopes with respect to
@@ -65,11 +67,12 @@
     <volume name="World">
       <materialref ref="Air"/>
       <solidref ref="world_box"/>
+      
       <physvol copynumber="1">
         <file name="tagger.gdml"/>
         <positionref ref="tagger_pos"/>
         <rotationref ref="identity"/>
-      </physvol> 
+      </physvol>
       <physvol copynumber="2">
         <file name="target.gdml"  />
         <positionref ref="center" />
@@ -79,7 +82,7 @@
         <file name="trig_scint.gdml"/>
         <positionref ref="trig_scint_pos"/>
         <rotationref ref="identity"/>
-      </physvol>
+      </physvol>      
       <physvol copynumber="5">
         <file name="recoil.gdml"/>
         <positionref ref="recoil_pos"/>
@@ -100,6 +103,7 @@
         <positionref ref="magnet_pos"/> 
         <rotationref ref="identity"/> 
       </physvol>
+      
       <auxiliary auxtype="DetElem" auxvalue="Top"/>
     </volume>
   </structure>
@@ -107,12 +111,11 @@
   <userinfo>
     <!-- detector version -->
     <auxiliary auxtype="DetectorVersion" auxvalue="15">
-      <auxiliary auxtype="DetectorName" auxvalue="ldmx-lyso-r4-v15"/>
-      <auxiliary auxtype="Author" auxvalue="Weilong (Sam) Zhou, James Oyang, Tamas Almos Vami"/>
+      <auxiliary auxtype="DetectorName" auxvalue="ldmx-det-v15-8gev"/>
       <auxiliary auxtype="Description" 
-                 auxvalue="Geometry with LYSO target with two bars"/>
+                 auxvalue="The Late 2022 Design Report Geometry with air instead of vacuum."/>
     </auxiliary>
-
+    
     <!-- magnetic field with global field map definition -->     
     <auxiliary auxtype="MagneticField" auxvalue="AnalyzingDipole">
       <auxiliary auxtype="MagneticFieldType" auxvalue="MagneticFieldMap3D"/>
@@ -139,89 +142,11 @@
       <auxiliary auxtype="StoreTrajectories" auxvalue="true"/>
     </auxiliary>
 
-    <!-- define vis attributes -->
-    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="NoDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="TargetVis">
-      <auxiliary auxtype="R" auxvalue="1.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="EcalVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.6"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="HcalVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.3"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="TaggerVis">
-      <auxiliary auxtype="R" auxvalue="0.8"/>
-      <auxiliary auxtype="G" auxvalue="0.8"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="RecoilVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis">
-      <auxiliary auxtype="R" auxvalue="0.9"/>
-      <auxiliary auxtype="G" auxvalue="0.8"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="MagnetVis">
-      <auxiliary auxtype="R" auxvalue="0.75"/>
-      <auxiliary auxtype="G" auxvalue="0.75"/>
-      <auxiliary auxtype="B" auxvalue="0.75"/>
-      <auxiliary auxtype="A" auxvalue="0.8"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>  
+    <!--Set color mode for visualization (optional)-->
+    <auxiliary auxtype="ColorMode" auxvalue="Material"/>
+    
+    &visattributes;
+    
   </userinfo>  
 
   <setup name="Default" version="1.0">

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal.gdml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <!--
     The LDMX ECal Geant4 Simulation Model
@@ -113,10 +112,6 @@
     <!-- flip over y-axis for odd-side of bilayer sandwich -->
     <rotation name="flip" unit="deg" x="0" y="180" z="0"/>
   </define>
-
-  
-    
-  
 
   <solids>
     <!--
@@ -280,6 +275,8 @@
     <volume name="C_volume_CarbonCoolingPlane">
       <materialref ref="CarbonEpoxyComposite"/>
       <solidref ref="CarbonCoolingPlane"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="CarbonMaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
 
     <assembly name="PCB_motherboard_volume">
@@ -298,27 +295,36 @@
     <volume name="PCB_volume">
       <materialref ref="FR4"/>
       <solidref ref="PCB_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
   
     <volume name="Glue_volume">
       <materialref ref="Glue"/>
       <solidref ref="Glue_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
   
     <volume name="Si_volume">
       <materialref ref="Silicon"/>
       <solidref ref="Si_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
   
     <volume name="GlueThick_volume">
-      <materialref ref="Silicon"/>
+      <materialref ref="Glue"/>
       <solidref ref="GlueThick_hexagon"/>
+            <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
 
     <volume name="CarbonBasePlate_volume">
       <materialref ref="CarbonEpoxyComposite"/>
       <solidref ref="CarbonBasePlate_hexagon"/>
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid" />-->
+      <auxiliary auxtype="VisAttributes" auxvalue="CarbonEpoxyCompositeMaterialVis" />
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
 
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
@@ -326,16 +332,20 @@
       <volume name="strongback_bar_volume[bilayer]">
         <materialref ref="Aluminum" />
         <solidref ref="strongback_bar[bilayer]" />
+      <auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis" />
+	<auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
       </volume>
       <volume name="W_front_volume[bilayer]">
         <materialref ref="Tungsten"/>
         <solidref ref="W_front_absorber[bilayer]"/>
-        <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
+      <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis" />
+        <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
       </volume>
       <volume name="W_cooling_volume[bilayer]">
         <materialref ref="Tungsten"/>
         <solidref ref="W_cooling_absorber[bilayer]"/>
-        <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
+      <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis" />
+        <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
       </volume>
     </loop>
 
@@ -939,7 +949,7 @@
       </loop>
 
       <auxiliary auxtype="Region" auxvalue="CalorimeterRegion"/>
-          <!--<auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame"/>-->
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="Ecal"/>
     </volume>
   </structure>
@@ -948,49 +958,5 @@
     <world ref="em_calorimeters"/>
   </setup>
 
-  <userinfo>
-    <!-- define vis attributes
-    -->
-    <auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.6"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="BlueWireFrame">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="BlueSolid">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="0.4"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="Invisible">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="0.4"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary> 
-  </userinfo>  
 
 </gdml>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard5_assembly.gdml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <define>
     <position name="nohole_motherboard5_assembly_v0" unit="mm" x="197.0682" y="8.166" z="380.9181"/>
@@ -277,6 +277,8 @@
     <volume name="nohole_motherboard5_assembly">
       <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard5_assembly-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_motherboard6_assembly.gdml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <define>
     <position name="nohole_motherboard6_assembly_v0" unit="mm" x="106.2316" y="8.166" z="10.69263"/>
@@ -363,6 +363,8 @@
     <volume name="nohole_motherboard6_assembly">
       <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard6_assembly-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis" />
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_support_box.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/ecal_support_box.gdml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <define>
     <position name="support_box_v0" unit="mm" x="4.381496" y="2.070568e-15" z="674.116"/>
@@ -1482,6 +1482,8 @@
     <volume name="support_box">
       <materialref ref="Aluminum"/>
       <solidref ref="support_box-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml.xsd
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="gdml_core.xsd"/>
+  <xs:include schemaLocation="gdml_define.xsd"/>
+  <xs:include schemaLocation="gdml_materials.xsd"/>
+  <xs:include schemaLocation="gdml_solids.xsd"/>
+  <xs:include schemaLocation="gdml_replicas.xsd"/>
+  <xs:include schemaLocation="gdml_parameterised.xsd"/>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType abstract="true" name="IdentifiableVolumeType">
+    <xs:attribute name="name" type="xs:ID" use="required"/>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="SinglePlacementType">
+    <xs:annotation>
+      <xs:documentation>Represents a single unique copy a of an associated logical volume
+        in geometrical hierarchy</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:choice minOccurs="1">
+	<xs:element name="file" type="FileReferenceType"/>
+	<xs:element name="volumeref" type="ReferenceType"/>
+      </xs:choice>      
+      <xs:choice minOccurs="0">
+	<xs:element name="position" type="positionType"/>
+	<xs:element name="positionref" type="ReferenceType"/>
+      </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="rotation" type="rotationType"/>
+	<xs:element name="rotationref" type="ReferenceType"/>
+      </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="scale" type="scaleType"/>
+	<xs:element name="scaleref" type="ReferenceType"/>
+      </xs:choice>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:ID"></xs:attribute>
+    <xs:attribute name="copynumber" type="xs:integer"/>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="DivisionPlacementType">
+    <xs:annotation>
+      <xs:documentation>Represents a division of the associated logical volume
+        in geometrical hierarchy</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="volumeref" type="ReferenceType"/>
+    </xs:sequence>
+    <xs:attribute name="axis" type="xs:string" use="required"></xs:attribute>
+    <xs:attribute name="number" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="width" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="offset" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute default="mm" name="unit" type="xs:string"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="VolumeType">
+    <xs:annotation>
+      <xs:documentation>Represents a top of a geometrical sub-hierarchy not placed in space
+        None of its children can coincide with its boundary defined by an associated solid
+        Two different placements of the same logical volume represent two different geometrical
+        hierarchies in space</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="IdentifiableVolumeType">
+	<xs:sequence>
+	  <xs:element name="materialref" type="ReferenceType"/>
+	  <xs:element name="solidref" type="ReferenceType"/>	  
+	  <xs:choice minOccurs="0">	    
+	    <xs:element maxOccurs="unbounded" name="physvol" type="SinglePlacementType"/>
+	    <xs:element maxOccurs="1" minOccurs="1" name="divisionvol" type="DivisionPlacementType"/>
+	    <xs:element maxOccurs="1" minOccurs="1" ref="replicavol"/>
+	    <xs:element maxOccurs="1" minOccurs="1" name="paramvol" type="ParameterisedPlacementType"/>
+	  </xs:choice>
+	  <xs:element maxOccurs="unbounded" minOccurs="0" ref="loop"/>
+	  <xs:element name="auxiliary" maxOccurs="unbounded" minOccurs="0" type="AuxiliaryType"/>
+	</xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="AssemblyVolumeType">
+    <xs:annotation>
+      <xs:documentation>Allows to create a group of volumes bound together without a boundary
+        All the volumes exits inside the same virtual reference system of the assmebly volume
+        they belong to
+        When assembly volume is placed all its children follow the global transformation applied
+        to their assembly volume
+        After the assembly volume is placed its children exist as standalone placements in space
+        independent of each other</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="IdentifiableVolumeType">
+	<xs:choice>
+	  <xs:element maxOccurs="unbounded" name="physvol" type="SinglePlacementType"/>
+	  <xs:element maxOccurs="1" minOccurs="1" ref="replicavol"/>
+	  <xs:element maxOccurs="1" minOccurs="1" name="paramvol" type="ParameterisedPlacementType"/>
+	</xs:choice>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="LogicalSurfaceType">
+    <xs:annotation>
+      <xs:documentation>Base type for logical surfaces (for the moment only optical)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+    <xs:attribute name="surfaceproperty" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element abstract="true" name="Surface" type="LogicalSurfaceType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for all solids substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="bordersurface" substitutionGroup="Surface">
+    <xs:annotation>
+      <xs:documentation>Surface between two physical volumes</xs:documentation>
+    </xs:annotation>
+      <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="LogicalSurfaceType">
+	 <xs:sequence>
+	  <xs:element name="physvolref" type="ReferenceType"/>
+	  <xs:element name="physvolref" type="ReferenceType"/>
+	 </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+     </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="skinsurface" substitutionGroup="Surface">
+    <xs:annotation>
+      <xs:documentation>Surface between two physical volumes</xs:documentation>
+    </xs:annotation>
+     <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="LogicalSurfaceType">
+	  <xs:sequence>
+             <xs:element name="volumeref" type="ReferenceType"/>
+	  </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+     </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="structure">
+    <xs:annotation>
+      <xs:documentation>Definitions of a geometrical hierarchy of a set of volumes</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+	<xs:choice maxOccurs="unbounded">
+	  <xs:element name="volume" type="VolumeType"/>
+	  <xs:element name="assembly" type="AssemblyVolumeType"/>
+	  <xs:element maxOccurs="unbounded" minOccurs="0" ref="loop"/>
+	  <xs:element ref="ParameterisationAlgorithm"/>
+	</xs:choice>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="Surface"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="gdml">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="define"/>
+	<xs:element ref="materials"/>
+	<xs:element ref="solids"/>
+	<xs:element ref="structure"/>
+	<xs:element minOccurs="0" maxOccurs="1" name="userinfo">
+	  <xs:complexType>
+	    <xs:sequence>
+	      <xs:element maxOccurs="unbounded" minOccurs="0" name="auxiliary" type="AuxiliaryType"/>
+	    </xs:sequence>
+	  </xs:complexType>	  
+	</xs:element>
+	
+	<xs:element maxOccurs="unbounded" name="setup">
+	  <xs:annotation>
+	    <xs:documentation>Geometry setup representing the particular geometry hierarchy by refferring to
+              a given volume which becomes the top level volume</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:sequence>
+	      <xs:element name="world" type="ReferenceType">
+		<xs:annotation>
+		  <xs:documentation>A reference to the previously defined volume
+                    in the structure block chosen by this setup
+                    World volumme can't be an assembly volume</xs:documentation>
+		</xs:annotation>
+	      </xs:element>
+	    </xs:sequence>
+	    <xs:attribute name="name" type="xs:ID" use="required"/>
+	    <xs:attribute name="version" type="xs:string" use="required"/>
+	  </xs:complexType>
+	</xs:element>
+      </xs:sequence>
+      <xs:attribute fixed="3.1.7" name="version" type="xs:string">
+	<xs:annotation>
+	  <xs:documentation>The GDML Schema version consists of 3 digits X.Y.Z
+            where these mean:
+            X - major number, increased when major new
+            features or backward incompatible bug fixes
+            are added and means the GDML Processor is
+            allowed to refuse processing of such a
+            document if this is using the more recent
+            version of the GDML Schema then GDML Processor
+            understands 
+            Y - minor number, increased when incremental and
+            backward compatible changes or improvements
+            are made into the GDML Schema. GDML Processor
+            should be able to process such a document
+            using higher minor version number then that of
+            the GDML Processor
+            Z - bugfix revision number, increased when fully
+            backward compatible changes which resolve a
+            problem in GDML Schema are applied</xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_core.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_core.xsd
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema []>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:simpleType name="InlineExpressionType">
+    <xs:restriction base="xs:string"></xs:restriction>
+  </xs:simpleType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:simpleType name="ExpressionOrIDREFType">
+    <xs:union memberTypes="xs:IDREF InlineExpressionType xs:double "></xs:union>
+  </xs:simpleType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableExpressionType">
+    <xs:simpleContent>
+      <xs:extension base="InlineExpressionType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <!--
+      <xs:complexType name="ExpressionType" mixed="true">
+	<xs:annotation>
+	  <xs:documentation>
+            A base type for expressions
+	  </xs:documentation>
+	</xs:annotation>
+      </xs:complexType>
+      -->
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <!--
+	<xs:complexType name="IdentifiableExpressionType" mixed="true">
+	  <xs:annotation>
+	    <xs:documentation>
+              Named (referenced), global scope,
+              expression (may contain named constants and quantities)
+	    </xs:documentation>
+	  </xs:annotation>
+	  <xs:complexContent>
+	    <xs:extension base="ExpressionType">
+	      <xs:attribute name="name" type="xs:ID" use="required"/>
+	    </xs:extension>
+	  </xs:complexContent>
+	</xs:complexType>
+	-->
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ConstantType">
+    <xs:annotation>
+      <xs:documentation>An anonymous, local scope, value</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="value" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="VariableType">
+    <xs:annotation>
+      <xs:documentation>An anonymous, local scope, value</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="value" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableConstantType">
+    <xs:annotation>
+      <xs:documentation>Named (referenced), global scope, constant value</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ConstantType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableVariableType">
+    <xs:annotation>
+      <xs:documentation>Named (referenced), local scope, variable value</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="VariableType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="QuantityType">
+    <xs:annotation>
+      <xs:documentation>An anonymous quantity, local scope, with a unit,
+        (possibly of a given type) quantity</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ConstantType">
+	<!-- The unit attribute was originally required,
+             but set to optional and is recommended to provide
+             a default value in its derived type
+          -->
+	<xs:attribute name="unit" type="xs:string" use="optional"></xs:attribute>
+	<xs:attribute name="type" type="xs:string" use="optional"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableQuantityType">
+    <xs:annotation>
+      <xs:documentation>Named (referenced), global scope,(possibly of a given type) quantity</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="QuantityType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ThreeVectorType">
+    <xs:annotation>
+      <xs:documentation>An anonymous, 3 dimensional, local scope, vector of doubles</xs:documentation>
+    </xs:annotation>
+    <xs:attribute default="0.0" name="x" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="y" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="z" type="ExpressionOrIDREFType"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="MatrixType">
+    <xs:annotation>
+      <xs:documentation>A bi-dimensional matrix of doubles</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID"></xs:attribute>
+    <xs:attribute name="coldim" type="xs:nonNegativeInteger"></xs:attribute>
+    <xs:attribute name="values" type="xs:string"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableThreeVectorType">
+    <xs:annotation>
+      <xs:documentation>Named (referenced), 3 dimensional, global scope, vector of doubles</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ThreeVectorType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="QuantityVectorType">
+    <xs:annotation>
+      <xs:documentation>An anonymous, 3 dimensional, local scope, with a unit,
+        (possibly of a given type) quantity vector</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ThreeVectorType">
+	<!-- The unit attribute was originally required,
+             but set to optional and is recommended to provide
+             a default value in its derived type
+          -->
+	<xs:attribute name="unit" type="xs:string" use="optional"></xs:attribute>
+	<xs:attribute name="type" type="xs:string" use="optional"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="IdentifiableQuantityVectorType">
+    <xs:annotation>
+      <xs:documentation>Named (referenced), 3 dimensional, global scope, with a unit,
+        (possibly of a given type) quantity vector</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="QuantityVectorType">
+	<xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ReferenceType">
+    <xs:annotation>
+      <xs:documentation>Local reference to an element of a named type</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="ref" type="xs:IDREF" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="FileReferenceType">
+    <xs:annotation>
+      <xs:documentation>Reference to an external file containing sub-volume information</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:anyURI" use="required"></xs:attribute>
+    <xs:attribute name="volname" type="xs:string" use="optional"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ReferenceListType">
+    <xs:annotation>
+      <xs:documentation>List of local references to a set of element of a named type</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="refs" type="xs:IDREFS" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="AuxiliaryType">
+    <xs:annotation>
+      <xs:documentation>Auxiliary information like sensitive detector declaration, etc.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="auxiliary" maxOccurs="unbounded" minOccurs="0" type="AuxiliaryType"/>
+    </xs:sequence>
+    <xs:attribute name="auxtype" type="xs:string" use="required"></xs:attribute>
+    <xs:attribute name="auxvalue" type="xs:string" use="required"></xs:attribute>
+    <xs:attribute name="auxunit" type="xs:string" use="optional"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_define.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_define.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema []>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="gdml_core.xsd"/>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="define" type="defineType">
+    <xs:annotation>
+      <xs:documentation>Definition block of global named constants, quantitties, expressions,
+        positions and rotations which may be used by name or
+        by a reference in scope of the current document</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:complexType name="defineType">
+    <xs:annotation>
+      <xs:documentation>The global complex type is defined in order to reuse this defintion
+        in derived schemas</xs:documentation>
+    </xs:annotation>
+    <!-- |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+    
+    <xs:choice maxOccurs="unbounded">
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" ref="loop"/>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="constant" type="IdentifiableConstantType">
+	<xs:annotation>
+	  <xs:documentation>Named constant</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="variable" type="IdentifiableVariableType">
+	<xs:annotation>
+	  <xs:documentation>Named variable</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="matrix" type="MatrixType">
+	<xs:annotation>
+	  <xs:documentation>Named matrix</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="quantity" type="IdentifiableQuantityType">
+	<xs:annotation>
+	  <xs:documentation>Named quantity</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="expression" type="IdentifiableExpressionType">
+	<xs:annotation>
+	  <xs:documentation>Named expression, may contain other named constants,
+            quantities and expressions</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+      
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="position" type="positionType">
+	<xs:annotation>
+	  <xs:documentation>Named cartesian position, default unit mm</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+          
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="rotation" type="rotationType">
+	<xs:annotation>
+	  <xs:documentation>Named cartesian rotation, default unit radian</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+      <xs:element maxOccurs="unbounded" minOccurs="0" name="scale" type="scaleType">
+	<xs:annotation>
+	  <xs:documentation>Named cartesian rotation, default unit radian</xs:documentation>
+	</xs:annotation>
+      </xs:element>
+      <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+    </xs:choice>
+    <!-- |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| -->
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:complexType name="positionType">
+    <xs:complexContent>
+      <xs:restriction base="IdentifiableQuantityVectorType">
+	<xs:attribute default="mm" type="xs:string" name="unit"/>
+	<xs:attribute default="cartesian" type="xs:string" name="type"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:complexType name="rotationType">
+    <xs:complexContent>
+      <xs:restriction base="IdentifiableQuantityVectorType">
+	<xs:attribute default="radian" type="xs:string" name="unit"/>
+	<xs:attribute default="cartesian" type="xs:string" name="type"/>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:complexType name="scaleType">
+    <xs:complexContent>
+      <xs:restriction base="IdentifiableQuantityVectorType">
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_extensions.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_extensions.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="loop">
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element maxOccurs="unbounded" ref="Solid"/>
+	<xs:element name="volume" type="VolumeType"/>
+	<xs:element name="physvol" type="SinglePlacementType"/>
+	<xs:element name="loop" maxOccurs="unbounded"/>
+      </xs:choice>
+      <xs:attribute name="for" type="xs:string">
+	<xs:annotation>
+	  <xs:documentation>
+	  </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="from" type="xs:nonNegativeInteger">
+	<xs:annotation>
+	  <xs:documentation>
+	  </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="to" type="ExpressionOrIDREFType">
+	<xs:annotation>
+	  <xs:documentation>
+	  </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="step" type="xs:positiveInteger">
+	<xs:annotation>
+	  <xs:documentation>
+	  </xs:documentation>
+	</xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_materials.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_materials.xsd
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema []>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="0.1" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:include schemaLocation="gdml_core.xsd"></xs:include>
+  <xs:include schemaLocation="gdml_define.xsd"></xs:include>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- Removed abstract="true" in AtomType -->
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="AtomType">
+    <xs:annotation>
+      <xs:documentation>Atomic mass, quantity type A, default unit g/mole</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="QuantityType">
+	<xs:attribute default="g/mole" type="xs:string" name="unit"></xs:attribute>
+	<xs:attribute fixed="A" type="xs:string" name="type"></xs:attribute>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="DensityType">
+    <xs:annotation>
+      <xs:documentation>Density</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:restriction base="QuantityType">
+	<xs:attribute default="g/cm3" type="xs:string" name="unit"></xs:attribute>
+	<xs:attribute fixed="density" type="xs:string" name="type"></xs:attribute>
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:group name="MaterialPropertiesGroup">
+    <xs:annotation>
+      <xs:documentation>General material properties</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+	  <xs:choice minOccurs="0">
+	    <xs:element maxOccurs="unbounded" name="property">
+	      <xs:annotation>
+		<xs:documentation>General material property (const or vector)</xs:documentation>
+	      </xs:annotation>
+	      <xs:complexType>
+		<xs:complexContent>
+		  <xs:extension base="ReferenceType">
+		    <xs:attribute name="name" type="xs:string" use="required"></xs:attribute>
+		  </xs:extension>
+		</xs:complexContent>
+	      </xs:complexType>
+	    </xs:element>
+          </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="RL">
+	  <xs:annotation>
+	    <xs:documentation>Radiation length</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:complexContent>
+	      <xs:restriction base="QuantityType">
+		<xs:attribute default="cm" type="xs:string" name="unit"></xs:attribute>
+		<xs:attribute fixed="X0" type="xs:string" name="type"></xs:attribute>
+	      </xs:restriction>
+	    </xs:complexContent>
+	  </xs:complexType>
+	</xs:element>
+	<xs:element name="RLref" type="ReferenceType">
+	  <xs:annotation>
+	    <xs:documentation>A reference to a previsouly defined named radiation length quantity value</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="AL">
+	  <xs:annotation>
+	    <xs:documentation>Absorption length</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:complexContent>
+	      <xs:restriction base="QuantityType">
+		<xs:attribute default="cm" type="xs:string" name="unit"></xs:attribute>
+		<xs:attribute fixed="lambda" type="xs:string" name="type"></xs:attribute>
+	      </xs:restriction>
+	    </xs:complexContent>
+	  </xs:complexType>
+	</xs:element>
+	<xs:element name="ALref" type="ReferenceType">
+	  <xs:annotation>
+	    <xs:documentation>A reference to a previsouly defined named absorption length quantity value</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="T">
+	  <xs:annotation>
+	    <xs:documentation>Temperature</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:complexContent>
+	      <xs:restriction base="QuantityType">
+		<xs:attribute default="K" type="xs:string" name="unit"></xs:attribute>
+		<xs:attribute fixed="temperature" type="xs:string" name="type"></xs:attribute>
+	      </xs:restriction>
+	    </xs:complexContent>
+	  </xs:complexType>
+	</xs:element>
+	<xs:element name="Tref" type="ReferenceType">
+	  <xs:annotation>
+	    <xs:documentation>A reference to previously defined named temperature quantity value</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+      <xs:choice minOccurs="0">
+	<xs:element name="P">
+	  <xs:annotation>
+	    <xs:documentation>Pressure</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:complexContent>
+	      <xs:restriction base="QuantityType">
+		<xs:attribute default="pascal" type="xs:string" name="unit"></xs:attribute>
+		<xs:attribute fixed="pressure" type="xs:string" name="type"></xs:attribute>
+	      </xs:restriction>
+	    </xs:complexContent>
+	  </xs:complexType>
+	</xs:element>
+	<xs:element name="Pref" type="ReferenceType">
+	  <xs:annotation>
+	    <xs:documentation>A reference to previously defined named pressure quantity value</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+      <!-- new property added >>>>>>>>>>>>>>>>>>>>>> -->
+      <xs:choice minOccurs="0">
+	<xs:element name="MEE">
+	  <xs:annotation>
+	    <xs:documentation>Ionisation potential or Mean Excitation Energy</xs:documentation>
+	  </xs:annotation>
+	  <xs:complexType>
+	    <xs:complexContent>
+	      <xs:restriction base="QuantityType">
+		<xs:attribute default="eV" type="xs:string" name="unit"></xs:attribute>
+		<xs:attribute fixed="excitationE" type="xs:string" name="type"></xs:attribute>
+	      </xs:restriction>
+	    </xs:complexContent>
+	  </xs:complexType>
+	</xs:element>
+	<xs:element name="MEEref" type="ReferenceType">
+	  <xs:annotation>
+	    <xs:documentation>A reference to previously defined named ionisation potential quantity value</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+      <!-- <<<<<<<<<<<<<<<<<<<<<<<<< new property added -->
+    </xs:sequence>
+  </xs:group>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:attributeGroup name="MaterialAttributeGroup">
+    <xs:annotation>
+      <xs:documentation>General material attributes</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:ID" use="required">
+      <xs:annotation>
+	<xs:documentation>Material name</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="formula" type="xs:string" use="optional">
+      <xs:annotation>
+	<xs:documentation>Material chemical formula</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="unknown" name="state">
+      <xs:annotation>
+	<xs:documentation>Material physical state</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+	<xs:restriction base="xs:NMTOKEN">
+	  <xs:enumeration value="gas"></xs:enumeration>
+	  <xs:enumeration value="liquid"></xs:enumeration>
+	  <xs:enumeration value="solid"></xs:enumeration>
+	  <xs:enumeration value="unknown"></xs:enumeration>
+	</xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="MaterialType">
+    <xs:annotation>
+      <xs:documentation>Base type for materials</xs:documentation>
+    </xs:annotation>
+    <xs:group ref="MaterialPropertiesGroup"></xs:group>
+    <xs:attributeGroup ref="MaterialAttributeGroup"></xs:attributeGroup>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <!--
+      <xs:complexType name="ComplexMaterialType">
+	<xs:annotation>
+	  <xs:documentation>
+            Base type for complex materials
+	  </xs:documentation>
+	</xs:annotation>
+	<xs:complexContent>
+	  <xs:extension base="MaterialType">
+	    -->
+  <!-- <xs:group ref="MaterialPropertiesGroup"/> -->
+  <!--
+      Removed from referenced attribute group
+          <xs:attribute name="N" use="prohibited"/>
+          -->
+  <!--        
+	      <xs:attribute name="Z" type="xs:double" use="optional">
+		<xs:annotation>
+		  <xs:documentation>Atomic number</xs:documentation>
+		</xs:annotation>
+      </xs:attribute>
+      </xs:extension>
+      </xs:complexContent>
+      </xs:complexType>
+ -->
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="materials">
+    <xs:annotation>
+      <xs:documentation>Materials description</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element maxOccurs="unbounded" minOccurs="0" ref="loop"/>
+	<xs:element minOccurs="0" name="define" type="defineType">
+	  <xs:annotation>
+	    <xs:documentation>Material related definitons of constants and quantities
+              In this version of schema these become visible in global scope</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+	<xs:element maxOccurs="unbounded" minOccurs="0" name="isotope" type="MaterialIsotopeType">
+	  <xs:annotation>
+	    <xs:documentation>An isotope</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+	<xs:element maxOccurs="unbounded" minOccurs="0" name="element" type="MaterialElementType">
+	  <xs:annotation>
+	    <xs:documentation>A simple element or an element composed of isotopes</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+	<xs:element maxOccurs="unbounded" minOccurs="0" name="material" type="MaterialMixtureType">
+	  <xs:annotation>
+	    <xs:documentation>A composite or a mixture complex material</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="MaterialIsotopeType">
+    <xs:annotation>
+      <xs:documentation>Exported isotope type</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="MaterialType">
+	<xs:sequence>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="D" type="DensityType">
+	      <xs:annotation>
+		<xs:documentation>Density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	    <xs:element name="Dref" type="ReferenceType">
+	      <xs:annotation>
+		<xs:documentation>A reference to a previsouly defined named density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	  </xs:choice>
+	  <xs:element name="atom" type="AtomType"></xs:element>
+	</xs:sequence>
+	<xs:attribute name="N" type="xs:positiveInteger" use="required">
+	  <xs:annotation>
+	    <xs:documentation>Number of nucleons</xs:documentation>
+	  </xs:annotation>
+	</xs:attribute>
+	<xs:attribute name="Z" type="xs:double" use="required">
+	  <xs:annotation>
+	    <xs:documentation>Atomic number</xs:documentation>
+	  </xs:annotation>
+	</xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="MaterialElementType">
+    <xs:annotation>
+      <xs:documentation>Exported material element type</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="MaterialType">
+	<xs:sequence>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="D" type="DensityType">
+	      <xs:annotation>
+		<xs:documentation>Density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	    <xs:element name="Dref" type="ReferenceType">
+	      <xs:annotation>
+		<xs:documentation>A reference to a previsouly defined named density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	  </xs:choice>
+	  <xs:choice>
+	    <xs:annotation>
+	      <xs:documentation>An element can be defined either as a simple element or by a set
+                of isotopes fractions</xs:documentation>
+	    </xs:annotation>
+	    <xs:element name="atom" type="AtomType"></xs:element>
+	    <xs:element maxOccurs="unbounded" name="fraction">
+	      <xs:annotation>
+		<xs:documentation>An isotope fraction of an element where n is the actual amount
+		  of the isotope in the element</xs:documentation>
+	      </xs:annotation>
+	      <xs:complexType>
+		<xs:complexContent>
+		  <xs:extension base="ReferenceType">
+		    <xs:attribute name="n" type="xs:double" use="required"></xs:attribute>
+		  </xs:extension>
+		</xs:complexContent>
+	      </xs:complexType>
+	    </xs:element>
+	  </xs:choice>
+	</xs:sequence>
+	<xs:attribute name="N" type="xs:positiveInteger" use="optional">
+	  <xs:annotation>
+	    <xs:documentation>Number of nucleons</xs:documentation>
+	  </xs:annotation>
+	</xs:attribute>
+	<xs:attribute name="Z" type="xs:double" use="optional">
+	  <xs:annotation>
+	    <xs:documentation>Atomic number</xs:documentation>
+	  </xs:annotation>
+	</xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="MaterialMixtureType">
+    <xs:annotation>
+      <xs:documentation>Exported material composite or mixture type</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <!-- <xs:extension base="ComplexMaterialType"> -->
+      <xs:extension base="MaterialType">
+	<xs:sequence>
+	  <xs:choice>
+	    <xs:element name="D" type="DensityType">
+	      <xs:annotation>
+		<xs:documentation>Density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	    <xs:element name="Dref" type="ReferenceType">
+	      <xs:annotation>
+		<xs:documentation>A reference to a previsouly defined named density quantity value</xs:documentation>
+	      </xs:annotation>
+	    </xs:element>
+	  </xs:choice>
+	  <xs:choice>
+	    <xs:annotation>
+	      <xs:documentation>A complex material can be defined as a simple mixture when
+                its material properties are known or as a composite material
+                or a mixture. A composite material is defined by a set of elements
+                by specifying the number of atoms.
+                The second way is by a set of material fractions where the fractions
+                can be either simple elements or other complex materials.
+                The restriction is that one can't mix composition by atoms and fractions
+                at the same time.</xs:documentation>
+						</xs:annotation>
+	    <xs:element name="atom" type="AtomType"></xs:element>
+	    <xs:element maxOccurs="unbounded" name="composite">
+	      <xs:annotation>
+		<xs:documentation>Elements of this composite material specified as a set of local references
+                  to already defined simple elements where value of n in each means the number of atoms</xs:documentation>
+	      </xs:annotation>
+	      <xs:complexType>
+		<xs:complexContent>
+		  <xs:extension base="ReferenceType">
+		    <xs:attribute name="n" type="xs:positiveInteger" use="required"></xs:attribute>
+		  </xs:extension>
+		</xs:complexContent>
+	      </xs:complexType>
+	    </xs:element>
+	    <xs:element maxOccurs="unbounded" name="fraction">
+	      <xs:annotation>
+		<xs:documentation>Fractions of this mixture specified as a set of local references to already defined
+                  elements or other mixtures where value of n in each means the fraction of the whole
+                  material in the range 0.0 &lt; n &lt; 1.0</xs:documentation>
+	      </xs:annotation>
+	      <xs:complexType>
+		<xs:complexContent>
+		  <xs:extension base="ReferenceType">
+		    <xs:attribute name="n" type="xs:double" use="required"></xs:attribute>
+		  </xs:extension>
+		</xs:complexContent>
+	      </xs:complexType>
+	    </xs:element>
+	  </xs:choice>
+	</xs:sequence>
+	<xs:attribute name="Z" type="xs:double" use="optional">
+	  <xs:annotation>
+	    <xs:documentation>Atomic number</xs:documentation>
+	  </xs:annotation>
+	</xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_parameterised.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_parameterised.xsd
@@ -1,0 +1,332 @@
+<?xml version="1.0"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="gdml_define.xsd"/>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType abstract="false" name="DimensionsType">
+    <xs:annotation>
+      <xs:documentation>Abstract base for parametrised dimensions</xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="Dimensions" abstract="true" type="DimensionsType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="BoxDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Boxes. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="x"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="z"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm" name="lunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="box_dimensions" substitutionGroup="Dimensions" type="BoxDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="TrdDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Trd. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="x1"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="x2"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y1"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y2"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="z"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm" name="lunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="trd_dimensions" substitutionGroup="Dimensions" type="TrdDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="TrapDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Trap. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="z"      type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="theta"  type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="phi"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y1"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="x1"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="x2"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="alpha1" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y2"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="x3"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="x4"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="alpha2" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm" name="lunit"   type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="trap_dimensions" substitutionGroup="Dimensions" type="TrapDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="TubeDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Tubes. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="DeltaPhi" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="InR"      type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="OutR"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="StartPhi" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="hz"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"    type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="tube_dimensions" substitutionGroup="Dimensions" type="TubeDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ConeDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Cones. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="rmin1"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmax1"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmin2"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmax2"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="z"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="deltaphi" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"    type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="cone_dimensions" substitutionGroup="Dimensions" type="ConeDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="SphereDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Spheres. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="rmin"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmax"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="starttheta" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="deltatheta" type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="startphi"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="deltaphi"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"      type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit"   type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="sphere_dimensions" substitutionGroup="Dimensions" type="SphereDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="OrbDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Orbs. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="r"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"   type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="orb_dimensions" substitutionGroup="Dimensions" type="OrbDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="TorusDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Torus. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="rmin"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmax"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rtor"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="startphi"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="deltaphi"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"      type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit"   type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="torus_dimensions" substitutionGroup="Dimensions" type="TorusDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="EllipsoidDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Ellipsoid. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="ax"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="by"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="cz"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="-1000000.0" name="zcut1"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1000000.0" name="zcut2"   type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"      type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="ellipsoid_dimensions" substitutionGroup="Dimensions" type="EllipsoidDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ParaDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Paras. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="x"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="y"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="z"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="alpha"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="theta"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="phi"      type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"    type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="para_dimensions" substitutionGroup="Dimensions" type="ParaDimensionsType"/>
+   <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="PolyconeDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Polycone. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+        <xs:sequence>
+	  <xs:element name="zplane" minOccurs="1" maxOccurs="unbounded" type="ZPlaneType"/>	
+        </xs:sequence>
+       	<xs:attribute default="1.0" name="numRZ"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="0.0" name="startPhi"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="openPhi"      type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"        type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit"     type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="polycone_dimensions" substitutionGroup="Dimensions" type="PolyconeDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="PolyhedraDimensionsType">
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Polyhedra. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+        <xs:sequence>
+	  <xs:element name="zplane" minOccurs="1" maxOccurs="unbounded" type="ZPlaneParamType"/>	
+        </xs:sequence>
+       	<xs:attribute default="1.0" name="numRZ"         type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="numSide"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="startPhi"      type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="openPhi"       type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"         type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit"      type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="polyhedra_dimensions" substitutionGroup="Dimensions" type="PolyhedraDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ZPlaneParamType">
+     <xs:attribute default="0.0" name="z"    type="ExpressionOrIDREFType" ></xs:attribute>
+     <xs:attribute default="0.0" name="rmin" type="ExpressionOrIDREFType"></xs:attribute>
+     <xs:attribute default="1.0" name="rmax" type="ExpressionOrIDREFType" ></xs:attribute>
+  </xs:complexType>
+ <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="HypeDimensionsType">
+ <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+    <xs:annotation>
+      <xs:documentation>Dimensions for parametrised Hypes. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="DimensionsType">
+	<xs:attribute default="1.0" name="rmin"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="rmax"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="inst"     type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="outst"    type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="1.0" name="z"        type="ExpressionOrIDREFType"></xs:attribute>
+	<xs:attribute default="mm"  name="lunit"    type="xs:string"></xs:attribute>
+	<xs:attribute default="radian" name="aunit" type="xs:string"></xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="hype_dimensions" substitutionGroup="Dimensions" type="HypeDimensionsType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType abstract="false" name="ParameterisationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Abstract base for parameterised placement strategies</xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="ParameterisationAlgorithm" abstract="true" type="ParameterisationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="PositionSizeParameterisationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Parameterised volumes get created using 
+	the tabularized position and sizes. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ParameterisationAlgorithmType">
+	<xs:sequence>
+	  <xs:element maxOccurs="unbounded" name="parameters" type="ParametersType"/>
+	</xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="parameterised_position_size" substitutionGroup="ParameterisationAlgorithm" type="PositionSizeParameterisationAlgorithmType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ParameterisedPlacementType">
+    <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+    <xs:annotation>
+      <xs:documentation>Base type for parameterised volumes</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="volumeref" type="ReferenceType"></xs:element> 
+      <xs:element ref="ParameterisationAlgorithm"/> 
+    </xs:sequence>
+    <xs:attribute name="ncopies" type="xs:positiveInteger" use="required"/>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="paramvol" type="ParameterisedPlacementType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ParametersType">
+    <xs:annotation>
+      <xs:documentation>
+	Holds parameteres for parameterised volumes.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element type="positionType" name="position"/>
+      <xs:element ref="Dimensions"/>
+    </xs:sequence>
+    <xs:attribute type="xs:positiveInteger" use="required" name="number"/>
+  </xs:complexType>
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_replicas.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_replicas.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="gdml_define.xsd"/>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType abstract="false" name="ReplicationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Abstract base for replication placement strategies</xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="ReplicationAlgorithm" abstract="true" type="ReplicationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="AxisReplicationAlgorithmType">
+    <xs:annotation>
+      <xs:documentation>Replica volumes get created along the specified direction
+	starting with the first replica placed at the given position and rotated
+	according to the given rotation and others placed using	the given distance;
+	If position and/or rotation is omitted the defaults will be applied, e.g.
+	position at the mother volume center and identity rotation;
+	NOTE: THE ROTATION IS APPLIED TO ALL REPLICATED VOLUMES!</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ReplicationAlgorithmType">
+	<xs:sequence>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="position" type="positionType"/>
+	    <xs:element name="positionref" type="ReferenceType"/>
+	  </xs:choice>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="rotation" type="rotationType"/>
+	    <xs:element name="rotationref" type="ReferenceType"/>
+	  </xs:choice>
+	  <xs:choice>
+	    <xs:element ref="direction"/>
+	    <xs:element name="directionref" type="ReferenceType"/>
+	  </xs:choice>
+	  <xs:element ref="width"/>
+	  <xs:element ref="offset"/>
+	</xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="replicate_along_axis" substitutionGroup="ReplicationAlgorithm" type="AxisReplicationAlgorithmType"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="ReplicaPlacementType">
+    <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+    <xs:annotation>
+      <xs:documentation>Base type for replicated volumes</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="volumeref" type="ReferenceType"></xs:element> 
+      <xs:element ref="ReplicationAlgorithm"/>
+    </xs:sequence>
+    <xs:attribute name="number" type="xs:positiveInteger" use="required"/>
+    <xs:attribute name="copy_num_start" type="xs:positiveInteger" use="optional" default="1"/>
+    <xs:attribute name="copy_num_step" type="xs:positiveInteger" use="optional" default="1"/>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:complexType name="directionType">
+    <xs:attribute default="0.0" name="x" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="y" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="z" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="phi" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute default="0.0" name="rho" type="ExpressionOrIDREFType"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:element name="direction" type="directionType"/>
+  <xs:element name="width" type="QuantityType"/>
+  <xs:element name="offset" type="QuantityType"/>
+  <xs:element name="replicavol" type="ReplicaPlacementType"/>
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_solids.xsd
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/gdml_solids.xsd
@@ -1,0 +1,1008 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema []>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified" version="1.0" xmlns:gdml="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:include schemaLocation="gdml_core.xsd"></xs:include>
+  <xs:include schemaLocation="gdml_define.xsd"></xs:include>
+  <xs:include schemaLocation="gdml_extensions.xsd"/>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:complexType name="SolidType">
+    <xs:annotation>
+      <xs:documentation>Base solid type</xs:documentation>
+    </xs:annotation>
+    <xs:attribute default="mm" name="lunit" type="xs:string">
+      <xs:annotation>
+	<xs:documentation>Length unit of all dimensions used for this instance of solid</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="radian" name="aunit" type="xs:string">
+      <xs:annotation>
+	<xs:documentation>Angle unit of angles used in definition of this solid</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:complexType name="BooleanSolidType">
+    <xs:annotation>
+      <xs:documentation>Base type for boolean solids</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="SolidType">
+	<xs:sequence>
+	  <xs:element name="first" type="ReferenceType"></xs:element>
+	  <xs:element name="second" type="ReferenceType"></xs:element>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="position" type="positionType"></xs:element>
+	    <xs:element name="positionref" type="ReferenceType"></xs:element>
+	  </xs:choice>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="rotation" type="rotationType"></xs:element>
+	    <xs:element name="rotationref" type="ReferenceType"></xs:element>
+	  </xs:choice>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="firstposition" type="positionType"></xs:element>
+	    <xs:element name="firstpositionref" type="ReferenceType"></xs:element>
+	  </xs:choice>
+	  <xs:choice minOccurs="0">
+	    <xs:element name="firstrotation" type="rotationType"></xs:element>
+	    <xs:element name="firstrotationref" type="ReferenceType"></xs:element>
+	  </xs:choice>
+	</xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:complexType name="multiUnionNode">
+    <xs:annotation>
+      <xs:documentation>Base node for Multi-Union structure</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="SolidType">
+	<xs:sequence>
+	  <xs:element name="solid" type="ReferenceType"></xs:element>
+          <xs:choice minOccurs="0">
+            <xs:element name="position" type="positionType"></xs:element>
+            <xs:element name="positionref" type="ReferenceType"></xs:element>
+          </xs:choice>
+          <xs:choice minOccurs="0">
+            <xs:element name="rotation" type="rotationType"></xs:element>
+            <xs:element name="rotationref" type="ReferenceType"></xs:element>
+          </xs:choice>
+	</xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="multiUnion" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>MultiUnion is a Solid created by Union of many Solids.
+       This Solid is constructed by multiUnionNodes;
+       each Node is described by solid with its position and rotation.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="multiUnionNode" minOccurs="1" maxOccurs="unbounded" type="multiUnionNode"/>	
+	  </xs:sequence>
+	 </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="reflectedSolid" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Reflected solid: 
+        sx, sy, sz are scale components (containing reflection),
+        rx, ry, rz are rotation angles around given axes and 
+        dx, dy, dz is the translation.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="solid" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="1.0" name="sx" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="1.0" name="sy" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="1.0" name="sz" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="rx" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="ry" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="rz" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="dx" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="dy" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="dz" type="ExpressionOrIDREFType"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="scaledSolid" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Scaled solid: 
+        For the scale component, values must be greater than zero.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="solidref" type="ReferenceType"></xs:element>
+            <xs:choice minOccurs="1">
+              <xs:element name="scale" type="scaleType"></xs:element>
+              <xs:element name="scaleref" type="ReferenceType"></xs:element>
+            </xs:choice>
+	  </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  <xs:group name="OpticalSurfacePropertiesGroup">
+    <xs:annotation>
+      <xs:documentation>General optical surface properties</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+	  <xs:choice minOccurs="0">
+	    <xs:element maxOccurs="unbounded" name="property">
+	      <xs:annotation>
+		<xs:documentation>General optical surface property (const or vector)</xs:documentation>
+	      </xs:annotation>
+	      <xs:complexType>
+		<xs:complexContent>
+		  <xs:extension base="ReferenceType">
+		    <xs:attribute name="name" type="xs:string" use="required"></xs:attribute>
+		  </xs:extension>
+		</xs:complexContent>
+	      </xs:complexType>
+	    </xs:element>
+          </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  
+  <xs:complexType name="SurfacePropertyType">
+    <xs:annotation>
+      <xs:documentation>Base surface type</xs:documentation>
+    </xs:annotation>
+    <xs:group ref="OpticalSurfacePropertiesGroup"></xs:group> 
+    <xs:attribute name="name" type="xs:ID" use="required"></xs:attribute>
+    <xs:attribute name="type" type="xs:string" default="dielectric_dielectric"></xs:attribute>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element abstract="true" name="Solid" type="SolidType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for all solids substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element abstract="true" name="SurfaceProperty" type="SurfacePropertyType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for surfaces substitution</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="solids">
+    <xs:annotation>
+      <xs:documentation>Solids definitions block</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice maxOccurs="unbounded">
+	<xs:element minOccurs="0" name="define" type="defineType">
+	  <xs:annotation>
+	    <xs:documentation>Definitions of constants and expressions to be used for solids'
+              dimensions and transformations
+              In this version these become part of the global scope.</xs:documentation>
+	  </xs:annotation>
+	</xs:element>
+	<xs:element maxOccurs="unbounded" ref="Solid"></xs:element>
+	<xs:element minOccurs="0" maxOccurs="unbounded" ref="SurfaceProperty"></xs:element>
+	<xs:element maxOccurs="unbounded" minOccurs="0" ref="loop"/>	
+      </xs:choice>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="union" substitutionGroup="Solid" type="BooleanSolidType">
+    <xs:annotation>
+      <xs:documentation>Exported boolean union of two solids</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="subtraction" substitutionGroup="Solid" type="BooleanSolidType">
+    <xs:annotation>
+      <xs:documentation>Exported boolean subtraction of two solids</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="intersection" substitutionGroup="Solid" type="BooleanSolidType">
+    <xs:annotation>
+      <xs:documentation>Exported boolean intersectioin of two solids</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="box" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG box solid described by 3 dimensions of x, y, and z</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="twistedbox" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG twisted box solid described by 4 dimensions of 
+	x  length along x axis
+	y  length along y axis
+	z  length along z axis
+	PhiTwist twist angle </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="PhiTwist" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="twistedtrap" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>general twisted trapezoid. faces perpendicular to the z planes are trapezia, and their centres are 
+			not necessarily on a line paralell to the z axis.
+	PhiTwist Twist Angle
+	z     length along the z-axis
+	Theta  Polar angle of the line joining the centres of the faces at -/+z
+	Phi    Azimuthal angle of the line joing the centre of the face at -z to the centre of the face at +z
+	y1    length along y of the face at -z
+    	x1    length along x of the side at y=-y1 of the face at -z
+	x2    length along x of the side at y=+y1 of the face at -z
+	y2    length along y of the face at +z
+	x3    length along x of the side at y=-y2 of the face at +z
+	x4    length along x of the side at y=+y2 of the face at +z
+	Alph   Angle with respect to the y axis from the centre of the side </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+          <xs:attribute name="PhiTwist" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="Theta" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="Phi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x3" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x4" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+          <xs:attribute name="Alph" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="twistedtrd" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>different length axis twistable trapezoid. faces perpendicular to the z planes are trapezia, and their centres are 
+			not necessarily on a line paralell to the z axis.
+	PhiTwist Twist Angle
+	z     length along the z-axis
+	y1    length along y of the face at -z
+    	x1    length along x of the side at y=-y1 of the face at -z
+	x2    length along x of the side at y=+y1 of the face at -z
+	y2    length along y of the face at +z </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+          <xs:attribute name="PhiTwist" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="paraboloid" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG paraboloid defined by
+       rlo         radius at -dz
+       rhi         radius at +dz
+       dz          half z length
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="rlo" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="rhi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="dz" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="sphere" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG sphere or spherical shell segment solid described by
+        rmin        inner radius
+        rmax        outer radius
+        startphi    starting angle of the segment in radians(0 &lt;= phi &lt;= 2*PI)
+        deltaphi    delta angle of the segment in radians
+        starttheta  starting angle of the segment in radians(0 &lt;= theta &lt;= PI)
+        deltatheta  delta angle of the segment in radians
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute default="0.0" name="rmin" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="starttheta" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="deltatheta" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="ellipsoid" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG ellispoid or ellipsoidal shell segment solid described by
+        ax         x semiaxis
+        by         y semiaxis
+	cz	   z semiaxis
+        zcut1      bottom plane cutting ellipsoid
+        zcut2      top plane cutting ellispoid
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="ax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="by" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="cz" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="-1000000.0" name="zcut1" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="1000000.0" name="zcut2" type="ExpressionOrIDREFType"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="tube" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG tube or tube segement solid described by
+	rmin      Inner radius
+        rmax      Outer radius
+        z         length in z
+        startphi  The starting phi angle in radians, adjusted such that
+        (startphi+deltaphi &lt;= 2PI, startphi &gt; -2PI)
+        deltaphi  Delta angle of the segment in radians</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="z" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="rmin" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+ <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="twistedtubs" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG twisted tube segment solid described by
+	twistedangle	twist angle (constructors 1,2,3,4)
+	endinnerrad	inside radius at end of segment (constructors 1,2)
+	endouterrad	outside radius at end of segment (constructors 1,2)
+        midinnerrad     inner radius at z=0 (constructors 3,4)
+        midouterrad     outer radius at z=0 (constructors 3,4)
+        negativeEndz    -ve z endplate (constructors 3,4)
+        positiveEndz    +ve z endplate (constructors 3,4)
+	zlen		z length of segment (constructors 1,2)
+        nseg            number of segments in totalPhi (constructors 2,4)
+        totphi          total angle of all segments (constructors 2,4)
+	phi		phi angle of a segment (constructors 1,3)</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="twistedangle" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="endinnerrad" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="endouterrad" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="midinnerrad" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="midouterrad" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="negativeEndz" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="positiveEndz" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="zlen" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0" name="nseg" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="totphi" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="phi" type="ExpressionOrIDREFType"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="cutTube" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG cut tube or cut tube segment solid described by
+	rmin                    Inner radius
+        rmax                    Outer radius
+        z                       length in z
+        startphi                The starting phi angle in radians, adjusted such that (startphi+deltaphi &lt;= 2PI, startphi &gt; -2PI)
+        deltaphi                Delta angle of the segment in radians
+	lowX, lowY, lowZ        Normal at lower Z plane
+	highX, highY, highZ     Normal at higher Z plane
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="z" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="rmin" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="lowX" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="lowY" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="lowZ" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="highX" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="highY" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="highZ" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="cone" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG cone or cone segment described by
+        rmin1    inside radius at  z/2
+        rmin2    inside radius at  z/2
+        rmax1    outside radius at z/2
+        rmax2    outside radius at z/2
+        z        length in z
+        startphi starting angle of the segment in radians
+        deltaphi delta angle of the segment in radians</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="rmin1" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute default="0.0" name="rmin2" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="rmax1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="rmax2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="elcone" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG  cone with elliptical cross section 
+        dx    semiaxis in X
+        dy    semiaxis in Y
+        zmax  height of elliptical cone
+        zcut  upper cut plane level
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="dx" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="dy" type="ExpressionOrIDREFType"></xs:attribute>
+	  <xs:attribute name="zmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="zcut" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 </xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="polycone" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG polycone or polycone segment described by
+        startphi starting angle of the segment in radians
+        deltaphi delta angle of the segment in radians
+	
+	and a set of z-planes each described by
+        rmin     inside radius at  z/2
+        rmax     outside radius at z/2
+        z        length in z
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="zplane" minOccurs="1" maxOccurs="unbounded" type="ZPlaneType"/>	
+	  </xs:sequence>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- +++++++++++++ -->
+  <xs:complexType name="ZPlaneType">
+    <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute default="0.0" name="rmin" type="ExpressionOrIDREFType"></xs:attribute>
+    <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>
+
+ <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="genericPolycone" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Generic polycone or polycone segment described by
+        startphi starting angle of the segment in radians
+        deltaphi delta angle of the segment in radians
+	and a set of points with (r,z)coordinates
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="rzpoint" minOccurs="3" maxOccurs="unbounded" type="RZPointType"/>	
+	  </xs:sequence>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute default="0.0" name="startphi" type="ExpressionOrIDREFType"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- +++++++++++++ -->
+  <xs:complexType name="RZPointType">
+    <xs:attribute name="r" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>  
+  </xs:complexType>
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="para" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG parallelepiped solid is described by
+        x, y, z  length in x,y,z
+        alpha    Angle formed by the y axis and by the plane joining the centre of the faces
+        G4Parallel to the z-x plane at -y and +y
+        theta    Polar angle of the line joining the centres of the faces at -z and +z in z
+        phi      Azimuthal angle of the line joining the centres of the faces at -z and +z in z</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="alpha" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="theta" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="phi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="trd" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG trapezoid solid with varying x and y dimensions along z axis
+        x1 Length along x at the surface positioned at -z
+        x2 Length along x at the surface positioned at +z
+        y1 Length along y at the surface positioned at -z
+        y2 Length along y at the surface positioned at +z
+        z  Length along z axis</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="x1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="trap" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG general trapezoid solid is described by
+        z      Length along the z-axis
+        theta  Polar angle of the line joining the centres of the faces at -/+z
+        phi    Azimuthal angle of the line joing the centre of the face at -z to the centre of the face at +z
+        y1     Length along y of the face at -z
+        x1     Length along x of the side at y = -y1 of the face at -z
+        x2     Length along x of the side at y = +y1 of the face at -z
+        alp1   Angle with respect to the y axis from the centre of the side at y =- y1 to the centre at y = +y1 of the face at -z
+        y2     Length along y of the face at +z
+        x3     Length along x of the side at y = -y2 of the face at +z
+        x4     Length along x of the side at y = +y2 of the face at +z
+        alp2   Angle with respect to the y axis from the centre of the side at y = -y2 to the centre at y = +y2 of the face at +z</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="theta" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="phi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="alpha1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="y2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x3" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="x4" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="alpha2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="torus" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG torus solid is described by
+	rmin  Inside radius
+	rmax  Outside radius
+	rtor  swept radius of torus
+	startphi  The starting phi angle in radians adjusted such that sphi+dphi lt 2PI, sphi gt -2PI
+	deltaphi  Delta angle of the segment in radians
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="rmin" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="rtor" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="startphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="orb" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>CSG orb solid (simplified sphere with only rmax) is described by
+	r  Outside radius</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="r" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="polyhedra" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Polyhedra is described by
+	startphi     initial phi starting angle
+	totalphi     total phi angle
+	numsides  number sides
+	and a set of zplanes.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="zplane" minOccurs="1" maxOccurs="unbounded" type="ZPlaneType"/>	
+	  </xs:sequence>
+	  
+	  <xs:attribute name="startphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="numsides" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>	
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="genericPolyhedra" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Polyhedra is described by
+	startphi     initial phi starting angle
+	totalphi     total phi angle
+	numsides  number sides
+	and a set of points with (r,z) coordinates.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element name="rzpoint" minOccurs="3" maxOccurs="unbounded" type="RZPointType"/>	
+	  </xs:sequence>
+	  
+	  <xs:attribute name="startphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="deltaphi" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="numsides" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>	
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:complexType name="TwoDimVertexType">
+    <xs:attribute name="x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>
+  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+    
+  <xs:complexType name="SectionType">
+    <xs:attribute name="zOrder" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="zPosition" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="xOffset" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="yOffset" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+    <xs:attribute name="scalingFactor" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+  </xs:complexType>  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="xtru" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Poligonal extrusion is described by
+	an unbounded (min. 3) number of vertices of the blueprint polygon
+	and an unbounded number of Z sections.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:sequence>
+	      <xs:element name="twoDimVertex" minOccurs="3" maxOccurs="unbounded" type="TwoDimVertexType"/>	
+            </xs:sequence>
+	    <xs:sequence>
+	      <xs:element name="section" minOccurs="2" maxOccurs="unbounded" type="SectionType"/>	
+	    </xs:sequence>
+	  </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>	
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="hype" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Tube with hyperbolic profile described by
+	rmin    innerRadius
+	rmax    outerRadius
+	inst    innerStereo
+	outst   outerStereo
+        z       z length
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="rmin" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="rmax" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="inst" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="outst" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="z" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="eltube" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>
+	Volume representing a tube with elliptical
+	cross section.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:attribute name="dx" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="dy" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	  <xs:attribute name="dz" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="tet" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>
+	Volume representing a tetrahedron.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+ 	 <xs:attribute name="vertex1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="vertex2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="vertex3" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="vertex4" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="arb8" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>
+	Volume representing an (almost)arbitrary 8 vertices solid.
+	The solid is defined by two quadrilaterals sitting on parallel planes,
+	the distance between these two planes is dz*2.
+	The base quadrilateral contained within the plane located at -dz is defined by
+	the first 4 vertices (v1,v2,v3,v4 each one with the x and y coordinates).
+	The other parallel quadrilateral contained within the plane at +dz is defined by
+	the other 4 vertices (v5,v6,v7,v8 each one with the x and y coordinates).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+ 	 <xs:attribute name="v1x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v1y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v2x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v2y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v3x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v3y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v4x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v4y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v5x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v5y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v6x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v6y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v7x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v7y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v8x" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="v8y" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	 <xs:attribute name="dz" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>     
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <!-- Tessellated solid elements -->  
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
+
+  <xs:complexType name="FacetType">
+    <xs:annotation>
+      <xs:documentation>Base facet type</xs:documentation>
+    </xs:annotation>
+  </xs:complexType>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element abstract="true" name="Facet" type="FacetType">
+    <xs:annotation>
+      <xs:documentation>Abstract element for all facets substitution group</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="triangular" substitutionGroup="Facet">
+    <xs:annotation>
+      <xs:documentation>
+      Triangular facet.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="FacetType">
+	<xs:attribute name="vertex1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="vertex2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="vertex3" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="type" type="xs:string" default="ABSOLUTE"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="quadrangular" substitutionGroup="Facet">
+    <xs:annotation>
+      <xs:documentation>
+      Quadrangular facet.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="FacetType">
+	<xs:attribute name="vertex1" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="vertex2" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="vertex3" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="vertex4" type="ExpressionOrIDREFType" use="required"></xs:attribute>
+	<xs:attribute name="type" type="xs:string" default="ABSOLUTE"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>  
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+
+  <xs:element name="tessellated" substitutionGroup="Solid">
+    <xs:annotation>
+      <xs:documentation>Tessellated solid	
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SolidType">
+	  <xs:sequence>
+	    <xs:element minOccurs="1" maxOccurs="unbounded" ref="Facet"/>
+	  </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->
+  
+  <xs:element name="opticalsurface" substitutionGroup="SurfaceProperty">
+    <xs:annotation>
+      <xs:documentation>Optical surface used by Geant4 optical processes</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:complexContent>
+	<xs:extension base="SurfacePropertyType">
+	  <xs:attribute name="model" type="xs:string" default="glisur"></xs:attribute>
+	  <xs:attribute name="finish" type="xs:string" default="polished"></xs:attribute>
+	  <xs:attribute name="value" type="xs:string" default="1.0"></xs:attribute>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+  </xs:element>
+  <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
+
+</xs:schema>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/hcal.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/hcal.gdml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <define>
 
@@ -44,12 +43,8 @@
                   -(ecal_side_dy/2.0-hcal_scintWidth/2.0)
                   ecal_side_dy/2.0-hcal_scintWidth/2.0"/>
   </define>
-    
-  
-    
-  
 
-
+  
   <solids>
   
     <!-- - - - - - - - - HCal solids - - - - - - - -  -->
@@ -88,16 +83,22 @@
     <volume name="back_hcal_absoVolume">
       <materialref ref="Steel" />
       <solidref ref="back_hcal_absoBox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="SteelMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
     </volume>
 
     <volume name="back_hcal_scintYVolume">
       <materialref ref="Scintillator" />
       <solidref ref="back_hcal_scintYBox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
     </volume>
 
     <volume name="back_hcal_scintXVolume">
       <materialref ref="Scintillator" />
       <solidref ref="back_hcal_scintXBox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
     </volume>
 
     <!-- - - - - - - - -  SIDE HCAL STRUCTURES - - - - - - - -  -->
@@ -105,28 +106,40 @@
       <volume name="side_hcal_absoX[module]Volume">
         <materialref ref="Steel" />
         <solidref ref="side_hcal_absoX[module]Box" />
+	<auxiliary auxtype="VisAttributes" auxvalue="SteelMaterialVis"/>
+	<auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
       </volume>
       <volume name="side_hcal_absoY[module]Volume">
         <materialref ref="Steel" />
         <solidref ref="side_hcal_absoY[module]Box" />
+	<auxiliary auxtype="VisAttributes" auxvalue="SteelMaterialVis"/>
+	<auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
       </volume>
       <volume name="side_hcal_scintX[module]Volume">
         <materialref ref="Scintillator" />
         <solidref ref="side_hcal_scintX[module]Box" />
+	<auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+	<auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
       </volume>
       <volume name="side_hcal_scintY[module]Volume">
         <materialref ref="Scintillator" />
         <solidref ref="side_hcal_scintY[module]Box" />
+	<auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+	<auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
       </volume>
     </loop>
 
     <volume name="side_hcal_scintZXVolume">
       <materialref ref="Scintillator" />
       <solidref ref="side_hcal_scintZXBox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
     </volume>
     <volume name="side_hcal_scintZYVolume">
       <materialref ref="Scintillator" />
       <solidref ref="side_hcal_scintZYBox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis" />
     </volume>
       
       <!-- - - - - - - - -  FULL HCAL STRUCTURES - - - - - - - -  -->
@@ -328,7 +341,7 @@
         </loop> <!-- Y-oriented Side Hcal Sections  -->
 
       <auxiliary auxtype="Region" auxvalue="CalorimeterRegion"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="HcalVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="Hcal"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/magnet.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/magnet.gdml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
     <define>
 
         &constants; 
@@ -3455,10 +3454,6 @@
         <position name="bot_coil_pos" unit="mm" x="0" y="0.5*mm" z="0" />
         <rotation name="identity" unit="radian" z="0" x="0" y="0" />
     </define>
-
-    
-      
-    
 
     <solids>
         <box aunit="radian" lunit="mm" name="magnet_box" x="magnet_box_x" y="magnet_box_y" z="magnet_box_z" />
@@ -10212,42 +10207,62 @@
         <volume name="coil_1_vol" >
             <materialref ref="Copper" />
             <solidref ref="coil_1" />
+      <auxiliary auxtype="VisAttributes" auxvalue="CopperMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="coil_2_vol" >
             <materialref ref="Copper" />
             <solidref ref="coil_2" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="CopperMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="shim_right" >
             <materialref ref="Iron" />
             <solidref ref="shim_right_box" />
+      <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="shim_left" >
             <materialref ref="Iron" />
             <solidref ref="shim_left_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="corner_iron_block_top_left" >
             <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_left_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="corner_iron_block_top_right" >
             <materialref ref="Iron" />
             <solidref ref="corner_iron_block_top_right_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="corner_iron_block_bot_left" >
             <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_left_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="corner_iron_block_bot_right" >
             <materialref ref="Iron" />
             <solidref ref="corner_iron_block_bot_right_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="center_iron_block_top" >
             <materialref ref="Iron" />
             <solidref ref="center_iron_block_top_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="center_iron_block_bot" >
             <materialref ref="Iron" />
             <solidref ref="center_iron_block_bot_box" />
+	    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis"/>
+	    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis" />
         </volume>
         <volume name="ldmx_magnet" >
             <materialref ref="Vacuum" />
@@ -10302,8 +10317,9 @@
                 <positionref ref="center_iron_block_bot_pos" />
                 <rotationref ref="identity" />
             </physvol>
-            <auxiliary auxtype="Region" auxvalue="MagnetRegion"/>
-            <auxiliary auxtype="VisAttributes" auxvalue="MagnetVis"/>
+
+	    <auxiliary auxtype="Region" auxvalue="MagnetRegion"/>
+            <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
         </volume>
     </structure>
     <setup name="Default" version="1.0" >

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/makeTSassemblyfiles.py
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/makeTSassemblyfiles.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 import os
 import sys
 
@@ -83,13 +82,13 @@ For now all vertical surfaces are flush with no space left in between
 Horizontal surfaces have gaps (the spaces between the bars)
 
 Todo: add the plastic casing, add the metal feet which attach the bars
-to the housing, and maybe see if the visattributes can be reworked
+to the housing
 -->
 
 
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
 
   <define>
@@ -100,13 +99,21 @@ to the housing, and maybe see if the visattributes can be reworked
 
   <solids>
     <!--The envelope encompassing the assembly-->
-    <box lunit="mm" name="one_pad_box{i + 1}" x="tspad{i + 1}_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <box lunit="mm" name="one_pad_box{i + 1}"
+         x="tspad{i + 1}_envelope_x"
+         y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*2"
+         z="trigger_pad_thickness"/>
     <!--The scintillator bar dimensions (same for each pad)-->
-    <box lunit="mm" name="trigger_bar_box{i + 1}" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+    <box lunit="mm" name="trigger_bar_box{i + 1}"
+         x="trigger_bar_dx" y="trigger_bar_dy"
+         z="trigger_pad_bar_thickness" />
         <!--The light pipe dimensions (different for each TSPad)-->
-    <box lunit="mm" name="trigger_light_pipe_box{i + 1}" x="trigger_light_pipe{i + 1}_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <box lunit="mm" name="trigger_light_pipe_box{i + 1}"
+         x="trigger_light_pipe{i + 1}_dx"
+         y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
     <!--SiPM dimensions-->
-    <box lunit="mm" name="trigger_sipm_box{i + 1}" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+    <box lunit="mm" name="trigger_sipm_box{i + 1}"
+         x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
   </solids>
 
 
@@ -116,7 +123,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="{scintillator_lvname}">
       <materialref ref="{scintillator_mat}"/>
       <solidref ref="trigger_bar_box{i + 1}"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="{scintillator_mat}MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -124,7 +132,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="{lightpipe_lvname}">
       <materialref ref="{lightpipe_mat}"/>
       <solidref ref="trigger_light_pipe_box{i + 1}"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="{lightpipe_mat}MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -133,7 +142,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="{sipm_lvname}">
       <materialref ref="{sipm_mat}"/>
       <solidref ref="trigger_sipm_box{i + 1}"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="{sipm_mat}MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -144,70 +154,77 @@ to the housing, and maybe see if the visattributes can be reworked
       <loop for="x" from="1" to="number_of_bars" step="1">
 
         <!--
-        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
-        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
-        along the +x edge of the TSPad envelope, and work backwards from there.
-        There are more elegant ways to write the x offset, but this one is the most legible.
+        The light pipes and therefore the TS modules as a whole are of
+        variable length. However, they align at the 'left' edge along
+        the beam direction (positive x in the simulation). Therefore in
+        the x position, we align the SiPMs along the +x edge of the
+        TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this
+        one is the most legible.
         -->
 
   <physvol copynumber="2*x-2">
     <volumeref ref="{sipm_lvname}" />
           <position name="trigger_sipm_layer1_pos" unit="mm"
-                x="(tspad{i + 1}_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="{sipm_lvname}" />
           <position name="trigger_sipm_layer2_pos" unit="mm"
-                x="(tspad{i + 1}_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
     <volumeref ref="{lightpipe_lvname}" />
           <position name="trigger_pad_pipe_layer1_pos" unit="mm"
-                x="(tspad{i + 1}_envelope_x-trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="{lightpipe_lvname}" />
           <position name="trigger_pad_pipe_layer2_pos" unit="mm"
-                x="(tspad{i + 1}_envelope_x-trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
           <volumeref ref="{scintillator_lvname}" />
           <position name="trigger_pad_bar_layer1_pos" unit="mm"
-        x="(tspad{i + 1}_envelope_x-trigger_bar_dx-2*trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5)
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x - 1">
           <volumeref ref="{scintillator_lvname}" />
           <position name="trigger_pad_bar_layer2_pos" unit="mm"
-        x="(tspad{i + 1}_envelope_x-trigger_bar_dx-2*trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad{i + 1}_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe{i + 1}_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*x
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
       </loop>
 
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="Region" auxvalue="{region_name[i]}" />
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/recoil.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/recoil.gdml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-      xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+      xsi:noNamespaceSchemaLocation="gdml.xsd">
   <define>      
     &constants;
   
@@ -65,9 +64,7 @@
                                                       stereo_angle
                                                      -stereo_angle" />
   </define>
-   
-    
-  
+
   <solids>
     <box lunit="mm" name="recoil_l14_active_sensor_box" 
          x="si_large_active_sensor_dx" y="si_large_active_sensor_dy" z="si_sensor_thickness"/>
@@ -86,11 +83,14 @@
     <volume name="Recoil_l14_active_Sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l14_active_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
     </volume>
     <volume name="recoil_l14_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l14_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
       <physvol name="recoil_l14_active_sensor">
         <volumeref ref="Recoil_l14_active_Sensor_vol"/>
         <position name="recoil_l14_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
@@ -99,11 +99,14 @@
     <volume name="Recoil_l56_active_Sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l56_active_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
     </volume>
     <volume name="recoil_l56_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l56_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
       <physvol name="recoil_l56_active_sensor">
         <volumeref ref="Recoil_l56_active_Sensor_vol"/>
         <position name="recoil_l56_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/scoring_planes.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/scoring_planes.gdml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    xsi:noNamespaceSchemaLocation="gdml.xsd">
 
   <define>
 
@@ -153,10 +152,6 @@
 
   </define>
 
-  
-    
-  
-
   <solids>
     <box name="world_box" x="world_dim" y="world_dim" z="world_dim"/>
 
@@ -186,6 +181,7 @@
       <volume name="sp_target">
         <materialref ref="Vacuum" />
         <solidref ref="sp_target_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop>
@@ -199,6 +195,7 @@
       <volume name="sp_trigScint">
         <materialref ref="Vacuum" />
         <solidref ref="sp_trigscint_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop>
@@ -208,6 +205,7 @@
       <volume name="sp_recoil"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_recoil_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop> 
@@ -216,11 +214,13 @@
       <volume name="sp_magnet_gap_top_bot"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_magnet_gap_top_bot_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume>
       <volume name="sp_magnet_gap_left_right"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_magnet_gap_left_right_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop> 
@@ -229,16 +229,19 @@
       <volume name="sp_ecal_front_back"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_front_back_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume>  
       <volume name="sp_ecal_top_bot"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_top_bot_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume>
       <volume name="sp_ecal_left_right"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_left_right_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop>
@@ -247,16 +250,19 @@
       <volume name="sp_hcal_front_back"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_front_back_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume>  
       <volume name="sp_hcal_top_bot"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_top_bot_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume>
       <volume name="sp_hcal_left_right"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_left_right_box" />
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau"/>
         <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
       </volume> 
     </loop>
@@ -338,23 +344,10 @@
           <rotationref ref="identity" />
         </physvol> 
       </loop> 
-
+        <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
     </volume>
   </structure>
-
-  <userinfo>
-    <auxiliary auxtype="VisAttributes" auxvalue="SpVis">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="2.0"/>
-    </auxiliary>
-  </userinfo>
-
+  
   <setup name="Default" version="1.0">
     <world ref="SP_World" />
   </setup>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tagger.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tagger.gdml
@@ -2,11 +2,10 @@
 
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+    xsi:noNamespaceSchemaLocation="gdml.xsd">
   <define>
     &constants;  
 
@@ -46,9 +45,7 @@
   
   
   </define>
-   
-    
-  
+
   <solids>
     <box lunit="mm" name="tagger_active_sensor_box" 
        x="si_active_sensor_dx" y="si_active_sensor_dy" z="si_sensor_thickness"/>
@@ -67,6 +64,8 @@
     <volume name="tagger_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="tagger_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TaggerRegionVis"/>
       <physvol name="tagger_active_sensor">
       <volumeref ref="Tagger_active_Sensor_vol"/>
       <position name="tagger_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/target.gdml
@@ -5,7 +5,7 @@
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
   <define>
 
@@ -40,7 +40,11 @@
     <volume name="target">
       <materialref ref="LYSO"/>
       <solidref ref="target_bar"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="LYSOMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis"/>
+
     </volume>
+
     <volume name="lvTargetArray1">
       <materialref ref="Vacuum"/>
       <solidref ref="target_array1"/>
@@ -81,7 +85,8 @@
     <volume name="trigger_pad3_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -89,7 +94,7 @@
       <materialref ref="Vacuum"/>
       <solidref ref="target_area_box" />
 
-            <physvol>
+      <physvol>
         <file name="tspad3_assembly.gdml"/>
         <position name="tspad3_pos" unit="mm" x="(tspad3_envelope_x-trigger_bar_dx)/2" y="0"
 		  z="trigger_pad3_z" />
@@ -102,7 +107,7 @@
       </physvol>
 
       <auxiliary auxtype="Region" auxvalue="target" />
-      <!-- <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/> -->
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="target"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/trig_scint.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/trig_scint.gdml
@@ -5,7 +5,7 @@
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
   <define>
 
@@ -32,14 +32,16 @@
     <volume name="trigger_pad2_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
     <volume name="trigger_pad1_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -79,7 +81,7 @@
       </loop>
 
       <auxiliary auxtype="Region" auxvalue="trig_scint" />
-      <!-- <auxiliary auxtype="VisAttributes" auxvalue="VisibleShowDau"/> -->
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad1_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad1_assembly.gdml
@@ -14,13 +14,13 @@ For now all vertical surfaces are flush with no space left in between
 Horizontal surfaces have gaps (the spaces between the bars)
 
 Todo: add the plastic casing, add the metal feet which attach the bars
-to the housing, and maybe see if the visattributes can be reworked
+to the housing
 -->
 
 
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
 
   <define>
@@ -31,13 +31,21 @@ to the housing, and maybe see if the visattributes can be reworked
 
   <solids>
     <!--The envelope encompassing the assembly-->
-    <box lunit="mm" name="one_pad_box1" x="tspad1_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <box lunit="mm" name="one_pad_box1"
+         x="tspad1_envelope_x"
+         y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*2"
+         z="trigger_pad_thickness"/>
     <!--The scintillator bar dimensions (same for each pad)-->
-    <box lunit="mm" name="trigger_bar_box1" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+    <box lunit="mm" name="trigger_bar_box1"
+         x="trigger_bar_dx" y="trigger_bar_dy"
+         z="trigger_pad_bar_thickness" />
         <!--The light pipe dimensions (different for each TSPad)-->
-    <box lunit="mm" name="trigger_light_pipe_box1" x="trigger_light_pipe1_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <box lunit="mm" name="trigger_light_pipe_box1"
+         x="trigger_light_pipe1_dx"
+         y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
     <!--SiPM dimensions-->
-    <box lunit="mm" name="trigger_sipm_box1" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+    <box lunit="mm" name="trigger_sipm_box1"
+         x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
   </solids>
 
 
@@ -47,7 +55,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="trigger_pad1_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box1"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -55,7 +64,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad1_lightpipe_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="trigger_light_pipe_box1"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -64,7 +74,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad1_sipm_volume">
       <materialref ref="Silicon"/>
       <solidref ref="trigger_sipm_box1"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -75,70 +86,77 @@ to the housing, and maybe see if the visattributes can be reworked
       <loop for="x" from="1" to="number_of_bars" step="1">
 
         <!--
-        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
-        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
-        along the +x edge of the TSPad envelope, and work backwards from there.
-        There are more elegant ways to write the x offset, but this one is the most legible.
+        The light pipes and therefore the TS modules as a whole are of
+        variable length. However, they align at the 'left' edge along
+        the beam direction (positive x in the simulation). Therefore in
+        the x position, we align the SiPMs along the +x edge of the
+        TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this
+        one is the most legible.
         -->
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad1_sipm_volume" />
           <position name="trigger_sipm_layer1_pos" unit="mm"
-                x="(tspad1_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad1_sipm_volume" />
           <position name="trigger_sipm_layer2_pos" unit="mm"
-                x="(tspad1_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad1_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer1_pos" unit="mm"
-                x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad1_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer2_pos" unit="mm"
-                x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-trigger_light_pipe1_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
           <volumeref ref="trigger_pad1_bar_volume" />
           <position name="trigger_pad_bar_layer1_pos" unit="mm"
-        x="(tspad1_envelope_x-trigger_bar_dx-2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5)
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x - 1">
           <volumeref ref="trigger_pad1_bar_volume" />
           <position name="trigger_pad_bar_layer2_pos" unit="mm"
-        x="(tspad1_envelope_x-trigger_bar_dx-2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad1_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe1_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*x
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
       </loop>
 
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="Region" auxvalue="trig_scint" />
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad2_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad2_assembly.gdml
@@ -14,13 +14,13 @@ For now all vertical surfaces are flush with no space left in between
 Horizontal surfaces have gaps (the spaces between the bars)
 
 Todo: add the plastic casing, add the metal feet which attach the bars
-to the housing, and maybe see if the visattributes can be reworked
+to the housing
 -->
 
 
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
 
   <define>
@@ -31,13 +31,21 @@ to the housing, and maybe see if the visattributes can be reworked
 
   <solids>
     <!--The envelope encompassing the assembly-->
-    <box lunit="mm" name="one_pad_box2" x="tspad2_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <box lunit="mm" name="one_pad_box2"
+         x="tspad2_envelope_x"
+         y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*2"
+         z="trigger_pad_thickness"/>
     <!--The scintillator bar dimensions (same for each pad)-->
-    <box lunit="mm" name="trigger_bar_box2" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+    <box lunit="mm" name="trigger_bar_box2"
+         x="trigger_bar_dx" y="trigger_bar_dy"
+         z="trigger_pad_bar_thickness" />
         <!--The light pipe dimensions (different for each TSPad)-->
-    <box lunit="mm" name="trigger_light_pipe_box2" x="trigger_light_pipe2_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <box lunit="mm" name="trigger_light_pipe_box2"
+         x="trigger_light_pipe2_dx"
+         y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
     <!--SiPM dimensions-->
-    <box lunit="mm" name="trigger_sipm_box2" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+    <box lunit="mm" name="trigger_sipm_box2"
+         x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
   </solids>
 
 
@@ -47,7 +55,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="trigger_pad2_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box2"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -55,7 +64,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad2_lightpipe_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="trigger_light_pipe_box2"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -64,7 +74,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad2_sipm_volume">
       <materialref ref="Silicon"/>
       <solidref ref="trigger_sipm_box2"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -75,70 +86,77 @@ to the housing, and maybe see if the visattributes can be reworked
       <loop for="x" from="1" to="number_of_bars" step="1">
 
         <!--
-        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
-        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
-        along the +x edge of the TSPad envelope, and work backwards from there.
-        There are more elegant ways to write the x offset, but this one is the most legible.
+        The light pipes and therefore the TS modules as a whole are of
+        variable length. However, they align at the 'left' edge along
+        the beam direction (positive x in the simulation). Therefore in
+        the x position, we align the SiPMs along the +x edge of the
+        TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this
+        one is the most legible.
         -->
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad2_sipm_volume" />
           <position name="trigger_sipm_layer1_pos" unit="mm"
-                x="(tspad2_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad2_sipm_volume" />
           <position name="trigger_sipm_layer2_pos" unit="mm"
-                x="(tspad2_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad2_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer1_pos" unit="mm"
-                x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad2_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer2_pos" unit="mm"
-                x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-trigger_light_pipe2_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
           <volumeref ref="trigger_pad2_bar_volume" />
           <position name="trigger_pad_bar_layer1_pos" unit="mm"
-        x="(tspad2_envelope_x-trigger_bar_dx-2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5)
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x - 1">
           <volumeref ref="trigger_pad2_bar_volume" />
           <position name="trigger_pad_bar_layer2_pos" unit="mm"
-        x="(tspad2_envelope_x-trigger_bar_dx-2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad2_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe2_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*x
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
       </loop>
 
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="Region" auxvalue="trig_scint" />
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad3_assembly.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/tspad3_assembly.gdml
@@ -14,13 +14,13 @@ For now all vertical surfaces are flush with no space left in between
 Horizontal surfaces have gaps (the spaces between the bars)
 
 Todo: add the plastic casing, add the metal feet which attach the bars
-to the housing, and maybe see if the visattributes can be reworked
+to the housing
 -->
 
 
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd" >
+    xsi:noNamespaceSchemaLocation="gdml.xsd" >
 
 
   <define>
@@ -31,13 +31,21 @@ to the housing, and maybe see if the visattributes can be reworked
 
   <solids>
     <!--The envelope encompassing the assembly-->
-    <box lunit="mm" name="one_pad_box3" x="tspad3_envelope_x" y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*1.1" z="trigger_pad_thickness"/>
+    <box lunit="mm" name="one_pad_box3"
+         x="tspad3_envelope_x"
+         y="(trigger_bar_dy+trigger_pad_bar_gap)*number_of_bars*2"
+         z="trigger_pad_thickness"/>
     <!--The scintillator bar dimensions (same for each pad)-->
-    <box lunit="mm" name="trigger_bar_box3" x="trigger_bar_dx" y="trigger_bar_dy" z="trigger_pad_bar_thickness" />
+    <box lunit="mm" name="trigger_bar_box3"
+         x="trigger_bar_dx" y="trigger_bar_dy"
+         z="trigger_pad_bar_thickness" />
         <!--The light pipe dimensions (different for each TSPad)-->
-    <box lunit="mm" name="trigger_light_pipe_box3" x="trigger_light_pipe3_dx" y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
+    <box lunit="mm" name="trigger_light_pipe_box3"
+         x="trigger_light_pipe3_dx"
+         y="trigger_light_pipe_dy" z="trigger_light_pipe_thickness" />
     <!--SiPM dimensions-->
-    <box lunit="mm" name="trigger_sipm_box3" x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
+    <box lunit="mm" name="trigger_sipm_box3"
+         x="sipm_thickness" y="sipm_dy" z="sipm_dz" />
   </solids>
 
 
@@ -47,7 +55,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="trigger_pad3_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box3"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -55,7 +64,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad3_lightpipe_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="trigger_light_pipe_box3"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -64,7 +74,8 @@ to the housing, and maybe see if the visattributes can be reworked
     <volume name="tspad3_sipm_volume">
       <materialref ref="Silicon"/>
       <solidref ref="trigger_sipm_box3"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -75,70 +86,77 @@ to the housing, and maybe see if the visattributes can be reworked
       <loop for="x" from="1" to="number_of_bars" step="1">
 
         <!--
-        The light pipes and therefore the TS modules as a whole are of variable length. However, they align at the 'left'
-        edge along the beam direction (positive x in the simulation). Therefore in the x position, we align the SiPMs
-        along the +x edge of the TSPad envelope, and work backwards from there.
-        There are more elegant ways to write the x offset, but this one is the most legible.
+        The light pipes and therefore the TS modules as a whole are of
+        variable length. However, they align at the 'left' edge along
+        the beam direction (positive x in the simulation). Therefore in
+        the x position, we align the SiPMs along the +x edge of the
+        TSPad envelope, and work backwards from there.
+        There are more elegant ways to write the x offset, but this
+        one is the most legible.
         -->
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad3_sipm_volume" />
           <position name="trigger_sipm_layer1_pos" unit="mm"
-                x="(tspad3_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad3_sipm_volume" />
           <position name="trigger_sipm_layer2_pos" unit="mm"
-                x="(tspad3_envelope_x-sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
     <volumeref ref="tspad3_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer1_pos" unit="mm"
-                x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*(x-0.5)+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x-1">
           <volumeref ref="tspad3_lightpipe_volume" />
           <position name="trigger_pad_pipe_layer2_pos" unit="mm"
-                x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-trigger_light_pipe3_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2+trigger_bar_dy*x+trigger_pad_bar_gap*(x-1)+trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
   <physvol copynumber="2*x-2">
           <volumeref ref="trigger_pad3_bar_volume" />
           <position name="trigger_pad_bar_layer1_pos" unit="mm"
-        x="(tspad3_envelope_x-trigger_bar_dx-2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5) + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*(x - 0.5)
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="-trigger_pad_bar_thickness/2 - trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
         <physvol copynumber="2*x - 1">
           <volumeref ref="trigger_pad3_bar_volume" />
           <position name="trigger_pad_bar_layer2_pos" unit="mm"
-        x="(tspad3_envelope_x-trigger_bar_dx-2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
-                    y="-target_dim_y/2 + trigger_bar_dy*x + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
-                    z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
+ x="(tspad3_envelope_x-trigger_bar_dx
+   -2*trigger_light_pipe3_dx-2*sipm_thickness)/2"
+ y="-target_dim_y/2 + trigger_bar_dy*x
+   + trigger_pad_bar_gap*(x - 1) + trigger_pad_offset"
+ z="trigger_pad_bar_thickness/2 + trigger_pad_bar_gap/2" />
           <rotationref ref="identity" />
         </physvol>
 
       </loop>
 
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="Region" auxvalue="target" />
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>-->
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
 
     </volume>

--- a/Detectors/data/ldmx-lyso-r4-v15-8gev/visattributes.gdml
+++ b/Detectors/data/ldmx-lyso-r4-v15-8gev/visattributes.gdml
@@ -1,0 +1,299 @@
+<!-- define vis attributes -->
+
+<!--
+There are 3 categories of visattributes included here: invisible options,
+options by region, and options by material. To switch between definition
+by region and definition by material, set the optional 'ColorMode' tag
+in detector.gdml, in the userinfo, before loading this accessory file.
+The default is definition by region, or invisible.
+
+For the material visattributes, I arbitrarily assigned object colors
+based on my imagination. These can be changed as the user pleases.
+I'd recommend a free online RGB color picker to help you select the
+perfect color.
+-->
+
+<!--Styles of invisible (applicable in many scenarios)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="NoDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+    </auxiliary>  
+
+    <!--Visattributes by region (applies to all volumes in the region)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.6"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.3"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TaggerRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.8"/>
+      <auxiliary auxtype="G" auxvalue="0.8"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="RecoilRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.9"/>
+      <auxiliary auxtype="G" auxvalue="0.8"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.75"/>
+      <auxiliary auxtype="G" auxvalue="0.75"/>
+      <auxiliary auxtype="B" auxvalue="0.75"/>
+      <auxiliary auxtype="A" auxvalue="0.8"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SpVis">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="2.0"/>
+    </auxiliary>
+
+
+    <!--Visattributes by material-->
+    <!--Only solid materials get a color and are visible-->
+    <!--'Unimportant' materials are semi-transparent-->
+
+    <auxiliary auxtype="VisAttributes" auxvalue="CarbonMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.1"/>
+      <auxiliary auxtype="G" auxvalue="0.1"/>
+      <auxiliary auxtype="B" auxvalue="0.1"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.9"/>
+      <auxiliary auxtype="G" auxvalue="0.9"/>
+      <auxiliary auxtype="B" auxvalue="0.9"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.3"/>
+      <auxiliary auxtype="G" auxvalue="0.3"/>
+      <auxiliary auxtype="B" auxvalue="0.3"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="CopperMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.741"/>
+      <auxiliary auxtype="G" auxvalue="0.4"/>
+      <auxiliary auxtype="B" auxvalue="0.114"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    
+    <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.075"/>
+      <auxiliary auxtype="G" auxvalue="0.651"/>
+      <auxiliary auxtype="B" auxvalue="0.2"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="1.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.5"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="CarbonEpoxyCompositeMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="1.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.5"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SteelMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.71"/>
+      <auxiliary auxtype="G" auxvalue="0.737"/>
+      <auxiliary auxtype="B" auxvalue="0.82"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.9"/>
+      <auxiliary auxtype="B" auxvalue="0.8"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.949"/>
+      <auxiliary auxtype="G" auxvalue="0.902"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.89"/>
+      <auxiliary auxtype="B" auxvalue="0.62"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="LYSOMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="1.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    
+    <!--Historic visattributes definitions (unsure if needed)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.6"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="BlueWireFrame">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="BlueSolid">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.4"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="Invisible">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.4"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>      
+    </auxiliary>


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves #1978 again, by importing new visualization features to `ldmx-lyso-r4-v15-8gev`.

Working on this revealed a couple minor discrepancies, which I'll address in follow-up comments. If they're significant enough, I can create a new issue and a new PR.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

The visualization works much like it does in v15, but the 'target' is green instead of red (arbitrary choice) since it's made of LYSO:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2f72a6bf-3e98-405d-baf8-145c4c75c9d8" />
