### PR TITLE
Change the EN config so the threshold is at 100 MeV

### DIFF
--- a/Biasing/python/target.py
+++ b/Biasing/python/target.py
@@ -50,7 +50,7 @@ def electro_nuclear(detector, generator):
     sim.biasing_operators = [bias_operators.ElectroNuclear("target", 1e5)]
 
     # Configure the sequence in which user actions should be called.
-    recoil_thresh = 0.975 * generator.energy * 1000.0
+    recoil_thresh = 0.9875 * generator.energy * 1000.0
     tagger_threshold = 0.95 * generator.energy * 1000.0
     sim.actions.extend(
         [


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
We said we want to study ω ∈[0.1,4] GeV for that the recoil threshold needs to change accoring to this PR

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
