### PR TITLE
Move dEdx based mass estimator to use reco tracks

### DIFF
--- a/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
+++ b/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
@@ -59,7 +59,7 @@ class TrackDeDxMassEstimate {
    * Set the number of hits used in the dEdx calculation.
    * @param nhits The number of hits used in the dEdx calculation.
    */
-  void setNhits(float nhits) { n_hits_ = nhits; }
+  void setNhits(int nhits) { n_hits_ = nhits; }
 
   /**
    * Set the Ih of the particle/track.
@@ -125,6 +125,12 @@ class TrackDeDxMassEstimate {
   int getTrackType() const { return track_type_; }
 
   /**
+   * Get the number of hits on the track.
+   * @return The umber of hits on the track.
+   */
+  int getNhits() const { return n_hits_; }
+
+  /**
    * Get the PDG ID of the track.
    * @return The DPG ID of the track.
    */
@@ -135,7 +141,7 @@ class TrackDeDxMassEstimate {
   float momentum_{0.};
 
   /* The number of hits used in the dEdx calculation */
-  float n_hits_{0.};
+  int n_hits_{0};
 
   /* The Ih of the particle/track */
   float the_ih_{0.};
@@ -155,7 +161,7 @@ class TrackDeDxMassEstimate {
   /**
    * The ROOT class definition.
    */
-  ClassDef(TrackDeDxMassEstimate, 5);
+  ClassDef(TrackDeDxMassEstimate, 6);
 };
 }  // namespace ldmx
 

--- a/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
+++ b/Recon/include/Recon/Event/TrackDeDxMassEstimate.h
@@ -126,7 +126,7 @@ class TrackDeDxMassEstimate {
 
   /**
    * Get the number of hits on the track.
-   * @return The umber of hits on the track.
+   * @return The number of hits on the track.
    */
   int getNhits() const { return n_hits_; }
 

--- a/Recon/python/track_dedx_mass_estimator.py
+++ b/Recon/python/track_dedx_mass_estimator.py
@@ -8,11 +8,14 @@ where m is the particle mass, p is the particle momentum,
 K and C are fit parameters.
 Using the fitted result of the parameters, the mass of
 the particle can be calculated from its dE/dx and momentum.
+More info in https://arxiv.org/pdf/2412.12125
 
 Attributes:
 -------------
 track_collection : string
     Name of the track collection used as input
+input_pass_name: string
+    Pass name of the track collection used as input
 fit_res_c : float
     The fitted result of the constant term C (unit: MeV/mm)
 fit_res_k : float
@@ -31,12 +34,13 @@ from LDMX.Framework import Processor, processor
 class TrackDeDxMassEstimator(Processor):
     """Configuration for the mass estimator from tracker dEdx"""
 
-    track_collection: str = "RecoilTruthTracks"
+    track_collection: str = "RecoilTracks"
+    input_pass_name: str = ""
     fit_res_c: float = 3.094
     fit_res_k: float = 1.862
 
 
 recoil_track_mass_estimator = TrackDeDxMassEstimator(
     instance_name="RecoilTrackMassEstimator",
-    track_collection="RecoilTruthTracks",
+    track_collection="RecoilTracks",
 )

--- a/Recon/src/Recon/TrackDeDxMassEstimator.cxx
+++ b/Recon/src/Recon/TrackDeDxMassEstimator.cxx
@@ -13,9 +13,8 @@ namespace recon {
 void TrackDeDxMassEstimator::configure(framework::config::Parameters &ps) {
   fit_res_c_ = ps.get<double>("fit_res_c");
   fit_res_k_ = ps.get<double>("fit_res_k");
-  input_pass_name_ = ps.get<std::string>("input_pass_name", "");
-  track_collection_ =
-      ps.get<std::string>("track_collection", "RecoilTruthSeeds");
+  input_pass_name_ = ps.get<std::string>("input_pass_name");
+  track_collection_ = ps.get<std::string>("track_collection");
 
   ldmx_log(info) << "Track Collection used for TrackDeDxMassEstimator "
                  << track_collection_;
@@ -37,26 +36,38 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
   std::string track_coll_str = track_collection_;
   std::transform(track_coll_str.begin(), track_coll_str.end(),
                  track_coll_str.begin(), ::tolower);
-  if (track_coll_str.find("tagger") != std::string::npos) {
-    track_type = 1;
-    simhit_collection_ = "TaggerSimHits";
-  } else if (track_coll_str.find("recoil") != std::string::npos) {
-    track_type = 2;
-    simhit_collection_ = "RecoilSimHits";
+
+  bool is_truth = track_coll_str.find("truth") != std::string::npos;
+
+  if (is_truth) {
+    if (track_coll_str.find("tagger") != std::string::npos) {
+      track_type = 1;
+      simhit_collection_ = "TaggerSimHits";
+    } else if (track_coll_str.find("recoil") != std::string::npos) {
+      track_type = 2;
+      simhit_collection_ = "RecoilSimHits";
+    } else {
+      track_type = 0;
+      simhit_collection_ = "";
+    }
   } else {
-    track_type = 0;
+    // Reco tracks (e.g. RecoilTracks, RecoilTracksClean)
+    track_type = 4;
     simhit_collection_ = "";
   }
 
-  // Retrieve the simhits
-  if (!event.exists(simhit_collection_, input_pass_name_)) {
-    ldmx_log(error) << " SimHit collection (" << simhit_collection_ << "_"
-                    << input_pass_name_ << ") does not exists, exiting...";
-    event.add("TrackDeDxMassEstimate", mass_estimates);
-    return;
+  // Retrieve simhits only for truth tracks
+  std::vector<ldmx::SimTrackerHit> simhits;
+  if (is_truth) {
+    if (!event.exists(simhit_collection_, input_pass_name_)) {
+      ldmx_log(error) << " SimHit collection (" << simhit_collection_ << "_"
+                      << input_pass_name_ << ") does not exists, exiting...";
+      event.add("TrackDeDxMassEstimate", mass_estimates);
+      return;
+    }
+    simhits = event.getCollection<ldmx::SimTrackerHit>(simhit_collection_,
+                                                       input_pass_name_);
   }
-  auto simhits{event.getCollection<ldmx::SimTrackerHit>(simhit_collection_,
-                                                        input_pass_name_)};
 
   // Loop over the collection of tracks
   for (uint i = 0; i < tracks.size(); i++) {
@@ -72,18 +83,29 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     float momentum = 1. / std::abs(the_qop) * 1000;  // unit: MeV
     ldmx_log(debug) << "Track " << i << " has momentum " << momentum;
 
-    /// Get the hits_ associated with the truth track
     ldmx::TrackDeDxMassEstimate mass_est;
     float sum_dedx_inv2 = 0.;
     float dedx;
-    float n_simhits = 0;
-    for (auto hit : simhits) {
-      // Check if the hit is associated with the track
-      if (hit.getTrackID() != track.getTrackID()) continue;
-      if (hit.getEdep() >= 0 && hit.getPathLength() > 0) {
-        dedx = hit.getEdep() / hit.getPathLength() * 10;  // unit: MeV/cm
-        sum_dedx_inv2 += 1. / (dedx * dedx);
-        n_simhits++;
+    int n_hits = 0;
+
+    if (is_truth) {
+      // Use simhits associated with the truth track
+      for (auto hit : simhits) {
+        if (hit.getTrackID() != track.getTrackID()) continue;
+        if (hit.getEdep() >= 0 && hit.getPathLength() > 0) {
+          dedx = hit.getEdep() / hit.getPathLength() * 10;  // unit: MeV/cm
+          sum_dedx_inv2 += 1. / (dedx * dedx);
+          n_hits++;
+        }
+      }
+    } else {
+      // Use dE/dx measurements stored on the reco track (in MeV/mm)
+      for (auto dedx_meas : track.getDedxMeasurements()) {
+        if (dedx_meas > 0) {
+          dedx = dedx_meas * 10;  // convert MeV/mm to MeV/cm
+          sum_dedx_inv2 += 1. / (dedx * dedx);
+          n_hits++;
+        }
       }
     }  // end of loop over measurements
 
@@ -93,7 +115,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     }
 
     // Ih = (1/N * sum_i^N(dE/dx_i)^-2)^-1/2
-    float the_ih = 1. / sqrt(1. / n_simhits * sum_dedx_inv2);
+    float the_ih = 1. / sqrt(1. / n_hits * sum_dedx_inv2);
 
     float mass = 0.;
     if (the_ih > fit_res_c_) {
@@ -105,7 +127,7 @@ void TrackDeDxMassEstimator::produce(framework::Event &event) {
     }
 
     mass_est.setMomentum(momentum);
-    mass_est.setNhits(n_simhits);
+    mass_est.setNhits(n_hits);
     mass_est.setIh(the_ih);
     mass_est.setMass(mass);
     mass_est.setTrackIndex(i);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/2016

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.

I ran the target genie config and it runs fine.