### PR TITLE
Updated CLUE clustering to pull RoC values from CSV file, if available.

### DIFF
--- a/Ecal/include/Ecal/CLUE.h
+++ b/Ecal/include/Ecal/CLUE.h
@@ -17,6 +17,8 @@
 #include <memory>
 #include <set>
 #include <stack>
+#include <stdlib.h>
+#include <fstream>
 
 #include "DetDescr/EcalID.h"
 #include "Ecal/Event/EcalHit.h"
@@ -88,7 +90,7 @@ class CLUE {
   // number we're working on
   std::vector<std::vector<const ldmx::EcalHit*>> clustering(
       std::vector<std::shared_ptr<Density>>& densities, bool connectingLayers,
-      int layerTag = 0);
+      int layerTag = 0, std::string roc_file_name="");
 
   std::vector<std::shared_ptr<Density>> setupForClue3D();
 
@@ -97,7 +99,7 @@ class CLUE {
 
   void cluster(const std::vector<ldmx::EcalHit>& hits, double dc, double rc,
                double deltac, double deltao, int nbrOfLayers,
-               bool reclustering);
+               bool reclustering, std::string roc_file_name);
 
   std::vector<double> getCentroidDistances() const {
     return centroid_distances_;

--- a/Ecal/include/Ecal/CLUE.h
+++ b/Ecal/include/Ecal/CLUE.h
@@ -8,8 +8,10 @@
 #define ECAL_CLUE_H_
 
 #include <math.h>
+#include <stdlib.h>
 
 #include <algorithm>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <limits>
@@ -17,8 +19,6 @@
 #include <memory>
 #include <set>
 #include <stack>
-#include <stdlib.h>
-#include <fstream>
 
 #include "DetDescr/EcalID.h"
 #include "Ecal/Event/EcalHit.h"
@@ -90,7 +90,7 @@ class CLUE {
   // number we're working on
   std::vector<std::vector<const ldmx::EcalHit*>> clustering(
       std::vector<std::shared_ptr<Density>>& densities, bool connectingLayers,
-      int layerTag = 0, std::string roc_file_name="");
+      int layerTag = 0, std::string roc_file_name = "");
 
   std::vector<std::shared_ptr<Density>> setupForClue3D();
 
@@ -98,8 +98,8 @@ class CLUE {
       std::vector<std::vector<const ldmx::EcalHit*>>& clusters);
 
   void cluster(const std::vector<ldmx::EcalHit>& hits, double dc, double rc,
-               double deltac, double deltao, int nbrOfLayers,
-               bool reclustering, std::string roc_file_name);
+               double deltac, double deltao, int nbrOfLayers, bool reclustering,
+               std::string roc_file_name);
 
   std::vector<double> getCentroidDistances() const {
     return centroid_distances_;

--- a/Ecal/include/Ecal/EcalClusterProducer.h
+++ b/Ecal/include/Ecal/EcalClusterProducer.h
@@ -74,6 +74,7 @@ class EcalClusterProducer : public framework::Producer {
   bool clue_;
   int nbr_of_layers_;
   bool reclustering_;
+  std::string roc_file_name_;
 
   /** The name of the cluster algorithm used. */
   TString algo_name_;

--- a/Ecal/python/ecal_clusters.py
+++ b/Ecal/python/ecal_clusters.py
@@ -7,7 +7,7 @@ Examples
 """
 
 from LDMX.Framework import Processor, processor
-
+from .make_path import make_roc_path
 
 @processor("ecal::EcalClusterProducer", "Ecal")
 class EcalClusterProducer(Processor):
@@ -45,10 +45,12 @@ class EcalClusterProducer(Processor):
         not used when nbr_of_layers > 1
     deltao: float
         minimum outlier separation
-    recluster: bool
+    reclustering: bool
         recluster merged clusters or not
         No reclustering leads to more undercounting
         reclustering leads to more overcounting
+    roc_file: str
+        Used in CLUE to set the roc values, if available
     """
 
     rec_hit_coll_name: str = "EcalRecHits"
@@ -65,3 +67,4 @@ class EcalClusterProducer(Processor):
     deltac: float = 10.0
     deltao: float = 40.0
     reclustering: bool = False
+    roc_file: str = make_roc_path("RoC_v14_8gev")

--- a/Ecal/src/Ecal/CLUE.cxx
+++ b/Ecal/src/Ecal/CLUE.cxx
@@ -1,4 +1,5 @@
 #include "Ecal/CLUE.h"
+
 #include <cmath>
 
 namespace ecal {
@@ -261,40 +262,42 @@ std::vector<std::vector<const ldmx::EcalHit*>> CLUE::clustering(
   if (!connecting_layers && nbr_of_layers_ > 1) {
     // if layerwise clustering override rhoc_ and deltac_ with per-layer values
 
-    //If possible, overwrite hard-coded roc values with values imported from the CSV file
-    //These should only need to be read once
-    static std::vector<double> radius_from_file_;
-    if(radius_from_file_.empty()&&roc_file_name!=""){
+    // If possible, overwrite hard-coded roc values with values imported from
+    // the CSV file These should only need to be read once
+    static std::vector<double> radius_from_file;
+    if (radius_from_file.empty() && roc_file_name != "") {
       ldmx_log(info) << "Attempting to use RoC values from CSV file.";
-      //File reading algorithm adapted from EcalVetoProcessor.cxx
+      // File reading algorithm adapted from EcalVetoProcessor.cxx
       if (!std::ifstream(roc_file_name).good()) {
-	EXCEPTION_RAISE(
-			"CLUE",
-			"The specified RoC file '" + roc_file_name + "' does not exist!");
+        EXCEPTION_RAISE("CLUE", "The specified RoC file '" + roc_file_name +
+                                    "' does not exist!");
       } else {
-	std::ifstream rocfile(roc_file_name);
-	std::string line, value;
-	
-	// Throw away the first (header) line in the file
-	std::getline(rocfile, line);
-	// In EcalVetoProcessor, the RoC values are a 2D array for many angle ranges
-	//As near as I (CJ) can tell, the RoC values in CLUE are only for the first
-	//angle range, 0<theta<10. So we only read the first line of the CSV file's values
-	
-	std::getline(rocfile, line);
-	std::stringstream ss(line);
-	int values_read = 0;
-	while (std::getline(ss, value, ',')) {
-	  values_read++;
-	  if(values_read < 5) continue;//First few entries in each line of RoC file are not RoC values
-	  float f_value = (value != "") ? std::stof(value) : -1.0;
-	  radius_from_file_.push_back(f_value);
-	}
+        std::ifstream rocfile(roc_file_name);
+        std::string line, value;
+
+        // Throw away the first (header) line in the file
+        std::getline(rocfile, line);
+        // In EcalVetoProcessor, the RoC values are a 2D array for many angle
+        // ranges
+        // As near as I (CJ) can tell, the RoC values in CLUE are only for the
+        // first angle range, 0<theta<10. So we only read the first line of the
+        // CSV file's values
+
+        std::getline(rocfile, line);
+        std::stringstream ss(line);
+        int values_read = 0;
+        while (std::getline(ss, value, ',')) {
+          values_read++;
+          if (values_read < 5)
+            continue;  // First few entries in each line of RoC file are not RoC
+                       // values
+          float f_value = (value != "") ? std::stof(value) : -1.0;
+          radius_from_file.push_back(f_value);
+        }
       }
     }
 
-    if(!radius_from_file_.empty())
-      radius_ = radius_from_file_;
+    if (!radius_from_file.empty()) radius_ = radius_from_file;
 
     rhoc_ = layer_rho_c_[layer_index];
     ldmx_log(trace) << "Setting rho_c on layer " << layer_index << " to "
@@ -616,7 +619,6 @@ void CLUE::convertToIntermediateClusters(
 void CLUE::cluster(const std::vector<ldmx::EcalHit>& unsorted_hits, double dc,
                    double rc, double delta_c, double delta_o, int nbr_of_layers,
                    bool reclustering, std::string roc_file_name) {
-
   ldmx_log(info) << "Starting CLUE clustering with parameters:" << "dc " << dc
                  << ", rc " << rc << ", delta_c " << delta_c << ", delta_o "
                  << delta_o << ", nbr_of_layers " << nbr_of_layers

--- a/Ecal/src/Ecal/CLUE.cxx
+++ b/Ecal/src/Ecal/CLUE.cxx
@@ -1,6 +1,4 @@
-
 #include "Ecal/CLUE.h"
-
 #include <cmath>
 
 namespace ecal {
@@ -254,13 +252,50 @@ std::vector<std::shared_ptr<CLUE::Density>> CLUE::setup(
 // number we're working on
 std::vector<std::vector<const ldmx::EcalHit*>> CLUE::clustering(
     std::vector<std::shared_ptr<CLUE::Density>>& densities,
-    bool connecting_layers, int layer_index) {
+    bool connecting_layers, int layer_index, std::string roc_file_name) {
   ldmx_log(trace) << "--- CLUSTERING ---";
   ldmx_log(trace) << "Number of densities: " << densities.size()
                   << "; connecting_layers: " << connecting_layers
                   << "; layer_index: " << layer_index;
+
   if (!connecting_layers && nbr_of_layers_ > 1) {
     // if layerwise clustering override rhoc_ and deltac_ with per-layer values
+
+    //If possible, overwrite hard-coded roc values with values imported from the CSV file
+    //These should only need to be read once
+    static std::vector<double> radius_from_file_;
+    if(radius_from_file_.empty()&&roc_file_name!=""){
+      ldmx_log(info) << "Attempting to use RoC values from CSV file.";
+      //File reading algorithm adapted from EcalVetoProcessor.cxx
+      if (!std::ifstream(roc_file_name).good()) {
+	EXCEPTION_RAISE(
+			"CLUE",
+			"The specified RoC file '" + roc_file_name + "' does not exist!");
+      } else {
+	std::ifstream rocfile(roc_file_name);
+	std::string line, value;
+	
+	// Throw away the first (header) line in the file
+	std::getline(rocfile, line);
+	// In EcalVetoProcessor, the RoC values are a 2D array for many angle ranges
+	//As near as I (CJ) can tell, the RoC values in CLUE are only for the first
+	//angle range, 0<theta<10. So we only read the first line of the CSV file's values
+	
+	std::getline(rocfile, line);
+	std::stringstream ss(line);
+	int values_read = 0;
+	while (std::getline(ss, value, ',')) {
+	  values_read++;
+	  if(values_read < 5) continue;//First few entries in each line of RoC file are not RoC values
+	  float f_value = (value != "") ? std::stof(value) : -1.0;
+	  radius_from_file_.push_back(f_value);
+	}
+      }
+    }
+
+    if(!radius_from_file_.empty())
+      radius_ = radius_from_file_;
+
     rhoc_ = layer_rho_c_[layer_index];
     ldmx_log(trace) << "Setting rho_c on layer " << layer_index << " to "
                     << rhoc_;
@@ -278,7 +313,6 @@ std::vector<std::vector<const ldmx::EcalHit*>> CLUE::clustering(
     // deltac_ = 100.;
     // rhoc_ = 1000.;
   }
-
   bool energy_overload = false;
   double max_energy = 10000.;
   clustering_loops_ = 0;
@@ -581,7 +615,8 @@ void CLUE::convertToIntermediateClusters(
 
 void CLUE::cluster(const std::vector<ldmx::EcalHit>& unsorted_hits, double dc,
                    double rc, double delta_c, double delta_o, int nbr_of_layers,
-                   bool reclustering) {
+                   bool reclustering, std::string roc_file_name) {
+
   ldmx_log(info) << "Starting CLUE clustering with parameters:" << "dc " << dc
                  << ", rc " << rc << ", delta_c " << delta_c << ", delta_o "
                  << delta_o << ", nbr_of_layers " << nbr_of_layers
@@ -636,7 +671,7 @@ void CLUE::cluster(const std::vector<ldmx::EcalHit>& unsorted_hits, double dc,
     for (int i = 0; i < layers.size(); i++) {
       ldmx_log(trace) << "--- LAYER " << i + 1 << " ---";
       auto densities = setup(layers[i]);
-      auto clusters = clustering(densities, false, i);
+      auto clusters = clustering(densities, false, i, roc_file_name);
       convertToIntermediateClusters(clusters);
       // clustering without 3D
     }
@@ -648,7 +683,7 @@ void CLUE::cluster(const std::vector<ldmx::EcalHit>& unsorted_hits, double dc,
   } else {
     ldmx_log(debug) << "Only one layer, doing 2D clustering";
     auto densities = setup(hits);
-    auto clusters = clustering(densities, false);
+    auto clusters = clustering(densities, false, 0, roc_file_name);
     convertToIntermediateClusters(clusters);
   }
 }

--- a/Ecal/src/Ecal/EcalClusterProducer.cxx
+++ b/Ecal/src/Ecal/EcalClusterProducer.cxx
@@ -31,6 +31,7 @@ void EcalClusterProducer::configure(framework::config::Parameters& ps) {
   clue_ = ps.get<bool>("clue");
   nbr_of_layers_ = ps.get<int>("nbr_of_layers");
   reclustering_ = ps.get<bool>("reclustering");
+  roc_file_name_ = ps.get<std::string>("roc_file");
 }
 
 void EcalClusterProducer::produce(framework::Event& event) {
@@ -46,7 +47,7 @@ void EcalClusterProducer::produce(framework::Event& event) {
     ldmx_log(info) << "Using CLUE clustering algorithm";
     CLUE cf;
     cf.cluster(ecal_hits, dc_, rhoc_, deltac_, deltao_, nbr_of_layers_,
-               reclustering_);
+               reclustering_, roc_file_name_);
     ldmx_log(debug) << "CLUE algorithm finished clustering";
     std::vector<IntermediateCluster> interm_cluster = cf.getClusters();
     std::vector<IntermediateCluster> f_interm_cluster =


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #1885 

When calculating... Something (not sure what and it doesn't say in the code), the CLUE algorithm has been relying on a hardcoded array of containment radii defined in [CLUE.h](https://github.com/LDMX-Software/ldmx-sw/blob/4dfa4987f4a2cd01a8b38c5b6e60c4f059587e3e/Ecal/include/Ecal/CLUE.h). These values are outdated and, like most hardcoded values, at risk of becoming outdated again even if we update them.

With this PR, if possible, the hardcoded array will be replaced with values pulled from a CSV file stored in [Ecal/Data](https://github.com/LDMX-Software/ldmx-sw/tree/dfe42ac6b49fd835c84143bf0446d70b59faafbf/Ecal/data). To do this, the path to the selected CSV file is passed through the EcalClusterProducer, just like the rest of the parameters used in CLUE. If there is no CSV file path defined, the program defaults to using the hardcoded values. If the file path is somehow faulty, the program exits with an error. I considered downgrading this to a warning, followed by defaulting to the hardcoded values, but I think an exception is more appropriate.

Only two disclaimers this time:
1. the array in question is a vector of doubles. The file reading algorithm is designed for floats. As far as I can tell, this doesn't affect anything in the results.
(as an aside: it turns out that there's some thorny issue related to localization that messes up `stod` and `stof` when operating in a country where decimal places are denoted by ',' instead of '.' and I spent way too much time diving into this rabbit hole)
2. The RoC array as implemented in CLUE is a 1D array, while in the EcalVetoProcessor (from which I adapted the CSV file reading) uses a 2D array. Each row in the CSV file is valid for a different containment region. I made the assumption that the RoC values used in CLUE are only for the minimum angle range, from 0 to 10 degrees.

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
Ran without crashing, RoC values were updated (when setting ECalClusterProducer.nbr_of_layers to a value >1, which I don't think any of the CI tests do anyway)