### PR TITLE
Warning message fix in OverlayProducer track ID encoding

### DIFF
--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -555,8 +555,8 @@ int OverlayProducer::encodeTrack(int track_id,
     // origin ids in the SimCalorimeterHit contribs, which aren't used anyways
     // and present no risk for overwriting data for duplicate track IDs, so we
     // can leave this alone
-    ldmx_log(warn) << "Track ID has value " << track_id
-                   << " < 0; no encoding will be applied";
+    ldmx_log(trace) << "Track ID has value " << track_id
+                   << " < 0; no encoding will be applied (this is expected for origin IDs in SimCalorimeterHits)";
     return track_id;
   }
 

--- a/Recon/src/Recon/OverlayProducer.cxx
+++ b/Recon/src/Recon/OverlayProducer.cxx
@@ -556,7 +556,8 @@ int OverlayProducer::encodeTrack(int track_id,
     // and present no risk for overwriting data for duplicate track IDs, so we
     // can leave this alone
     ldmx_log(trace) << "Track ID has value " << track_id
-                   << " < 0; no encoding will be applied (this is expected for origin IDs in SimCalorimeterHits)";
+                    << " < 0; no encoding will be applied (this is expected "
+                       "for origin IDs in SimCalorimeterHits)";
     return track_id;
   }
 


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->

The SimCalorimeterHits in the ECal currently set all origin IDs to a default value of -1, which the track ID encoding in the OverlayProducer can't handle. This results in a warning message. However, since this is the case for *all* origin IDs, this message shows up far too often to be appropriate. Accordingly, this PR resolves #2026 by changing the log level from `warn` to `trace` and by adding a note that this should be expected for origin IDs when track encoding SimCalorimeterHits.

*Did this commit on web, so I'm waiting on the validation runs to show that compilation succeeds and the development works.*

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Gold.log
<img width="592" height="315" alt="Screenshot 2026-04-16 at 21 32 25" src="https://github.com/user-attachments/assets/3fc04aa2-5675-4dfd-a566-4ee1df525a19" />

Output.log
<img width="911" height="294" alt="Screenshot 2026-04-16 at 21 32 46" src="https://github.com/user-attachments/assets/7c02a79e-44b4-4bf5-b841-8a9bb3d22cc5" />

