### PR TITLE
TS Track Producer Update

### DIFF
--- a/TrigScint/exampleConfigs/runTSvert.py
+++ b/TrigScint/exampleConfigs/runTSvert.py
@@ -77,7 +77,7 @@ count = ElectronCounter(
     input_pass_name="",
 )
 
-p.logger.term_level = 1
+p.logger.term_level = 0
 
 p.sequence.extend([
         *ts_digis,

--- a/TrigScint/exampleConfigs/runTSvert.py
+++ b/TrigScint/exampleConfigs/runTSvert.py
@@ -1,3 +1,4 @@
+#Ricardo,05-26
 from LDMX.Framework import ldmxcfg
 
 p = ldmxcfg.Process('test')

--- a/TrigScint/exampleConfigs/runTSvert.py
+++ b/TrigScint/exampleConfigs/runTSvert.py
@@ -1,0 +1,87 @@
+from LDMX.Framework import ldmxcfg
+
+p = ldmxcfg.Process('test')
+
+from LDMX.SimCore import simulator as sim
+
+my_sim = sim.Simulator( "my_sim" )
+det = 'ldmx-vertTS-v14-8gev'
+my_sim.set_detector(det, include_scoring_planes_minimal = True )
+from LDMX.SimCore import generators as gen
+
+my_sim.generators.append( gen.single_8gev_e_upstream_tagger() )
+my_sim.description = 'Basic test Simulation'
+
+p.sequence = [ my_sim ]
+
+import os
+import sys
+
+p.run = int(sys.argv[1])
+p.max_events = int(sys.argv[2])
+p.output_files = ['events.root']
+
+
+p.histogram_file = 'hist.root'
+
+# Load the full tracking sequence
+import LDMX.Ecal.digi as ecal_digi
+import LDMX.Ecal.ecal_clusters as ecal_cluster
+
+# Load the ECAL modules
+import LDMX.Ecal.ecal_geometry
+import LDMX.Ecal.ecal_hardcoded_conditions
+import LDMX.Ecal.vetos as ecal_vetos
+import LDMX.Hcal.digi as hcal_digi_and_reco
+
+# Load the HCAL modules
+import LDMX.Hcal.hcal_geometry
+import LDMX.Hcal.hcal_hardcoded_conditions
+
+# Load the TS modules
+from LDMX.TrigScint.trig_scint import (
+        TrigScintClusterProducer,
+        TrigScintDigiProducer,
+        trig_scint_track
+)
+
+
+ts_digis = [
+        TrigScintDigiProducer.pad1(),
+        TrigScintDigiProducer.pad2(),
+        TrigScintDigiProducer.pad3(),
+        ]
+
+ts_clusters = [
+        TrigScintClusterProducer.pad1(),
+        TrigScintClusterProducer.pad2(),
+        TrigScintClusterProducer.pad3(),
+        ]
+    
+trig_scint_track.delta_vert_max=1. #0 or 1
+#0 creates tracks with the same centroid
+#1 allows for tracks with a deviation in the last pad
+# one centroid to the left or to the right
+
+# Load the DQM modules
+from LDMX.DQM import dqm
+
+# Load electron counting and trigger
+from LDMX.Recon.electron_counter import ElectronCounter
+
+
+
+count = ElectronCounter(
+    simulated_electron_number=1,
+    instance_name="ElectronCounter",
+    input_pass_name="",
+)
+
+p.logger.term_level = 1
+
+p.sequence.extend([
+        *ts_digis,
+        *ts_clusters,
+        trig_scint_track,
+        count, 
+        ])

--- a/TrigScint/exampleConfigs/runTSvert.py
+++ b/TrigScint/exampleConfigs/runTSvert.py
@@ -64,6 +64,13 @@ trig_scint_track.delta_vert_max=1. #0 or 1
 #1 allows for tracks with a deviation in the last pad
 # one centroid to the left or to the right
 
+# In order to run this geometry, one have 
+# to manually define these quantities
+trig_scint_track.number_horizontal_bars = 16
+trig_scint_track.horizontal_bar_gap = 2.1
+trig_scint_track.number_vertical_bars = 8 
+trig_scint_track.vertical_bar_gap = 0.1
+
 # Load the DQM modules
 from LDMX.DQM import dqm
 

--- a/TrigScint/include/TrigScint/TrigScintTrackProducer.h
+++ b/TrigScint/include/TrigScint/TrigScintTrackProducer.h
@@ -44,6 +44,9 @@ class TrigScintTrackProducer : public framework::Producer {
   // in the next pad tolerated to form a track
   double max_delta_{0.};
 
+  double max_delta_vert{0.}; 
+  double bar_length_y_{30.}; 
+
   // producer specific verbosity
   int verbose_{0};
 

--- a/TrigScint/python/trig_scint.py
+++ b/TrigScint/python/trig_scint.py
@@ -370,8 +370,9 @@ class TrigScintClusterProducer(Processor):
 @processor("trigscint::TrigScintTrackProducer", "TrigScint")
 class TrigScintTrackProducer(Processor):
     """Configuration for track producer for Trigger Scintillators"""
-
+    horizontal_bar_length: float = 30.
     delta_max: float = 0.75
+    delta_vert_max: float = 0.
     tracking_threshold: float = 0.0
     seeding_collection: str = "TriggerPad1Clusters"
     further_input_collections: list[str] = [

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -126,31 +126,6 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
                     << input_collections_.at(1) << " with "
                     << clusters_pad2.size() << " entries.";
   }
-        ////////////////////////// Ricardo
-  if (verbose_ > 1) {
-
-    ldmx_log(debug) << "max_delta = " << max_delta_;
-    
-    
-    auto print_cluster = [&](const std::string& name,
-                            const ldmx::TrigScintCluster& cl) {
-      ldmx_log(debug) << name
-                      << " c=" << cl.getCentroid()
-                      << " cx=" << cl.getCentroidX()
-                      << " cy=" << cl.getCentroidY()
-                      << " type=" << (cl.getCentroid() >= vert_bar_start_idx_ ? "VERT" : "HORIZ");
-    };
-
-    ldmx_log(debug) << "=== SEEDS ===";
-    for (const auto& cl : seeds) print_cluster("seed", cl);
-
-    ldmx_log(debug) << "=== PAD1 ===";
-    for (const auto& cl : clusters_pad1) print_cluster("pad2", cl);
-
-    ldmx_log(debug) << "=== PAD2 ===";
-    for (const auto& cl : clusters_pad2) print_cluster("pad3", cl);
-  }
-                //////////////////////////////////////
   std::vector<ldmx::TrigScintTrack> cleaned_tracks;
   std::vector<ldmx::TrigScintTrack> cleaned_tracks_y;
   std::vector<ldmx::TrigScintTrack> cleaned_tracks_x;

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -356,16 +356,13 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
               ((track.getCentroid()>=vert_bar_start_idx_) && ((consts_1[1].getCentroidX() == consts_2[1].getCentroidX()) ||
               (consts_1[2].getCentroidX() == consts_2[2].getCentroidX()) 
               || (consts_1[0].getCentroidX() == consts_2[0].getCentroidX())))) { //and vertical bars
-                 // we have overlap downstream of the
-            // seeding pad. probably, one cluster
-            // in seeding pad is noise
 
             if (verbose_ > 1) {
               ldmx_log(debug) << "Found overlap! Tracks at index " << idx
                               << " and " << idx_comp;
               ldmx_log(trace) << tracks_.at(idx);
               ldmx_log(trace) << tracks_.at(idx_comp);
-            } // 110 0.67 112 1.33
+            }
 
             if (((fabs((tracks_.at(idx)).getResidualX() -(tracks_.at(idx_comp)).getResidualX()))< 0.01) //it should be equal 
             && (track.getCentroid()>=vert_bar_start_idx_)){ //specific case for the vertical bars
@@ -686,7 +683,7 @@ void TrigScintTrackProducer::matchXYTracks(
         sx1 = x_conv_factor_ / 2.;  // 1 bar width
         sx2 = sx1;
         x = (x1 + x2) / 2.;
-        sx = fabs(x1 - x2) / 2;  // Ricardo: REMOVE the *x_conv_factor -- ,rely on x precision being one single pad width
+        sx = fabs(x1 - x2) / 2;  // rely on x precision being one single pad width
         if (verbose_)
           ldmx_log(debug) << "\t\t -- 2 x in quad: setting y track x "
                              "coordinate to midpoint";
@@ -697,7 +694,9 @@ void TrigScintTrackProducer::matchXYTracks(
       x = x0;
       sx = sx0;
       if (verbose_)
-        ldmx_log(debug) << "\t\t\t no x info in quad " << (*yitr).first
+        ldmx_log(debug) << "\t\t\t  currently no x info assigned in ambiguous case of "
+                        << n_xin_quad 
+                        << "vertical bar track candidates in quad " << (*yitr).first
                         << "; will set x to middle of pad, pad half-width as "
                            "precision: set (x, sx)=("
                         << x << ", " << sx << ")";
@@ -751,7 +750,7 @@ void TrigScintTrackProducer::matchXYTracks(
       if (sy1 == 0) sy1 = 1. / 2 * y_conv_factor_;
       if (sy2 == 0) sy2 = 1. / 2 * y_conv_factor_;
       y = (y1 + y2) / 2.;
-      sy = fabs(y1 - y2) / 2 ; //Ricardo: remove y_conv_factor
+      sy = fabs(y1 - y2) / 2 ; 
       if (verbose_)
         ldmx_log(debug)
             << "\t\t -- 2 y in quad: setting x track y coordinate to midpoint";
@@ -761,7 +760,7 @@ void TrigScintTrackProducer::matchXYTracks(
       if (n_xin_quad == 0){
         if (verbose_)
           ldmx_log(debug)
-            << "\t\t -- No x tracks but 2 y tracks in quad: unsual behaviour";
+            << "\t\t -- No x tracks but 2 y tracks in quad: unusual behaviour";
       }
       auto yidx1 = y_idx_quad_map.lower_bound((*yitr).first);
       auto yidx2 = y_idx_quad_map.upper_bound((*yitr).first);

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -1,7 +1,7 @@
 #include "TrigScint/TrigScintTrackProducer.h"
 
 #include <iterator>  // std::next
-#include <map>
+#include <map> //Ricardo,05-26
 
 namespace trigscint {
 

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -628,7 +628,8 @@ void TrigScintTrackProducer::matchXYTracks(
   // this should be half the pad... could also set
   // it to full beam spot width
   float sx0 = fabs(x_start_); 
-  float sx0_=fabs(bar_length_y_/2); // When there are no hits along the vertical bars
+  float sx0_vert=fabs(bar_length_y_/2); // When there are no hits 
+  // along the vertical bars
 
   // y_start_ is half the pad, so this should be half a quadrant
   float sy0 = fabs(y_start_) / 4.;
@@ -651,7 +652,7 @@ void TrigScintTrackProducer::matchXYTracks(
     if (n_xin_quad == 0) {  // then there's no hope of setting a better x here
       // just use the beam spot width... and center of pad
       x = x0;
-      sx = sx0_;
+      sx = sx0_vert;
       if (verbose_)
         ldmx_log(debug) << "\t\t\t no x info in quad " << (*yitr).first
                         << "; will set x to middle of pad, pad half-width as "

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -1,7 +1,8 @@
 #include "TrigScint/TrigScintTrackProducer.h"
+//Ricardo,05-26
 
 #include <iterator>  // std::next
-#include <map> //Ricardo,05-26
+#include <map> 
 
 namespace trigscint {
 

--- a/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
+++ b/TrigScint/src/TrigScint/TrigScintTrackProducer.cxx
@@ -7,7 +7,9 @@ namespace trigscint {
 
 void TrigScintTrackProducer::configure(framework::config::Parameters &ps) {
   max_delta_ = ps.get<double>(
-      "delta_max");  // max distance to consider adding in a cluster to track
+      "delta_max");  // max distance to consider adding in a cluster to track   
+  max_delta_vert= ps.get<double>("delta_vert_max"); //max distance between pad 1/2 and 3 along the x axis 
+  //to consider make a track using the vertical bars 
   seeding_collection_ = ps.get<std::string>(
       "seeding_collection");  // probably tagger pad, "TriggerPadTagClusters"
   input_collections_ = ps.get<std::vector<std::string>>(
@@ -24,6 +26,7 @@ void TrigScintTrackProducer::configure(framework::config::Parameters &ps) {
   bar_width_x_ = ps.get<double>("vertical_bar_width");
   bar_gap_x_ = ps.get<double>("vertical_bar_gap");
   skip_last_ = ps.get<bool>("allow_skip_last_collection");
+  bar_length_y_=ps.get<double>("horizontal_bar_length"); //bar lenght of the horizontal bars
 
   // TO DO: allow any number of input collections
 
@@ -123,7 +126,31 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
                     << input_collections_.at(1) << " with "
                     << clusters_pad2.size() << " entries.";
   }
+        ////////////////////////// Ricardo
+  if (verbose_ > 1) {
 
+    ldmx_log(debug) << "max_delta = " << max_delta_;
+    
+    
+    auto print_cluster = [&](const std::string& name,
+                            const ldmx::TrigScintCluster& cl) {
+      ldmx_log(debug) << name
+                      << " c=" << cl.getCentroid()
+                      << " cx=" << cl.getCentroidX()
+                      << " cy=" << cl.getCentroidY()
+                      << " type=" << (cl.getCentroid() >= vert_bar_start_idx_ ? "VERT" : "HORIZ");
+    };
+
+    ldmx_log(debug) << "=== SEEDS ===";
+    for (const auto& cl : seeds) print_cluster("seed", cl);
+
+    ldmx_log(debug) << "=== PAD1 ===";
+    for (const auto& cl : clusters_pad1) print_cluster("pad2", cl);
+
+    ldmx_log(debug) << "=== PAD2 ===";
+    for (const auto& cl : clusters_pad2) print_cluster("pad3", cl);
+  }
+                //////////////////////////////////////
   std::vector<ldmx::TrigScintTrack> cleaned_tracks;
   std::vector<ldmx::TrigScintTrack> cleaned_tracks_y;
   std::vector<ldmx::TrigScintTrack> cleaned_tracks_x;
@@ -155,11 +182,12 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
           ldmx_log(debug) << "\tGot pad1 cluster with centroid "
                           << cluster1.getCentroid();
         }
-        if (fabs(cluster1.getCentroid() - centroid) < max_delta_ ||
-            (centroid >= vert_bar_start_idx_  // then in vertical bars
-             && seed.getCentroidX() == cluster1.getCentroidX())) {
-          // use geometry y overlap scheme to see if this is really a match in x
-          // should be done in a map
+        if ((fabs(cluster1.getCentroid() - centroid) < max_delta_ &&
+            centroid < vert_bar_start_idx_) ||
+            (centroid >= vert_bar_start_idx_ && cluster1.getCentroid() >= vert_bar_start_idx_ &&
+            seed.getCentroidX() == cluster1.getCentroidX())) { 
+            // use geometry y overlap scheme to see if this is really a match in x
+            // should be done in a map
 
           if (centroid >= vert_bar_start_idx_ &&
               seed.getCentroidY() < cluster1.getCentroidY()) {
@@ -191,11 +219,12 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
                               << cluster2.getCentroid();
             }
 
-            if (fabs(cluster2.getCentroid() - centroid) < max_delta_ ||
-                (centroid >= vert_bar_start_idx_  // then in vertical bars
-                 && seed.getCentroidX() == cluster2.getCentroidX())) {
-              // use geometry y overlap scheme to see if this is really a match
-              // in x
+            if ((fabs(cluster2.getCentroid() - centroid) < max_delta_ &&
+                centroid < vert_bar_start_idx_) ||
+                (centroid >= vert_bar_start_idx_ && cluster2.getCentroid() >= vert_bar_start_idx_ &&
+                fabs(seed.getCentroidX() - cluster2.getCentroidX()) <= max_delta_vert)) { 
+                        // use geometry y overlap scheme to see if this is really a match
+                    // in x
 
               if (centroid >= vert_bar_start_idx_ &&
                   (seed.getCentroidY() < cluster2.getCentroidY() ||
@@ -242,11 +271,11 @@ void TrigScintTrackProducer::produce(framework::Event &event) {
           }
 
         }  // if possible (x,)y match in pad1
-        /*
-//same here
-if (madeTrack)
-break;
-*/
+                /*
+        //same here
+        if (madeTrack)
+        break;
+        */
 
       }  // over clusters in pad1
 
@@ -327,8 +356,11 @@ break;
 
         // no need to start pulling constituents from tracks that are
         // ridiculously far apart
-        if (fabs(track.getCentroid() - next_track.getCentroid()) <
-            3 * max_delta_) {
+        if (((fabs(track.getCentroid() - next_track.getCentroid()) <
+            3 * max_delta_) && (track.getCentroid()<vert_bar_start_idx_)) //for the horizontal bars
+            || ((fabs(track.getCentroidX() - next_track.getCentroidX()) < 2*max_delta_vert)
+          && (track.getCentroidY() == next_track.getCentroidY()) && (track.getCentroid()>=vert_bar_start_idx_))) { 
+            //and for the vertical bars, check if they are in the same quad and close enough
           std::vector<ldmx::TrigScintCluster> consts_1 =
               track.getConstituents();
           std::vector<ldmx::TrigScintCluster> consts_2 =
@@ -341,11 +373,14 @@ break;
                 << ", respectively. ";
           // let's do "if either cluster is shared" right now... but could also
           // have it settable to use a stricter cut: an AND
-          if (consts_1[1].getCentroid() == consts_2[1].getCentroid() ||
-              (consts_1.size() > 2 && consts_2.size() > 2 &&
-               consts_1[2].getCentroid() ==
-                   consts_2[2]
-                       .getCentroid())) {  // we have overlap downstream of the
+          if (((consts_1[1].getCentroid() == consts_2[1].getCentroid() ||
+              ((consts_1.size() > 2) && (consts_2.size() > 2) &&
+               (consts_1[2].getCentroid() == consts_2[2].getCentroid()))) && (track.getCentroid()<vert_bar_start_idx_)) || 
+               //horizontal bars
+              ((track.getCentroid()>=vert_bar_start_idx_) && ((consts_1[1].getCentroidX() == consts_2[1].getCentroidX()) ||
+              (consts_1[2].getCentroidX() == consts_2[2].getCentroidX()) 
+              || (consts_1[0].getCentroidX() == consts_2[0].getCentroidX())))) { //and vertical bars
+                 // we have overlap downstream of the
             // seeding pad. probably, one cluster
             // in seeding pad is noise
 
@@ -354,10 +389,13 @@ break;
                               << " and " << idx_comp;
               ldmx_log(trace) << tracks_.at(idx);
               ldmx_log(trace) << tracks_.at(idx_comp);
-            }
+            } // 110 0.67 112 1.33
 
-            if ((tracks_.at(idx)).getResidual() <
-                (tracks_.at(idx_comp)).getResidual()) {
+            if (((fabs((tracks_.at(idx)).getResidualX() -(tracks_.at(idx_comp)).getResidualX()))< 0.01) //it should be equal 
+            && (track.getCentroid()>=vert_bar_start_idx_)){ //specific case for the vertical bars
+              continue; //currently we can't do more here
+            } else if (((tracks_.at(idx)).getResidual() <(tracks_.at(idx_comp)).getResidual() && (track.getCentroid()<vert_bar_start_idx_)) ||
+            ((tracks_.at(idx)).getResidualX() <(tracks_.at(idx_comp)).getResidualX() && (track.getCentroid()>=vert_bar_start_idx_))) {
               // next track (lower index) is a worse choice, remove its flag for
               // keeping
               keep_indices.at(idx_comp) = 0;
@@ -526,6 +564,17 @@ ldmx::TrigScintTrack TrigScintTrackProducer::makeTrack(
                 ((clusters.at(i)).getCentroid() - centroid);
   residual = sqrt(residual / clusters.size());
 
+
+  float residual_x = 0; //only for the vertical bars
+  if (centroid>=vert_bar_start_idx_) {
+    for (uint i = 0; i < clusters.size(); i++)
+      residual_x += ((clusters.at(i)).getCentroidX() - centroid_x) *
+                ((clusters.at(i)).getCentroidX() - centroid_x);
+    residual_x = sqrt(residual_x / clusters.size());
+  }
+
+
+  tr.setResidualX(residual_x);
   tr.setCentroid(centroid);
   tr.setCentroidX(centroid_x);
   tr.setCentroidY(centroid_y);
@@ -568,25 +617,25 @@ void TrigScintTrackProducer::matchXYTracks(
       if (verbose_)
         ldmx_log(debug) << " --  In matchXYTracks found y track at "
                         << trk.getCentroidY() << "; mapping to quad "
-                        << (int)trk.getCentroidY() / 8 << " with trk index "
+                        << (int)trk.getCentroidY() / (n_bars_y_/2) << " with trk index "
                         << trk_idx;
       // 2. order them... or map them to quadrants. note that there are 2 layers
       // so 2*n_bars_y_/4 channels per quadrant
-      y_quad_map.insert(std::make_pair((int)(trk.getCentroidY() / 8), trk));
+      y_quad_map.insert(std::make_pair((int)(trk.getCentroidY() / (n_bars_y_/2)), trk));
       y_track_map[trk] = trk_idx;
       y_idx_quad_map.insert(
-          std::make_pair((int)(trk.getCentroidY() / 8), trk_idx));
+          std::make_pair((int)(trk.getCentroidY() / (n_bars_y_/2)), trk_idx));
 
     } else {  // 3. get the remaining tracks (from vertical bars) and map them
               // (back) to (middle of) quadrants
-      x_quad_map.insert(std::make_pair((int)(trk.getCentroidY() / 8), trk));
+      x_quad_map.insert(std::make_pair((int)(trk.getCentroidY() / (n_bars_y_/2)), trk));
       x_track_map[trk] = trk_idx;
       x_idx_quad_map.insert(
-          std::make_pair((int)(trk.getCentroidY() / 8), trk_idx));
+          std::make_pair((int)(trk.getCentroidY() / (n_bars_y_/2)), trk_idx));
       if (verbose_)
         ldmx_log(debug) << " --  In matchXYTracks found x track at (x,y) = ("
                         << trk.getCentroidX() << ", " << trk.getCentroidY()
-                        << "); mapping to quad " << (int)trk.getCentroidY() / 8
+                        << "); mapping to quad " << (int)trk.getCentroidY() / (n_bars_y_/2)
                         << " with trk index " << trk_idx;
     }
   }
@@ -602,7 +651,8 @@ void TrigScintTrackProducer::matchXYTracks(
   float x0 = 0;
   // this should be half the pad... could also set
   // it to full beam spot width
-  float sx0 = fabs(x_start_);
+  float sx0 = fabs(x_start_); 
+  float sx0_=fabs(bar_length_y_/2); // When there are no hits along the vertical bars
 
   // y_start_ is half the pad, so this should be half a quadrant
   float sy0 = fabs(y_start_) / 4.;
@@ -615,7 +665,7 @@ void TrigScintTrackProducer::matchXYTracks(
     float y{-9999.}, sy{-9999.}, x{-9999.}, x1{-9999.}, x2{-9999.}, sx1{-9999.},
         sx2{-9999.}, y1{-9999.}, y2{-9999.}, sy1{-9999.}, sy2{-9999.};
     // quad midpoint:
-    float y0 = (*yitr).first * 8 + sy0;
+    float y0 = (((*yitr).first * 8)*y_conv_factor_ )+y_start_+ sy0; 
     float sx = 1. / 2 *
                x_conv_factor_;  // rely on x precision being one single bar
                                 // width; always used unless x is undeterminable
@@ -625,7 +675,7 @@ void TrigScintTrackProducer::matchXYTracks(
     if (n_xin_quad == 0) {  // then there's no hope of setting a better x here
       // just use the beam spot width... and center of pad
       x = x0;
-      sx = sx0;
+      sx = sx0_;
       if (verbose_)
         ldmx_log(debug) << "\t\t\t no x info in quad " << (*yitr).first
                         << "; will set x to middle of pad, pad half-width as "
@@ -659,13 +709,22 @@ void TrigScintTrackProducer::matchXYTracks(
         sx1 = x_conv_factor_ / 2.;  // 1 bar width
         sx2 = sx1;
         x = (x1 + x2) / 2.;
-        sx = fabs(x1 - x2) / 2 *
-             x_conv_factor_;  // rely on x precision being one single pad width
+        sx = fabs(x1 - x2) / 2;  // Ricardo: REMOVE the *x_conv_factor -- ,rely on x precision being one single pad width
         if (verbose_)
           ldmx_log(debug) << "\t\t -- 2 x in quad: setting y track x "
                              "coordinate to midpoint";
       }
     }  // if 2 x tracks in quad
+
+    if (n_xin_quad >= 3) {  // no implementaion made so far
+      x = x0;
+      sx = sx0;
+      if (verbose_)
+        ldmx_log(debug) << "\t\t\t no x info in quad " << (*yitr).first
+                        << "; will set x to middle of pad, pad half-width as "
+                           "precision: set (x, sx)=("
+                        << x << ", " << sx << ")";
+    }  // 3 x tracks in quadrant
 
     // ok! over y:
     // can skip 0 y case by construction
@@ -681,19 +740,21 @@ void TrigScintTrackProducer::matchXYTracks(
         // 4. every quadrant which just has one of each --> done ;
         // b) set the sx, sy of the x track now, using the residuals from the
         // other b1) special case: no x tracks; then x, sx have been set above
-        auto xidx = x_idx_quad_map.find((*yitr).first);
-        auto yidx = y_idx_quad_map.find((*yitr).first);
-        tracks.at((*xidx).second).setPosition(x, y);
-        tracks.at((*xidx).second).setSigmaXY(sx, sy);
-        tracks.at((*yidx).second).setPosition(x, y);
-        tracks.at((*yidx).second).setSigmaXY(sx, sy);
+        if (n_xin_quad==1){
+          auto xidx = x_idx_quad_map.find((*yitr).first);
+          tracks.at((*xidx).second).setPosition(x, y);
+          tracks.at((*xidx).second).setSigmaXY(sx, sy);
+        }
         if (verbose_)
           ldmx_log(debug) << "\t\t\t in quad " << (*yitr).first
                           << ", set (x, y) = (" << x << ", " << y
                           << ") and (sx, sy) = " << sx << ", " << sy << ")";
-        continue;
+      auto yidx = y_idx_quad_map.find((*yitr).first);
+      tracks.at((*yidx).second).setPosition(x, y);
+      tracks.at((*yidx).second).setSigmaXY(sx, sy);
+      continue;
       }
-    }  // 1 y, 0 or 1 x track in quadrant
+    }  // 1 y, 0 or 1 or 3+ x track in quadrant
 
     if (verbose_)
       ldmx_log(debug) << "\t\t in quad " << (*yitr).first
@@ -702,7 +763,7 @@ void TrigScintTrackProducer::matchXYTracks(
 
     if (n_yin_quad == 2) {  // let's start here and see if we can do >= 2 later
       // here one could do sth to avoid checking the other y track again in the
-      // outermost loop over y
+      // outermost loop over y      
       auto yitr1 = y_quad_map.lower_bound((*yitr).first);
       auto yitr2 = y_quad_map.upper_bound((*yitr).first);
       yitr2--;  // back up once
@@ -710,13 +771,31 @@ void TrigScintTrackProducer::matchXYTracks(
       y2 = ((*yitr2).second).getCentroidY() * y_conv_factor_ + y_start_;
       sy1 = ((*yitr1).second).getResidual() * y_conv_factor_;
       sy2 = ((*yitr2).second).getResidual() * y_conv_factor_;
+      if (sy1 == 0) sy1 = 1. / 2 * y_conv_factor_;
+      if (sy2 == 0) sy2 = 1. / 2 * y_conv_factor_;
       y = (y1 + y2) / 2.;
-      sy = fabs(y1 - y2) / 2 * y_conv_factor_;
+      sy = fabs(y1 - y2) / 2 ; //Ricardo: remove y_conv_factor
       if (verbose_)
         ldmx_log(debug)
             << "\t\t -- 2 y in quad: setting x track y coordinate to midpoint";
     }  // 2y in quad
-
+    
+    if ((n_xin_quad == 0 || n_xin_quad >= 3) && (n_yin_quad == 2)) { //not using the X tracks for now for >=3
+      if (n_xin_quad == 0){
+        if (verbose_)
+          ldmx_log(debug)
+            << "\t\t -- No x tracks but 2 y tracks in quad: unsual behaviour";
+      }
+      auto yidx1 = y_idx_quad_map.lower_bound((*yitr).first);
+      auto yidx2 = y_idx_quad_map.upper_bound((*yitr).first);
+      yidx2--;
+      tracks.at((*yidx1).second).setPosition(x, y1);
+      tracks.at((*yidx1).second).setSigmaXY(sx, sy1);
+      tracks.at((*yidx2).second).setPosition(x, y2);
+      tracks.at((*yidx2).second).setSigmaXY(sx, sy2);
+      continue;
+    }
+    
     if (n_yin_quad == 1 &&
         n_xin_quad == 2) {  // don't think we want to experiment with discerning
                             // three overlapping tracks, so not >= 2
@@ -876,5 +955,4 @@ void TrigScintTrackProducer::onProcessEnd() {
 }
 
 }  // namespace trigscint
-
 DECLARE_PRODUCER(trigscint::TrigScintTrackProducer);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

This resolves #2054 .

Besides solving the problems mentioned, I also added an option allowing tracks to be built with a ±1 centroid x difference from pad 1 and 2 (which must have the same centroid x) to pad 3. I also defined residual x, which was previously created but not defined when dealing with tracks with vertical bars.

The problems were the following:
- There was no variable storing the length of one horizontal bar (needed for sx).
- Duplicate track removal was being incorrectly applied for the vertical bars.
- Quads were being created based on the number of horizontal bars from `ldmx-vertTS-v14-8gev`; however, it should use the number of y bars for each specific TS geometry.
- Specific cases were not accounted for when merging tracks (e.g. 0X 2Y track).
- Position and precision values were wrongly defined or not created at all. 

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

Baseline = `ldmx-det-v14-8gev`; Alternative (NC and LC) = `ldmx-vertTS-v14-8gev` (making tracks with the same centroid and allowing a ±1 centroid x difference). 20 000 events.

Y tracks; 1 electron/event; baseline uncertainty is fixed.

<img width="2511" height="2258" alt="TracksY_uncertainty" src="https://github.com/user-attachments/assets/c9aa8b50-52ea-4d5b-9d51-8cd76a324717" />

Y tracks; 2 electrons/event; position now looks alright (note: that first higher bin was already present previously, and it is likely a feature not related to the track producer).

<img width="4224" height="2261" alt="TracksY_position" src="https://github.com/user-attachments/assets/3a66beea-fc42-4ef0-aa48-6189cb14ec64" />

X tracks; 2 electrons/event; position now looks alright (context: for each quad, there is a large peak around the center, since the position is set to the middle of the quad when there are two horizontal track candidates but only one vertical track candidate, and the energy deposit is not enough to consider the possibility of a bar overlap (two hits over the same bar)).

<img width="3877" height="2952" alt="TracksX_position1D" src="https://github.com/user-attachments/assets/2b22b17c-49dd-4439-8446-f378a5f8d3bf" />

Additionally, here are the 2D plots for Y tracks.
1 electron/event
<img width="7371" height="2265" alt="TracksY_position2D" src="https://github.com/user-attachments/assets/fdc17ce1-5caa-4a32-afb3-dd15bf47f95d" />

2 electron/event
<img width="7371" height="2265" alt="TracksY_position2D" src="https://github.com/user-attachments/assets/5e360c45-5299-4a44-b829-b2e7c9e0d598" />

