### PR TITLE
Fixing SingleSubsystemUnpacker bug

### DIFF
--- a/Packing/app/rogue_extract.cxx
+++ b/Packing/app/rogue_extract.cxx
@@ -109,7 +109,8 @@ int main(int argc, char* argv[]) {
     while (r) {
       r >> frame_header;
       frame_count++;
-      const int frame_end = r.tell() + static_cast<std::streamoff>(frame_header.size());
+      const int frame_end =
+          r.tell() + static_cast<std::streamoff>(frame_header.size());
       if (frame_header.channel() != 0) {
         // non-data channel in StreamWriter, skip
         r.seek(frame_end);

--- a/Packing/app/rogue_extract.cxx
+++ b/Packing/app/rogue_extract.cxx
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
     while (r) {
       r >> frame_header;
       frame_count++;
-      const int frame_end = r.tell() + frame_header.size();
+      const int frame_end = r.tell() + static_cast<std::streamoff>(frame_header.size());
       if (frame_header.channel() != 0) {
         // non-data channel in StreamWriter, skip
         r.seek(frame_end);

--- a/Packing/include/Packing/Utility/Reader.h
+++ b/Packing/include/Packing/Utility/Reader.h
@@ -59,7 +59,7 @@ class Reader {
    * @param[in] off number of bytes to move relative to dir
    * @param[in] dir location flag for the file, default is beginning
    */
-  void seek(int off, std::ios_base::seekdir dir = std::ios::beg) {
+  void seek(std::streampos off, std::ios_base::seekdir dir = std::ios::beg) {
     file_.seekg(off, dir);
   }
 
@@ -85,7 +85,7 @@ class Reader {
    *
    * @return int number of bytes relative to beginning of file
    */
-  int tell() { return file_.tellg(); }
+  std::streampos tell() { return file_.tellg(); }
 
   /**
    * Tell by number of words
@@ -93,8 +93,8 @@ class Reader {
    * @return int number of words relative to beginning of file
    */
   template <typename WordType>
-  int tell() {
-    return tell() / sizeof(WordType);
+  std::streamoff tell() {
+    return static_cast<std::streamoff>(file_.tellg()) / sizeof(WordType);
   }
 
   /**

--- a/Packing/src/Packing/RogueFrameHeader.cxx
+++ b/Packing/src/Packing/RogueFrameHeader.cxx
@@ -11,8 +11,8 @@ utility::Reader& RogueFrameHeader::read(utility::Reader& r) {
   // the bytes holding size have been read
   size_ -= 4;
 
-  int frame_start = r.tell();
-  r.seek(frame_start + size_ - 1);
+  std::streampos frame_start = r.tell();
+  r.seek(frame_start + static_cast<std::streamoff>(size_ - 1));
   r >> trailer_;
   // reset back to beginning of frame
   r.seek(frame_start);

--- a/Packing/src/Packing/SingleSubsystemUnpacker.cxx
+++ b/Packing/src/Packing/SingleSubsystemUnpacker.cxx
@@ -36,7 +36,8 @@ void SingleSubsystemUnpacker::produce(framework::Event& event) {
 
     // store location of end-of-frame for skipping this frame
     // if we fail any of the filter checks
-    const auto frame_end = reader_.tell() + static_cast<std::streamoff>(frame_header.size());
+    const auto frame_end =
+        reader_.tell() + static_cast<std::streamoff>(frame_header.size());
 
     if (frame_header.channel() != 0 or frame_header.probablyYaml()) {
       // non-data channel in StreamWriter, skip

--- a/Packing/src/Packing/SingleSubsystemUnpacker.cxx
+++ b/Packing/src/Packing/SingleSubsystemUnpacker.cxx
@@ -36,7 +36,7 @@ void SingleSubsystemUnpacker::produce(framework::Event& event) {
 
     // store location of end-of-frame for skipping this frame
     // if we fail any of the filter checks
-    const auto frame_end = reader_.tell() + frame_header.size();
+    const auto frame_end = reader_.tell() + static_cast<std::streamoff>(frame_header.size());
 
     if (frame_header.channel() != 0 or frame_header.probablyYaml()) {
       // non-data channel in StreamWriter, skip


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
 This resolves #2036

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

We can now read the full number of TS frames in `Run_182_20251213_174649.dat`. This is `frame_count_` at the end of the file: `Total Frames: 41123`.


