### PR TITLE
Cleaned up and centralized materials definitions and visattributes.

### DIFF
--- a/.github/validation_samples/cascade_history/config.py
+++ b/.github/validation_samples/cascade_history/config.py
@@ -29,6 +29,7 @@ p.sequence = [my_sim]
 
 import os
 
+
 p.max_events = int(os.environ["LDMX_NUM_EVENTS"])
 p.run = int(os.environ["LDMX_RUN_NUMBER"])
 

--- a/Detectors/data/ldmx-reduced-v3/detector.gdml
+++ b/Detectors/data/ldmx-reduced-v3/detector.gdml
@@ -2,6 +2,7 @@
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
 <!ENTITY materials SYSTEM "materials.gdml">
+<!ENTITY visattributes SYSTEM "visattributes.gdml">
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
 
@@ -117,89 +118,11 @@
       <auxiliary auxtype="StoreTrajectories" auxvalue="true"/>
     </auxiliary>
 
-    <!-- define vis attributes -->
-    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="NoDau">
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="TargetVis">
-      <auxiliary auxtype="R" auxvalue="1.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="EcalVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.6"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>  
-    <auxiliary auxtype="VisAttributes" auxvalue="HcalVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.3"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="TaggerVis">
-      <auxiliary auxtype="R" auxvalue="0.8"/>
-      <auxiliary auxtype="G" auxvalue="0.8"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="RecoilVis">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis">
-      <auxiliary auxtype="R" auxvalue="0.9"/>
-      <auxiliary auxtype="G" auxvalue="0.8"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="MagnetVis">
-      <auxiliary auxtype="R" auxvalue="0.75"/>
-      <auxiliary auxtype="G" auxvalue="0.75"/>
-      <auxiliary auxtype="B" auxvalue="0.75"/>
-      <auxiliary auxtype="A" auxvalue="0.8"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>  
+        <!--Set color mode for visualization (optional)-->
+    <auxiliary auxtype="ColorMode" auxvalue="Region"/>
+    
+    &visattributes;
+
   </userinfo>  
 
   <setup name="Default" version="1.0">

--- a/Detectors/data/ldmx-reduced-v3/ecal.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal.gdml
@@ -113,234 +113,7 @@
     <rotation name="flip" unit="deg" x="0" y="180" z="0"/>
   </define>
 
-  <materials>
-    <!-- alimunum for support box -->
-    <material Z="13" name="G4_Al0x2705780" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="166"/>
-      <D unit="g/cm3" value="2.699"/>
-      <atom unit="g/mole" value="26.9815"/>
-    </material>
-
-    <!-- PCB mixture -->
-    <isotope N="63" Z="29" name="Cu630x271bbf0">
-      <atom unit="g/mole" value="62.9296"/>
-    </isotope>
-    <isotope N="65" Z="29" name="Cu650x271bc60">
-      <atom unit="g/mole" value="64.9278"/>
-    </isotope>
-    <element name="Cu0x271b990">
-      <fraction n="0.6917" ref="Cu630x271bbf0"/>
-      <fraction n="0.3083" ref="Cu650x271bc60"/>
-    </element>
-    <isotope N="16" Z="8" name="O160x271e090">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O170x271e400">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O180x271e490">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O0x271e1a0">
-      <fraction n="0.99757" ref="O160x271e090"/>
-      <fraction n="0.00038" ref="O170x271e400"/>
-      <fraction n="0.00205" ref="O180x271e490"/>
-    </element>
-    <isotope N="23" Z="11" name="Na230x2725ef0">
-      <atom unit="g/mole" value="22.9898"/>
-    </isotope>
-    <element name="Na0x2725c90">
-      <fraction n="1" ref="Na230x2725ef0"/>
-    </element>
-    <isotope N="28" Z="14" name="Si280x271c4f0">
-      <atom unit="g/mole" value="27.9769"/>
-    </isotope>
-    <isotope N="29" Z="14" name="Si290x271c560">
-      <atom unit="g/mole" value="28.9765"/>
-    </isotope>
-    <isotope N="30" Z="14" name="Si300x271c5f0">
-      <atom unit="g/mole" value="29.9738"/>
-    </isotope>
-    <element name="Si0x271c2c0">
-      <fraction n="0.922296077703922" ref="Si280x271c4f0"/>
-      <fraction n="0.0468319531680468" ref="Si290x271c560"/>
-      <fraction n="0.0308719691280309" ref="Si300x271c5f0"/>
-    </element>
-    <isotope N="40" Z="20" name="Ca400x2726160">
-      <atom unit="g/mole" value="39.9626"/>
-    </isotope>
-    <isotope N="42" Z="20" name="Ca420x27261d0">
-      <atom unit="g/mole" value="41.9586"/>
-    </isotope>
-    <isotope N="43" Z="20" name="Ca430x2726240">
-      <atom unit="g/mole" value="42.9588"/>
-    </isotope>
-    <isotope N="44" Z="20" name="Ca440x27262e0">
-      <atom unit="g/mole" value="43.9555"/>
-    </isotope>
-    <isotope N="46" Z="20" name="Ca460x2726350">
-      <atom unit="g/mole" value="45.9537"/>
-    </isotope>
-    <isotope N="48" Z="20" name="Ca480x2726390">
-      <atom unit="g/mole" value="47.9525"/>
-    </isotope>
-    <element name="Ca0x2725f30">
-      <fraction n="0.96941" ref="Ca400x2726160"/>
-      <fraction n="0.00647" ref="Ca420x27261d0"/>
-      <fraction n="0.00135" ref="Ca430x2726240"/>
-      <fraction n="0.02086" ref="Ca440x27262e0"/>
-      <fraction n="4e-05" ref="Ca460x2726350"/>
-      <fraction n="0.00187" ref="Ca480x2726390"/>
-    </element>
-    <material name="FR40x27264f0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="201.221278976803"/>
-      <D unit="g/cm3" value="5.68"/>
-      <fraction n="0.5" ref="Cu0x271b990"/>
-      <fraction n="0.22990022990023" ref="O0x271e1a0"/>
-      <fraction n="0.0482205482205482" ref="Na0x2725c90"/>
-      <fraction n="0.168276668276668" ref="Si0x271c2c0"/>
-      <fraction n="0.0536025536025536" ref="Ca0x2725f30"/>
-    </material>
-
-    <!-- glue mixture -->
-    <isotope N="12" Z="6" name="C120x271ddf0">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C130x271de60">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C0x271db90">
-      <fraction n="0.9893" ref="C120x271ddf0"/>
-      <fraction n="0.0107" ref="C130x271de60"/>
-    </element>
-    <isotope N="1" Z="1" name="H10x271f760">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H20x271f7d0">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H0x271f530">
-      <fraction n="0.999885" ref="H10x271f760"/>
-      <fraction n="0.000115" ref="H20x271f7d0"/>
-    </element>
-    <material name="Glue0x272cce0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="73.3297495741215"/>
-      <D unit="g/cm3" value="0.845"/>
-      <fraction n="0.84491305" ref="C0x271db90"/>
-      <fraction n="0.042542086" ref="H0x271f530"/>
-      <fraction n="0.11254487" ref="O0x271e1a0"/>
-    </material>
-
-    <!-- sensitive silicon -->
-    <material name="G4_Si0x271c1c0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="173"/>
-      <D unit="g/cm3" value="2.33"/>
-      <fraction n="1" ref="Si0x271c2c0"/>
-    </material>
-
-    <!-- 
-    carbon+epoxy composite material for cooling plane 
-    
-    - taking the Epoxy mixture from the PDG values for
-      Epotek-301
-      https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
-    - the MEE value is pretty much made up at this point,
-      assuming it is the same as pure carbon which seems
-      to be an ok assumption since a majority of the epoxy
-      is carbon as well
-    - the epoxy to C-fiber ratio is 0.955 _by weight_
-
-    Fractions calculated by doing
-      C = 1+PDGFrac / 1.955
-      H = PDGFrac / 1.955
-      O = PDGFrac / 1.955
-      N = PDGFrac / 1.955
-    where PDGFrac is that material's mass fraction in the PDG
-    material linked above which we convert to molar fraction
-    by converting each fraction to moles individually and then
-    dividing by the sum.
-    -->
-    <material name="CarbonEpoxyComposite" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="1.439"/>
-      <fraction n="0.624883102" ref="C0x271db90"/>
-      <fraction n="0.308001109" ref="H0x271f530"/>
-      <fraction n="0.064281977" ref="O0x271e1a0"/>
-      <fraction n="0.002833811" ref="G4_AIR0x271da60"/><!--ref="N140x271e0d0"/>-->
-    </material>
-
-    <!-- air for gaps -->
-    <isotope N="14" Z="7" name="N140x271e0d0">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N150x271e140">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N0x271dea0">
-      <fraction n="0.99632" ref="N140x271e0d0"/>
-      <fraction n="0.00368" ref="N150x271e140"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar360x271e730">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar380x271e7c0">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar400x271e850">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar0x271e500">
-      <fraction n="0.003365" ref="Ar360x271e730"/>
-      <fraction n="0.000632" ref="Ar380x271e7c0"/>
-      <fraction n="0.996003" ref="Ar400x271e850"/>
-    </element>
-    <material name="G4_AIR0x271da60" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C0x271db90"/>
-      <fraction n="0.755267755267755" ref="N0x271dea0"/>
-      <fraction n="0.231781231781232" ref="O0x271e1a0"/>
-      <fraction n="0.0128270128270128" ref="Ar0x271e500"/>
-    </material>
-
-    <!-- Tungsten for absorber -->
-    <isotope N="180" Z="74" name="W1800x270c100">
-      <atom unit="g/mole" value="179.947"/>
-    </isotope>
-    <isotope N="182" Z="74" name="W1820x270c170">
-      <atom unit="g/mole" value="181.948"/>
-    </isotope>
-    <isotope N="183" Z="74" name="W1830x270c210">
-      <atom unit="g/mole" value="182.95"/>
-    </isotope>
-    <isotope N="184" Z="74" name="W1840x270c2b0">
-      <atom unit="g/mole" value="183.951"/>
-    </isotope>
-    <isotope N="186" Z="74" name="W1860x270c2f0">
-      <atom unit="g/mole" value="185.954"/>
-    </isotope>
-    <element name="W0x270bea0">
-      <fraction n="0.0012" ref="W1800x270c100"/>
-      <fraction n="0.265" ref="W1820x270c170"/>
-      <fraction n="0.1431" ref="W1830x270c210"/>
-      <fraction n="0.3064" ref="W1840x270c2b0"/>
-      <fraction n="0.2843" ref="W1860x270c2f0"/>
-    </element>
-    <material name="G4_W0x270bda0" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="727"/>
-      <D unit="g/cm3" value="19.3"/>
-      <fraction n="1" ref="W0x270bea0"/>
-    </material>
-
-  </materials>
-
+  
   <solids>
     <!--
       Strongback Parts
@@ -521,22 +294,22 @@
     </assembly>
 
     <volume name="PCB_volume">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="PCB_hexagon"/>
     </volume>
   
     <volume name="Glue_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Glue"/>
       <solidref ref="Glue_hexagon"/>
     </volume>
   
     <volume name="Si_volume">
-      <materialref ref="G4_Si0x271c1c0"/>
+      <materialref ref="Silicon"/>
       <solidref ref="Si_hexagon"/>
     </volume>
   
     <volume name="GlueThick_volume">
-      <materialref ref="Glue0x272cce0"/>
+      <materialref ref="Glue"/>
       <solidref ref="GlueThick_hexagon"/>
     </volume>
 
@@ -549,16 +322,16 @@
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
     <loop for="bilayer" from="1" to="num_bilayers-1" step="1">
       <volume name="strongback_bar_volume[bilayer]">
-        <materialref ref="G4_Al0x2705780" />
+        <materialref ref="Aluminum" />
         <solidref ref="strongback_bar[bilayer]" />
       </volume>
       <volume name="W_front_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_front_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
       <volume name="W_cooling_volume[bilayer]">
-        <materialref ref="G4_W0x270bda0"/>
+        <materialref ref="Tungsten"/>
         <solidref ref="W_cooling_absorber[bilayer]"/>
         <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
       </volume>
@@ -601,7 +374,7 @@
                           Back Tolerance Gap
     -->
     <volume name="em_calorimeters">
-      <materialref ref="G4_AIR"/>
+      <materialref ref="Air"/>
       <solidref ref="ECal_box"/>
 
       <!--
@@ -860,50 +633,5 @@
   <setup name="Default" version="1.0">
     <world ref="em_calorimeters"/>
   </setup>
-
-  <userinfo>
-    <!-- define vis attributes
-    -->
-    <auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame">
-      <auxiliary auxtype="R" auxvalue="0.6"/>
-      <auxiliary auxtype="G" auxvalue="0.6"/>
-      <auxiliary auxtype="B" auxvalue="0.6"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="BlueWireFrame">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="1.0"/>
-      <auxiliary auxtype="Style" auxvalue="wireframe"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="BlueSolid">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="0.4"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="true"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary>
-    <auxiliary auxtype="VisAttributes" auxvalue="Invisible">
-      <auxiliary auxtype="R" auxvalue="0.0"/>
-      <auxiliary auxtype="G" auxvalue="0.0"/>
-      <auxiliary auxtype="B" auxvalue="1.0"/>
-      <auxiliary auxtype="A" auxvalue="0.4"/>
-      <auxiliary auxtype="Style" auxvalue="solid"/>
-      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
-      <auxiliary auxtype="Visible" auxvalue="false"/>
-      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
-    </auxiliary> 
-  </userinfo>  
 
 </gdml>

--- a/Detectors/data/ldmx-reduced-v3/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_motherboard5_assembly.gdml
@@ -275,7 +275,7 @@
 
   <structure>
     <volume name="nohole_motherboard5_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard5_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-reduced-v3/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_motherboard6_assembly.gdml
@@ -361,7 +361,7 @@
 
   <structure>
     <volume name="nohole_motherboard6_assembly">
-      <materialref ref="FR40x27264f0"/>
+      <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard6_assembly-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-reduced-v3/ecal_support_box.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_support_box.gdml
@@ -1480,7 +1480,7 @@
 
   <structure>
     <volume name="support_box">
-      <materialref ref="G4_Al0x2705780"/>
+      <materialref ref="Aluminum"/>
       <solidref ref="support_box-SOL"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-reduced-v3/hcal.gdml
+++ b/Detectors/data/ldmx-reduced-v3/hcal.gdml
@@ -44,120 +44,6 @@
                   ecal_side_dy/2.0-hcal_scintWidth/2.0"/>
   </define>
     
-  <materials>
-    <isotope N="16" Z="8" name="O16">
-      <atom unit="g/mole" value="15.9949"/>
-    </isotope>
-    <isotope N="17" Z="8" name="O17">
-      <atom unit="g/mole" value="16.9991"/>
-    </isotope>
-    <isotope N="18" Z="8" name="O18">
-      <atom unit="g/mole" value="17.9992"/>
-    </isotope>
-    <element name="O">
-      <fraction n="0.99757" ref="O16"/>
-      <fraction n="0.00038" ref="O17"/>
-      <fraction n="0.00205" ref="O18"/>
-    </element>
-    <isotope N="12" Z="6" name="C12">
-      <atom unit="g/mole" value="12"/>
-    </isotope>
-    <isotope N="13" Z="6" name="C13">
-      <atom unit="g/mole" value="13.0034"/>
-    </isotope>
-    <element name="C">
-      <fraction n="0.9893" ref="C12"/>
-      <fraction n="0.0107" ref="C13"/>
-    </element>
-    <isotope N="1" Z="1" name="H1">
-      <atom unit="g/mole" value="1.00782503081372"/>
-    </isotope>
-    <isotope N="2" Z="1" name="H2">
-      <atom unit="g/mole" value="2.01410199966617"/>
-    </isotope>
-    <element name="H">
-      <fraction n="0.999885" ref="H1"/>
-      <fraction n="0.000115" ref="H2"/>
-    </element>
-    <material name="G4_C" state="solid">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="81"/>
-      <D unit="g/cm3" value="2"/>
-      <fraction n="1" ref="C"/>
-    </material>
-    <isotope N="14" Z="7" name="N14">
-      <atom unit="g/mole" value="14.0031"/>
-    </isotope>
-    <isotope N="15" Z="7" name="N15">
-      <atom unit="g/mole" value="15.0001"/>
-    </isotope>
-    <element name="N">
-      <fraction n="0.99632" ref="N14"/>
-      <fraction n="0.00368" ref="N15"/>
-    </element>
-    <isotope N="36" Z="18" name="Ar36">
-      <atom unit="g/mole" value="35.9675"/>
-    </isotope>
-    <isotope N="38" Z="18" name="Ar38">
-      <atom unit="g/mole" value="37.9627"/>
-    </isotope>
-    <isotope N="40" Z="18" name="Ar40">
-      <atom unit="g/mole" value="39.9624"/>
-    </isotope>
-    <element name="Ar">
-      <fraction n="0.003365" ref="Ar36"/>
-      <fraction n="0.000632" ref="Ar38"/>
-      <fraction n="0.996003" ref="Ar40"/>
-    </element>
-    <material name="G4_AIR" state="gas">
-      <T unit="K" value="293.15"/>
-      <MEE unit="eV" value="85.7"/>
-      <D unit="g/cm3" value="0.00120479"/>
-      <fraction n="0.000124000124000124" ref="C"/>
-      <fraction n="0.755267755267755" ref="N"/>
-      <fraction n="0.231781231781232" ref="O"/>
-      <fraction n="0.0128270128270128" ref="Ar"/>
-    </material>
-    <isotope N="55" Z="25" name="Mn55">
-      <atom unit="g/mole" value="54.938"/>
-    </isotope>
-    <element name="Mn">
-      <fraction n="1" ref="Mn55"/>
-    </element>
-    <isotope N="54" Z="26" name="Fe54">
-      <atom unit="g/mole" value="53.9396"/>
-    </isotope>
-    <isotope N="56" Z="26" name="Fe56">
-      <atom unit="g/mole" value="55.9349"/>
-    </isotope>
-    <isotope N="57" Z="26" name="Fe57">
-      <atom unit="g/mole" value="56.9354"/>
-    </isotope>
-    <isotope N="58" Z="26" name="Fe58">
-      <atom unit="g/mole" value="57.9333"/>
-    </isotope>
-    <element name="Fe">
-      <fraction n="0.05845" ref="Fe54"/>
-      <fraction n="0.91754" ref="Fe56"/>
-      <fraction n="0.02119" ref="Fe57"/>
-      <fraction n="0.00282" ref="Fe58"/>
-    </element>
-    <material name="Steel" state="solid">
-       <T unit="K" value="293.15"/>
-       <D unit="g/cm3" value="7.87"/>
-       <fraction n="0.9843" ref="G4_Fe"/>
-       <fraction n="0.014" ref="G4_Mn"/>
-       <fraction n="0.0017" ref="G4_C"/>
-    </material>
-    <material name="Scintillator" state="solid">
-       <T unit="K" value="293.15"/>
-       <!-- <MEE unit="eV" value="64.7494480275643"/> -->
-       <D unit="g/cm3" value="1.032"/>
-       <fraction n="0.91512109"  ref="G4_C"/>
-       <fraction n="0.084878906" ref="G4_H"/>
-    </material>
-  </materials>
-
 
   <solids>
   
@@ -240,7 +126,7 @@
       
       <!-- - - - - - - - -  FULL HCAL STRUCTURES - - - - - - - -  -->
     <volume name="hadronic_calorimeter">
-      <materialref ref="G4_AIR" />
+      <materialref ref="Air" />
       <solidref ref="hadron_calorimeter_Box" />
       <!-- BACK HCAL  -->
         <!-- Note the step size of 2  -->
@@ -437,7 +323,7 @@
         </loop> <!-- Y-oriented Side Hcal Sections  -->
 
       <auxiliary auxtype="Region" auxvalue="CalorimeterRegion"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="HcalVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="Hcal"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-reduced-v3/materials.gdml
+++ b/Detectors/data/ldmx-reduced-v3/materials.gdml
@@ -1,6 +1,36 @@
+<!--
+This file is organized in the following way:
+
+Element definitions
+Pure (one element) material definitions
+Composite material definitions
+
+We don't currently have any enriched elements in LDMX, but
+if we did, I would add those between the element definitions
+and the pure material definitions. And don't worry about the
+isotopic composition of the natural elements - GDML is at
+least smart enough to assign those abundances automatically
+
+Both the elements and the pure materials are organized by
+Z number in ascending order. Also, not all elements have
+corresponding pure materials defined (but most do). If you
+add more, please try to keep the ordering correct!
+
+Lastly, the naming conventions are as follows:
+Element definitions should use the element's abbreviation
+as seen on the periodic table. Pure elemental materials
+should have the formal name listed on the periodic table
+(I guess we'll use the US standard named like 'aluminum'
+instead of 'aluminium' because Geant4 is US-based and
+uses those standards). Composite materials can have
+whatever name you want, but I would recommend using
+names that are coloquially understandable, like how we
+use "glue" instead of listing the chemical formula.
+
+-->
 
 <element Z="1" formula="H" name="H">
-  <atom type="A" unit="g/mol" value="1.00794"/>
+  <atom type="A" unit="g/mol" value="1.00782"/>
 </element>
 <element Z="6" formula="C" name="C">
   <atom type="A" unit="g/mol" value="12.0107"/>
@@ -11,18 +41,108 @@
 <element Z="8" formula="O" name="O">
   <atom type="A" unit="g/mol" value="15.9994"/>
 </element>
+<element Z="11" formula="Na" name="Na">
+  <atom type="A" unit="g/mol" value="22.9898"/>
+</element>
+<element Z="13" formula="Al" name="Al">
+  <atom type="A" unit="g/mol" value="26.982"/>
+</element>
+<element Z="14" formula="Si" name="Si">
+  <atom type="A" unit="g/mol" value="28.0854"/>
+</element>
 <element Z="18" formula="Ar" name="Ar">
   <atom type="A" unit="g/mol" value="39.9477"/>
 </element>
+<element Z="20" formula="Ca" name="Ca">
+  <atom type="A" unit="g/mol" value="40.08"/>
+</element>
+<element Z="25" formula="Mn" name="Mn">
+  <atom type="A" unit="g/mol" value="54.938"/>
+</element>
+<element Z="26" formula="Fe" name="Fe">
+  <atom type="A" unit="g/mol" value="55.845"/>
+</element>
+<element Z="29" formula="Cu" name="Cu">
+  <atom type="A" unit="g/mol" value="63.546"/>
+</element>           
+<element Z="39" formula="Y" name="Y">
+  <atom type="A" unit="g/mol" value="88.906"/>
+</element>
+<element Z="71" formula="Lu" name="Lu">
+  <atom type="A" unit="g/mol" value="174.967"/>
+</element>           
 <element Z="74" formula="W" name="W">
   <atom type="A" unit="g/mol" value="183.842"/>
 </element>           
-<element name="Lu" formula="Lu" Z="71">
-  <atom value="174.9668" unit="g/mole"/>
-</element>
-<element name="Y" formula="Y" Z="39">
-  <atom value="88.90584" unit="g/mole"/>
-</element>
+
+<material name="Hydrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="13.6"/>
+  <D unit="g/cm3" value="0.0000899"/>
+  <fraction n="1" ref="H"/>
+</material>
+<material name="Carbon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="81"/>
+  <D unit="g/cm3" value="1.99999894768203"/>
+  <fraction n="1" ref="C"/>
+</material>
+<material name="Nitrogen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="82.0"/>
+  <D unit="g/cm3" value="0.00125"/>
+  <fraction n="1" ref="N"/>
+</material>
+<material name="Oxygen" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="95.0"/>
+  <D unit="g/cm3" value="0.001429"/>
+  <fraction n="1" ref="O"/>
+</material>
+<material name="Aluminum" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="166"/>
+  <D unit="g/cm3" value="2.699"/>
+  <fraction n="1" ref="Al"/>
+</material>
+<material name="Silicon" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="173"/>
+  <D unit="g/cm3" value="2.32999877404956"/>
+  <fraction n="1" ref="Si"/>
+</material>
+<material name="Argon" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="188"/>
+  <D unit="g/cm3" value="0.00178"/>
+  <fraction n="1" ref="Ar"/>
+</material>
+<material name="Iron" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="286.0"/>
+  <D unit="g/cm3" value="7.874"/>
+  <fraction n="1" ref="Fe"/>
+</material>
+<material name="Copper" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="322"/>
+  <D unit="g/cm3" value="8.96"/>
+  <fraction n="1" ref="Cu"/>
+</material>
+<material name="Tungsten" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="727.0"/>
+  <D unit="g/cm3" value="19.25"/>
+  <fraction n="1" ref="W"/>
+</material>
+
+
+<material name="Vacuum" state="gas">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="19.2"/>
+  <D unit="g/cm3" value="9.99999473841014e-09"/>
+  <fraction n="1" ref="H"/>
+</material>
 <material name="Air" state="gas">
   <MEE unit="eV" value="85.643664635028"/>
   <D unit="g/cm3" value="0.00119999936860922"/>
@@ -30,34 +150,102 @@
   <fraction n="0.234" ref="O"/>
   <fraction n="0.012" ref="Ar"/>
 </material>
-<material name="Carbon" state="solid">
+<material name="FR4" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="201.221278976803"/>
+  <D unit="g/cm3" value="5.68"/>
+  <fraction n="0.5"                ref="Cu"/>
+  <fraction n="0.22990022990023"   ref="O"/>
+  <fraction n="0.0482205482205482" ref="Na"/>
+  <fraction n="0.168276668276668"  ref="Si"/>
+  <fraction n="0.0536025536025536" ref="Ca"/>
+</material>
+<material name="Glue" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="73.3297495741215"/>
+  <D unit="g/cm3" value="0.845"/>
+  <fraction n="0.84491305" ref="C"/>
+  <fraction n="0.042542086" ref="H"/>
+  <fraction n="0.11254487" ref="O"/>
+</material>
+<!-- 
+     carbon+epoxy composite material for cooling plane 
+     
+     - taking the Epoxy mixture from the PDG values for
+     Epotek-301
+     https://pdg.lbl.gov/2022/AtomicNuclearProperties/HTML/Epotek-301-1.html
+     - the MEE value is pretty much made up at this point,
+     assuming it is the same as pure carbon which seems
+     to be an ok assumption since a majority of the epoxy
+     is carbon as well
+     - the epoxy to C-fiber ratio is 0.955 _by weight_
+     
+     Fractions calculated by doing
+     C = 1+PDGFrac / 1.955
+     H = PDGFrac / 1.955
+     O = PDGFrac / 1.955
+     N = PDGFrac / 1.955
+     where PDGFrac is that material's mass fraction in the PDG
+     material linked above which we convert to molar fraction
+     by converting each fraction to moles individually and then
+     dividing by the sum.
+-->
+<material name="CarbonEpoxyComposite" state="solid">
+  <T unit="K" value="293.15"/>
   <MEE unit="eV" value="81"/>
-  <D unit="g/cm3" value="1.99999894768203"/>
-  <fraction n="1" ref="C"/>
+  <D unit="g/cm3" value="1.439"/>
+  <fraction n="0.624883102" ref="C"/>
+  <fraction n="0.308001109" ref="H"/>
+  <fraction n="0.064281977" ref="O"/>
+  <fraction n="0.002833811" ref="Air"/>
 </material>
-<element Z="14" formula="Si" name="Si">
-  <atom type="A" unit="g/mol" value="28.0854"/>
-</element>
-<material name="Silicon" state="solid">
-  <MEE unit="eV" value="173"/>
-  <D unit="g/cm3" value="2.32999877404956"/>
-  <fraction n="1" ref="Si"/>
+<material name="Steel" state="solid">
+  <T unit="K" value="293.15"/>
+  <D unit="g/cm3" value="7.87"/>
+  <fraction n="0.9843" ref="Fe"/>
+  <fraction n="0.014" ref="Mn"/>
+  <fraction n="0.0017" ref="C"/>
 </material>
-<material name="Vacuum" state="gas">
-  <MEE unit="eV" value="19.2"/>
-  <D unit="g/cm3" value="9.99999473841014e-09"/>
-  <fraction n="1" ref="H"/>
+<material name="Scintillator" state="solid">
+  <T unit="K" value="293.15"/>
+  <MEE unit="eV" value="64.7494480275643"/>
+  <D unit="g/cm3" value="1.032"/>
+  <fraction n="0.91512109"  ref="C"/>
+  <fraction n="0.084878906" ref="H"/>
 </material>
-<material name="AcrylicPMMA">
-  <D type="density" value="1.19" unit="g/cm3"/>
-  <composite n="5" ref="C"/>
-  <composite n="8" ref="H"/>
-  <composite n="2" ref="O"/>
+<material name="Polyvinyltoluene">
+  <D type="density" value="1.023" unit="g/cm3"/>
+  <!--Vinyltoluene chemical formula is C9H10-->
+  <composite n="9" ref="C"/>
+  <composite n="10" ref="H"/>
 </material>
+<material name="AcrylicPMMA" state="solid">
+  <MEE unit="eV" value="74.0"/>
+  <D unit="g/cm3" value="1.19"/>
+  <fraction n="0.534" ref="H"/>
+  <fraction n="0.333" ref="C"/>	
+  <fraction n="0.133" ref="O"/>
+</material>
+    <!-- LYSO target -->
+    <!--
+      Molar mass calculations:
+    - Lu: 1.86 × 174.967 = 325.44 g/mol
+    - Y: 0.2 × 88.906 = 17.78 g/mol
+    - Si: 1 × 28.085 = 28.09 g/mol
+    - O: 5 × 15.999 = 80.00 g/mol
+    - Total molar mass: 325.44 + 17.78 + 28.09 + 80.00 = 451.31 g/mol
+
+    Mass fraction calculations:
+    - Lu fraction: 325.44 / 451.31 = 0.7211
+    - Y fraction: 17.78 / 451.31 = 0.0394
+    - Si fraction: 28.09 / 451.31 = 0.0623
+    - O fraction: 80.00 / 451.31 = 0.1772
+    -->
 <material formula="Lu1.86Y0.2SiO5" name="LYSO" >
-    <D value="7.1" unit="g/cm3" />
-    <fraction n="0.7211" ref="Lu" />
-    <fraction n="0.0394" ref="Y"  />
-    <fraction n="0.0623" ref="Si" />
-    <fraction n="0.1772" ref="O"  />
+  <D value="7.1" unit="g/cm3" />
+  <fraction n="0.7211" ref="Lu" />
+  <fraction n="0.0394" ref="Y"  />
+  <fraction n="0.0623" ref="Si" />
+  <fraction n="0.1772" ref="O"  />
 </material>
+

--- a/Detectors/data/ldmx-reduced-v3/recoil.gdml
+++ b/Detectors/data/ldmx-reduced-v3/recoil.gdml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
 ]>
 <gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
       xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
@@ -70,9 +69,8 @@
                                                       stereo_angle
                                                      -stereo_angle" />
   </define>
-  <materials> 
-    &materials;
-  </materials>
+
+  
   <solids>
     <box lunit="mm" name="recoil_l14_active_sensor_box" 
          x="si_large_active_sensor_dx" y="si_large_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-reduced-v3/scoring_planes.gdml
+++ b/Detectors/data/ldmx-reduced-v3/scoring_planes.gdml
@@ -137,13 +137,7 @@
 
   </define>
 
-  <materials>
-    <material name="Vacuum" Z="1" state="gas">
-      <D unit="g/cm3" value="1e-12"/>
-      <atom unit="g/mole" value="1" />
-    </material> 
-  </materials>
-
+  
   <solids>
     <box name="world_box" x="world_dim" y="world_dim" z="world_dim"/>
 
@@ -170,7 +164,7 @@
       <volume name="sp_target">
         <materialref ref="Vacuum" />
         <solidref ref="sp_target_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume> 
     </loop>
 
@@ -183,7 +177,7 @@
       <volume name="sp_trigScint">
         <materialref ref="Vacuum" />
         <solidref ref="sp_trigscint_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume> 
     </loop>
 
@@ -192,7 +186,7 @@
       <volume name="sp_recoil"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_recoil_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume> 
     </loop> 
 
@@ -200,17 +194,17 @@
       <volume name="sp_ecal_front_back"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_front_back_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume>  
       <volume name="sp_ecal_top_bot"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_top_bot_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume>
       <volume name="sp_ecal_left_right"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_ecal_left_right_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume> 
     </loop>
 
@@ -218,17 +212,17 @@
       <volume name="sp_hcal_front_back"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_front_back_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume>  
       <volume name="sp_hcal_top_bot"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_top_bot_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume>
       <volume name="sp_hcal_left_right"> 
         <materialref ref="Vacuum" />
         <solidref ref="sp_hcal_left_right_box" />
-        <auxiliary auxtype="VisAttributes" auxvalue="SpVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="Invisible"/>
       </volume> 
     </loop>
 
@@ -300,7 +294,7 @@
   </structure>
 
   <userinfo>
-    <auxiliary auxtype="VisAttributes" auxvalue="SpVis">
+    <auxiliary auxtype="VisAttributes" auxvalue="Invisible">
       <auxiliary auxtype="R" auxvalue="0.0"/>
       <auxiliary auxtype="G" auxvalue="0.0"/>
       <auxiliary auxtype="B" auxvalue="1.0"/>

--- a/Detectors/data/ldmx-reduced-v3/tagger.gdml
+++ b/Detectors/data/ldmx-reduced-v3/tagger.gdml
@@ -2,7 +2,6 @@
 
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
-<!ENTITY materials SYSTEM "materials.gdml">
 ]>
 <gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML" 
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
@@ -46,9 +45,8 @@
   
   
   </define>
-  <materials> 
-    &materials;
-  </materials>
+
+
   <solids>
     <box lunit="mm" name="tagger_active_sensor_box" 
        x="si_active_sensor_dx" y="si_active_sensor_dy" z="si_sensor_thickness"/>

--- a/Detectors/data/ldmx-reduced-v3/target.gdml
+++ b/Detectors/data/ldmx-reduced-v3/target.gdml
@@ -34,34 +34,12 @@
     <box lunit="mm" name="lp3_bar_box"     x="trigger_bar_dx" y="lp_bar_dy"      z="trigger_pad_bar_thickness" />
   </solids>
 
-  <materials>
-    <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
-
-    <material formula="Lu1.86Y0.2SiO5" name="LYSO">
-      <D value="7.1" unit="g/cm3" />
-      <fraction n="0.7211" ref="Lu" />
-      <fraction n="0.0394" ref="Y"  />
-      <fraction n="0.0623" ref="Si" />
-      <fraction n="0.1772" ref="O"  />
-    </material>
-
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
-  </materials>
-
   <structure>
     <!-- Single LYSO bar -->
     <volume name="target">
       <materialref ref="LYSO"/>
       <solidref ref="target_bar"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TargetVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="Target"/>
       <auxiliary auxtype="Region" auxvalue="target"/>
     </volume>
@@ -101,7 +79,7 @@
     <volume name="lvTarget">
       <materialref ref="Air"/>
       <solidref ref="target_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TargetVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="Target"/>
       <auxiliary auxtype="Region" auxvalue="target"/>
 
@@ -122,7 +100,7 @@
     <volume name="lyso_lp_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="lp3_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="LightPipe"/>
     </volume>
 
@@ -130,7 +108,7 @@
     <volume name="trigger_pad3_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
       <!-- keep or drop; not critical -->
       <auxiliary auxtype="Region" auxvalue="trig_scint"/>
@@ -139,7 +117,7 @@
     <volume name="lp_pad3_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="lp3_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="LightPipe"/>
       <auxiliary auxtype="Region" auxvalue="trig_scint"/>
     </volume>

--- a/Detectors/data/ldmx-reduced-v3/trig_scint.gdml
+++ b/Detectors/data/ldmx-reduced-v3/trig_scint.gdml
@@ -24,36 +24,19 @@
   
   </solids>
 
-  <materials>
-
-    <material name="Vacuum" state="gas">
-      <MEE unit="eV" value="19.2"/>
-      <D unit="g/cm3" value="9.99999473841014e-09"/>
-      <fraction n="1" ref="H"/>
-    </material>
-    
-    <!-- Scintillator -->
-    <material name="Polyvinyltoluene">
-      <D type="density" value="1.023" unit="g/cm3"/>
-      <composite n="27" ref="C"/>
-      <composite n="30" ref="H"/>
-    </material>
-
-  </materials>
-
   <structure>
 
     <volume name="trigger_pad2_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
     <volume name="trigger_pad1_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
 
@@ -61,14 +44,14 @@
     <volume name="lp_pad2_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="light_pipe_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem"       auxvalue="LightPipe"/>
     </volume>
 
     <volume name="lp_pad1_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="light_pipe_bar_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem"       auxvalue="LightPipe"/>
     </volume>
 

--- a/Detectors/data/ldmx-reduced-v3/visattributes.gdml
+++ b/Detectors/data/ldmx-reduced-v3/visattributes.gdml
@@ -1,0 +1,289 @@
+<!-- define vis attributes -->
+
+<!--
+There are 3 categories of visattributes included here: invisible options,
+options by region, and options by material. To switch between definition
+by region and definition by material, set the optional 'ColorMode' tag
+in detector.gdml, in the userinfo, before loading this accessory file.
+The default is definition by region, or invisible.
+
+For the material visattributes, I arbitrarily assigned object colors
+based on my imagination. These can be changed as the user pleases.
+I'd recommend a free online RGB color picker to help you select the
+perfect color.
+-->
+
+<!--Styles of invisible (applicable in many scenarios)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleNoDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="NoDau">
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+    </auxiliary>  
+
+    <!--Visattributes by region (applies to all volumes in the region)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.6"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>  
+    <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.3"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TaggerRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.8"/>
+      <auxiliary auxtype="G" auxvalue="0.8"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="RecoilRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.9"/>
+      <auxiliary auxtype="G" auxvalue="0.8"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="true"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="MagnetRegionVis">
+      <auxiliary auxtype="R" auxvalue="0.75"/>
+      <auxiliary auxtype="G" auxvalue="0.75"/>
+      <auxiliary auxtype="B" auxvalue="0.75"/>
+      <auxiliary auxtype="A" auxvalue="0.8"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SpVis">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="2.0"/>
+    </auxiliary>
+
+
+    <!--Visattributes by material-->
+    <!--Only solid materials get a color and are visible-->
+    <!--'Unimportant' materials are semi-transparent-->
+
+    <auxiliary auxtype="VisAttributes" auxvalue="CarbonMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.1"/>
+      <auxiliary auxtype="G" auxvalue="0.1"/>
+      <auxiliary auxtype="B" auxvalue="0.1"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.9"/>
+      <auxiliary auxtype="G" auxvalue="0.9"/>
+      <auxiliary auxtype="B" auxvalue="0.9"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="IronMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.3"/>
+      <auxiliary auxtype="G" auxvalue="0.3"/>
+      <auxiliary auxtype="B" auxvalue="0.3"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="CopperMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.741"/>
+      <auxiliary auxtype="G" auxvalue="0.4"/>
+      <auxiliary auxtype="B" auxvalue="0.114"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="0.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    
+    <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.075"/>
+      <auxiliary auxtype="G" auxvalue="0.651"/>
+      <auxiliary auxtype="B" auxvalue="0.2"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="1.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.5"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="CarbonEpoxyCompositeMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="1.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.5"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="SteelMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.71"/>
+      <auxiliary auxtype="G" auxvalue="0.737"/>
+      <auxiliary auxtype="B" auxvalue="0.82"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.9"/>
+      <auxiliary auxtype="B" auxvalue="0.8"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis">
+      <auxiliary auxtype="R" auxvalue="0.949"/>
+      <auxiliary auxtype="G" auxvalue="0.902"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis">
+      <auxiliary auxtype="R" auxvalue="1.0"/>
+      <auxiliary auxtype="G" auxvalue="0.89"/>
+      <auxiliary auxtype="B" auxvalue="0.62"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    
+    <!--Historic visattributes definitions (unsure if needed)-->
+    <auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame">
+      <auxiliary auxtype="R" auxvalue="0.6"/>
+      <auxiliary auxtype="G" auxvalue="0.6"/>
+      <auxiliary auxtype="B" auxvalue="0.6"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="BlueWireFrame">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="1.0"/>
+      <auxiliary auxtype="Style" auxvalue="wireframe"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="BlueSolid">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.4"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="true"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>
+    </auxiliary>
+    <auxiliary auxtype="VisAttributes" auxvalue="Invisible">
+      <auxiliary auxtype="R" auxvalue="0.0"/>
+      <auxiliary auxtype="G" auxvalue="0.0"/>
+      <auxiliary auxtype="B" auxvalue="1.0"/>
+      <auxiliary auxtype="A" auxvalue="0.4"/>
+      <auxiliary auxtype="Style" auxvalue="solid"/>
+      <auxiliary auxtype="DaughtersInvisible" auxvalue="false"/>
+      <auxiliary auxtype="Visible" auxvalue="false"/>
+      <auxiliary auxtype="LineWidth" auxvalue="1.0"/>      
+    </auxiliary>


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
Following the successful inclusion of the tracking system in the slice test geometry, as outlined in the original plan for #1880, I've tidied up the GDML files to match the reworked format. All materials definitions are standardized and collected in one place, as are all visattributes, and the visattributes have been moved to a separate GDML file. The color mode tag has been included and set to region-by-region coloring. God willing and the creek don't rise, this is the last time we'll have to do this cleanup, and the tidiness should propagate through future geometry versions.

Work is not done on the visattributes side of things; they aren't properly implemented for nearly any volume. However I would like to take care of visattributes for all of the volumes at once - just as soon as we have a full slice test geometry.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
Passed the `reduced_ldmx` CI test and successfully rendered with `g4-vis`