### PR TITLE
Fix GENIE per-event Configure call

### DIFF
--- a/SimCore/include/SimCore/Generators/GenieGenerator.h
+++ b/SimCore/include/SimCore/Generators/GenieGenerator.h
@@ -73,9 +73,11 @@ class GenieGenerator : public simcore::PrimaryGenerator {
 
  private:
   /**
-   * The GENIE event generator driver and convertor to HepMC3GenEvent
+   * One GENIE event generator driver per target and convertor to
+   * HepMC3GenEvent. Each driver is configured once for its target during
+   * initialization.
    */
-  genie::GEVGDriver evg_driver_;
+  std::vector<genie::GEVGDriver> evg_drivers_;
   genie::HepMC3Converter hep_mc3_converter_;
 
   double energy_;

--- a/SimCore/src/SimCore/Generators/GenieGenerator.cxx
+++ b/SimCore/src/SimCore/Generators/GenieGenerator.cxx
@@ -379,7 +379,7 @@ void GenieGenerator::GeneratePrimaryVertex(G4Event* event) {
   }
 
   ++n_events_generated_;
-  // delete genie_event;
+  delete genie_event;
 }
 
 void GenieGenerator::RecordConfig(const std::string& id, ldmx::RunHeader& rh) {

--- a/SimCore/src/SimCore/Generators/GenieGenerator.cxx
+++ b/SimCore/src/SimCore/Generators/GenieGenerator.cxx
@@ -187,23 +187,23 @@ void GenieGenerator::initializeGENIE() {
 
   // set GHEP print level (needed?)
   genie::GHepRecord::SetPrintLevel(0);
-
-  // setup for event driver
-  evg_driver_.SetEventGeneratorList(
-      genie::RunOpt::Instance()->EventGeneratorList());
-  evg_driver_.SetUnphysEventMask(*genie::RunOpt::Instance()->UnphysEventMask());
 }
 
 void GenieGenerator::calculateTotalXS() {
   // initializing...
   xsec_total_ = 0;
   ev_weighting_integral_.resize(targets_.size(), 0.0);
+  evg_drivers_.resize(targets_.size());
 
   // calculate the total xsec per target...
   for (size_t i_t = 0; i_t < targets_.size(); ++i_t) {
     genie::InitialState initial_state(targets_[i_t], 11);
-    evg_driver_.Configure(initial_state);
-    evg_driver_.UseSplines();
+    evg_drivers_[i_t].SetEventGeneratorList(
+        genie::RunOpt::Instance()->EventGeneratorList());
+    evg_drivers_[i_t].SetUnphysEventMask(
+        *genie::RunOpt::Instance()->UnphysEventMask());
+    evg_drivers_[i_t].Configure(initial_state);
+    evg_drivers_[i_t].UseSplines();
 
     // setup the initial election
     TParticle initial_e;
@@ -215,7 +215,7 @@ void GenieGenerator::calculateTotalXS() {
     TLorentzVector e_p4;
     initial_e.Momentum(e_p4);
 
-    xsec_by_target_[i_t] = evg_driver_.XSecSum(e_p4);
+    xsec_by_target_[i_t] = evg_drivers_[i_t].XSecSum(e_p4);
     xsec_total_ += xsec_by_target_[i_t] * abundances_[i_t];
 
     ev_weighting_integral_[i_t] = xsec_total_;  // running sum
@@ -299,10 +299,6 @@ void GenieGenerator::GeneratePrimaryVertex(G4Event* event) {
   ldmx_log(debug) << "Generating interaction at (x_,y_,z_)=" << "(" << x_pos
                   << "," << y_pos << "," << z_pos << ")";
 
-  genie::InitialState initial_state(targets_.at(nucl_target_i), 11);
-  evg_driver_.Configure(initial_state);
-  evg_driver_.UseSplines();
-
   // setup the initial election
   TParticle initial_e;
   initial_e.SetPdgCode(11);
@@ -317,15 +313,12 @@ void GenieGenerator::GeneratePrimaryVertex(G4Event* event) {
                   << e_p4.Px() << "," << e_p4.Py() << "," << e_p4.Pz() << ","
                   << e_p4.E() << ")";
 
-  // calculate total xsec
-  if (n_events_by_target_[nucl_target_i] == 0)
-    xsec_by_target_[nucl_target_i] = evg_driver_.XSecSum(e_p4);
-
   n_events_by_target_[nucl_target_i] += 1;
 
-  // GENIE magic
+  // GENIE magic — use the pre-configured driver for this target
   genie::EventRecord* genie_event = NULL;
-  while (!genie_event) genie_event = evg_driver_.GenerateEvent(e_p4);
+  while (!genie_event)
+    genie_event = evg_drivers_[nucl_target_i].GenerateEvent(e_p4);
 
   auto ev_info = new UserEventInformation;
   auto hepmc3_genie = hep_mc3_converter_.ConvertToHepMC3(*genie_event);

--- a/lsan_suppressions.txt
+++ b/lsan_suppressions.txt
@@ -45,3 +45,14 @@ leak:Acts::BoundarySurface
 
 # Boost.Log
 leak:boost::log
+
+# GENIE internals
+leak:ROOT::new_geniecLcLHAIntranuke2018
+leak:genie::rew::GSystSet::Init
+leak:genie::GRV98LO::Initialize
+leak:genie::rew::GReWeightINukeParams::GReWeightINukeParams
+
+# ROOT Cling / interpreter
+leak:TF1::InitStandardFunctions
+leak:cling::IncrementalExecutor::executeWrapper
+leak:StrDup


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

Genie seems to make irreproducible results, moving the initialization to the configure should fix it


## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Target Genie CI runs