### PR TITLE
Add safety guard for ecal geom in EcalRecProducer

### DIFF
--- a/Ecal/src/Ecal/EcalRecProducer.cxx
+++ b/Ecal/src/Ecal/EcalRecProducer.cxx
@@ -40,6 +40,22 @@ void EcalRecProducer::produce(framework::Event& event) {
   const auto& geometry = getCondition<ldmx::EcalGeometry>(
       ldmx::EcalGeometry::CONDITIONS_OBJECT_NAME);
 
+  // Safety check: ensure layer_weights_ covers all geometry layers.
+  // A mismatch here typically means an outdated geometry configuration
+  // (e.g. v14) is being used with layer weights for a different geometry
+  // version (e.g. v15).
+  if (geometry.getNumLayers() > static_cast<int>(layer_weights_.size())) {
+    EXCEPTION_RAISE(
+        "InvalidConfig",
+        "The number of layers in the Ecal geometry (" +
+            std::to_string(geometry.getNumLayers()) +
+            ") exceeds the number of configured layer_weights (" +
+            std::to_string(layer_weights_.size()) +
+            "). This is likely caused by a mismatch between the geometry "
+            "version and the reconstruction configuration. Please ensure "
+            "that the correct geometry is being used.");
+  }
+
   // Get the reconstruction parameters
   EcalReconConditions the_conditions(
       getCondition<conditions::DoubleTableCondition>(

--- a/Ecal/test/EcalDigiPipelineTest.cxx
+++ b/Ecal/test/EcalDigiPipelineTest.cxx
@@ -180,7 +180,7 @@ class EcalFakeSimHits : public framework::Producer {
   ~EcalFakeSimHits() {}
 
   void beforeNewRun(ldmx::RunHeader &header) final override {
-    header.setDetectorName("ldmx-det-v14-8gev");
+    header.setDetectorName("ldmx-det-v15-8gev");
   }
 
   void produce(framework::Event &event) final override {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/2043

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
