### PR TITLE
Adding a simplified HCal to the reduced-v3 geometry

### DIFF
--- a/Detectors/data/ldmx-reduced-v3/constants.gdml
+++ b/Detectors/data/ldmx-reduced-v3/constants.gdml
@@ -1,4 +1,4 @@
-<!-- Constant defining the clearance between volumes --> 
+s<!-- Constant defining the clearance between volumes --> 
 <constant name="clearance" value="0.001*mm" />
 
 <!-- Define center position and identity rotation -->
@@ -195,16 +195,49 @@
 
 <!--
    HCal
-  TODO:
-  - add Hcal case
-  - do airBoxes need to be added?
+
+   The current implementation of the HCal is about as simple as it gets
+   The 80/20, most of the plastic housing, and the bench are currently not implemented
+   Only components directly in the beamline are included, which is two of the sides of
+   the plastic housing and, of course, the quad bars.
+
+   The z offset is arbitrarily chosen to place the structure directly behind the ECal
 --> 
 
-<!-- Common HCal components
-- Scintillator Thickness: oriented in z in back Hcal, y/x in side hcal
-- Scintillator Width: oriented in x/y in back Hcal
--->
+<!--The envelope holding all other HCal solids (dimensions chosen "just big enough"-->
+    <!--IMPORTANT: if you adjust any other dimensions, be careful! It may adjust the-->
+    <!--envelope's z value (thickness), which is calculated at the end-->
+    <!--This could eventually cause overlap with other envelopes-->
+    <constant name="hcal_envelope_x" value="1200"/>
+    <constant name="hcal_envelope_y" value="220"/>
 
+    <!--Quad spacing = air gap between quad bars-->
+    <constant name="quadspacing" value="10"/>
+    <!--Quadbar dimensions from on-site measurements and are approximate-->
+    <constant name="quadx" value="1000"/>
+    <constant name="quady" value="200"/>
+    <constant name="quadz" value="20"/>
+
+    <!--Housing spacing = space between plastic housing and first quad bar-->
+    <!--as well as space between last quad bar and plastic housing-->
+    <constant name="housingspacing" value="25"/>
+    <!--Plastic panel thickness is exact, other dimensions aren't accurate
+    but don't need to be atm-->
+    <constant name="housingx" value="1000"/>
+    <constant name="housingy" value="200"/>
+    <constant name="housingz" value="6.35"/>
+
+    <variable name="housinglayers" value="2"/>
+    <variable name="quadlayers" value="6"/>
+    
+    <!--Use the rest of the parameters to calculate the envelope thickness-->
+    <constant name="hcal_envelope_z" value="(quadlayers*quadz) + ((quadlayers-1)*quadspacing)+(housinglayers*housingspacing)+(housinglayers*housingz)"/>
+
+    <!--The rest of the hcal variables are kept here because other components
+        in ecal.gdml and scoring_planes.gdml still rely on them.
+        This should probably be updated by the responsible persons.
+    -->
+    
 <constant name="hcal_airThick" value="2."/>
 <constant name="hcal_scintThick" value="20."/> 
 <constant name="hcal_scintWidth" value="50."/> 

--- a/Detectors/data/ldmx-reduced-v3/constants.gdml
+++ b/Detectors/data/ldmx-reduced-v3/constants.gdml
@@ -1,4 +1,4 @@
-s<!-- Constant defining the clearance between volumes --> 
+<!-- Constant defining the clearance between volumes --> 
 <constant name="clearance" value="0.001*mm" />
 
 <!-- Define center position and identity rotation -->

--- a/Detectors/data/ldmx-reduced-v3/detector.gdml
+++ b/Detectors/data/ldmx-reduced-v3/detector.gdml
@@ -48,7 +48,7 @@
     <position name="hadron_calorimeter_pos"
 		  x="0.0" 
 		  y="support_box_shift"
-		  z="hadron_calorimeter_pos_z"/>
+		  z="1000.0"/>
     <position name="magnet_pos" x="0.0" y="0.0" z="magnet_pos_z" />
 	
   </define>

--- a/Detectors/data/ldmx-reduced-v3/hcal.gdml
+++ b/Detectors/data/ldmx-reduced-v3/hcal.gdml
@@ -2,328 +2,98 @@
 <!DOCTYPE gdml [
 <!ENTITY constants SYSTEM "constants.gdml">
 ]>
-<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gdml.xsd">
+  
 
-  <define>
+    <define>
 
     &constants; 
 
     <!-- loop variables - must be defined here -->
-    <variable name="layer" value="1"/>
-    <variable name="strip" value="1"/>
-    <variable name="module" value="1"/>
-    <variable name="section" value="1"/>
+    <variable name="n" value="1"/>
+    <variable name="n2" value="1"/>
 
-    <!-- 
-        Starting positions of steel / scintillator of the back HCal w.r.t 
-        center of the HCal mother volume, put absorber first.
-    -->        
-    <variable name="back_hcal_startZ" value="side_hcal_dz/2.0 - back_hcal_dz/2.0"/>
-    <variable name="back_hcal_startZAbso" value="back_hcal_startZ + hcal_airThick + back_hcal_absoThick/2.0"/>
-    <variable name="back_hcal_startZScint" value="back_hcal_startZ + hcal_airThick + back_hcal_absoThick + hcal_airThick + hcal_scintThick/2.0"/>
-    <variable name="back_hcal_startXScint" value="-back_hcal_dx/2.0 + hcal_scintWidth/2.0"/>
-    <variable name="back_hcal_startYScint" value="-back_hcal_dy/2.0 + hcal_scintWidth/2.0"/>
-
-    <!-- Side HCal sections: 1,2,3,4 are Top, Bottom, Left, Right -->
-    <matrix name="side_hcal_sign" coldim="1" values="-1 1 -1 1"/>
-    <matrix name="side_hcal_startXAbso" coldim="1" values="-(ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick)
-                 ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick
-                 -(ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick/2.0)
-                 ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick/2.0"/>
-    <matrix name="side_hcal_startXScint" coldim="1" values="ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick
-                  -(ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick)
-                  ecal_side_dx/2.0+2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0
-                  -(ecal_side_dx/2.0+2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0)"/>
-    <matrix name="side_hcal_startYAbso" coldim="1" values="ecal_side_dy/2.0+hcal_airThick+side_hcal_absoThick/2.0
-                 -(ecal_side_dy/2.0+hcal_airThick+side_hcal_absoThick/2.0)
-                 -(ecal_side_dy)
-                 (ecal_side_dy)"/>
-    <matrix name="side_hcal_startYScint" coldim="1" values="ecal_side_dy/2.0+2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0
-                  -(ecal_side_dy/2.0+2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0)
-                  -(ecal_side_dy/2.0-hcal_scintWidth/2.0)
-                  ecal_side_dy/2.0-hcal_scintWidth/2.0"/>
+    <!--Rather than having really messy position calculations in the physvol placement, I'm opting
+	to do some of the calculations here, with brief explanations.
+	
+	The first z position will be the upstream plastic panel, part of the plastic housing.
+	This should be more or less fixed, at the edge of the envelope but with the half-thickness
+	of the panel added back on so that it's not hanging out of the envelope.
+    -->
+    <constant name="upstreamhousingz" value="-(hcal_envelope_z-housingz)/2."/>
+    <!--Then there will be an airgap (a.k.a. housingspacing) before the first quad bar-->    
+    <constant name="quadstartz" value="upstreamhousingz+housingz/2.+housingspacing+quadz/2."/>
+    <!--The quad bars will be placed (with #spaces = quadbars - 1)-->
+    <constant name="quadendz" value="quadstartz+(quadlayers*quadz) + ((quadlayers-1)*quadspacing)"/>
+    <!--Then after another air gap will be the second plastic housing panel-->
+    <constant name="downstreamhousingz" value="quadendz+housingz/2.+housingspacing-quadz/2."/>
+    
   </define>
-    
 
-  <solids>
+
   
+  <solids>  
     <!-- - - - - - - - - HCal solids - - - - - - - -  -->
-    <box lunit="mm" name="back_hcal_absoBox" x="back_hcal_dx" y="back_hcal_dy" z="back_hcal_absoThick"/>
-    <box lunit="mm" name="back_hcal_scintXBox" x="back_hcal_dx" y="hcal_scintWidth" z="hcal_scintThick"/>
-    <box lunit="mm" name="back_hcal_scintYBox" x="hcal_scintWidth" y="back_hcal_dy" z="hcal_scintThick"/>
 
-    <loop for="module" from="1" to="side_hcal_numModules" step="1">
-      <box name="side_hcal_absoX[module]Box" lunit="mm"
-     x="side_hcal_length[module]" y="side_hcal_absoThick" z="side_hcal_dz"/>
-      <box name="side_hcal_absoY[module]Box" lunit="mm"
-           x="side_hcal_absoThick" y="side_hcal_length[module]" z="side_hcal_dz"/> 
-      <box name="side_hcal_scintX[module]Box" lunit="mm"
-     x="side_hcal_length[module]" y="hcal_scintThick" z="hcal_scintWidth"/>
-      <box name="side_hcal_scintY[module]Box" lunit="mm"
-           x="hcal_scintThick" y="side_hcal_length[module]" z="hcal_scintWidth"/>
-    </loop>
-    <box lunit="mm" name="side_hcal_scintZXBox" x="hcal_scintWidth" y="hcal_scintThick" z="side_hcal_dz"/>    
-    <box lunit="mm" name="side_hcal_scintZYBox" x="hcal_scintThick" y="hcal_scintWidth" z="side_hcal_dz"/>
-
-    <!-- - - - - - - - - Parent Volumes - - - - - - - -->     
-    <box lunit="mm" name="all_hcal_Box" x="hcal_envelope_dx" y="hcal_envelope_dy" z="hcal_dz"/>
-    <box lunit="mm" name="ecal_Box" x="ecal_side_dx" y="ecal_side_dy" z="side_hcal_dz"/>
-    <!-- The second solid is placed with given position, in the coordinates of the first solid -->
-    <subtraction name="hadron_calorimeter_Box">
-      <first ref="all_hcal_Box"/>
-      <second ref="ecal_Box"/>
-      <position name="hadron_calorimeter_parent_Box_pos" unit="mm" x="0." y="0." z="-back_hcal_dz/2.0"/>    
-    </subtraction>
-    
+    <box lunit="mm" name="quadbarbox" x="quadx" y="quady" z="quadz"/>
+    <box lunit="mm" name="plastichousing_xybox" x="housingx" y="housingy" z="housingz"/>
+    <box lunit="mm" name="hcal_envelope" x="hcal_envelope_x" y="hcal_envelope_y" z="hcal_envelope_z"/>
   </solids>
+
+
   
   <structure>      
+    <!-- - - - - - - - - - HCal volumes - - - - - - - - -->
+
+  <!--The name is chosen so that it will still be considered a sensitive detector in ldmx-sw-->
+     <volume name="scint_box">
+      <materialref ref="Scintillator" />
+      <solidref ref="quadbarbox" />
+    </volume>
+
+    <volume name="plastichousing_xy">
+      <materialref ref="AcrylicPMMA" />
+      <solidref ref="plastichousing_xybox" />
+    </volume>
+
     
-    <!-- - - - - - - - -  BACK HCAL STRUCTURES - - - - - - - -  -->
-    <volume name="back_hcal_absoVolume">
-      <materialref ref="Steel" />
-      <solidref ref="back_hcal_absoBox" />
-    </volume>
-
-    <volume name="back_hcal_scintYVolume">
-      <materialref ref="Scintillator" />
-      <solidref ref="back_hcal_scintYBox" />
-    </volume>
-
-    <volume name="back_hcal_scintXVolume">
-      <materialref ref="Scintillator" />
-      <solidref ref="back_hcal_scintXBox" />
-    </volume>
-
-    <!-- - - - - - - - -  SIDE HCAL STRUCTURES - - - - - - - -  -->
-    <loop for="module" from="1" to="side_hcal_numModules" step="1">
-      <volume name="side_hcal_absoX[module]Volume">
-        <materialref ref="Steel" />
-        <solidref ref="side_hcal_absoX[module]Box" />
-      </volume>
-      <volume name="side_hcal_absoY[module]Volume">
-        <materialref ref="Steel" />
-        <solidref ref="side_hcal_absoY[module]Box" />
-      </volume>
-      <volume name="side_hcal_scintX[module]Volume">
-        <materialref ref="Scintillator" />
-        <solidref ref="side_hcal_scintX[module]Box" />
-      </volume>
-      <volume name="side_hcal_scintY[module]Volume">
-        <materialref ref="Scintillator" />
-        <solidref ref="side_hcal_scintY[module]Box" />
-      </volume>
-    </loop>
-
-    <volume name="side_hcal_scintZXVolume">
-      <materialref ref="Scintillator" />
-      <solidref ref="side_hcal_scintZXBox" />
-    </volume>
-    <volume name="side_hcal_scintZYVolume">
-      <materialref ref="Scintillator" />
-      <solidref ref="side_hcal_scintZYBox" />
-    </volume>
-      
-      <!-- - - - - - - - -  FULL HCAL STRUCTURES - - - - - - - -  -->
+    
     <volume name="hadronic_calorimeter">
       <materialref ref="Air" />
-      <solidref ref="hadron_calorimeter_Box" />
-      <!-- BACK HCAL  -->
-        <!-- Note the step size of 2  -->
-        <loop for="layer" from="1" to="back_hcal_numLayers" step="2">
+      <solidref ref="hcal_envelope" />
 
-          <!-- Back Hcal Absorbers -->
-          <!-- Note: Placing two volumes at once since we are stepping two layers at a time  -->
-          <physvol name="back_hcal_absoPhysvol">
-            <volumeref ref="back_hcal_absoVolume"/>
-            <position name="back_hcal_abso1Pos" unit="mm"
-                      x="0"
-                      y="0"
-                      z="back_hcal_startZAbso + (layer-1)*back_hcal_layerThick"/>
-          </physvol>
+      <physvol copynumber="quadlayers+1">
+	<volumeref ref="plastichousing_xy"/>
+	  <position name ="plastic_pos_us" unit="mm"
+		    x="0"
+		    y="0"
+		    z="upstreamhousingz"/>
+	  <rotationref ref="identity" />
+	</physvol>
+	
+      <loop for="n" from="1" to="quadlayers" step="1">
+	<physvol copynumber="n">
+          <volumeref ref="scint_box" />
+          <position name="barpos" unit="mm" 
+          	    x="0"
+                    y="0"
+                    z="quadstartz + (n-1)*(quadz+quadspacing)" />
+          <rotationref ref="identity" />
+        </physvol>
+      </loop>
 
-          <physvol name="back_hcal_absoPhysvol">
-            <volumeref ref="back_hcal_absoVolume"/>
-            <position name="back_hcal_abso2Pos" unit="mm"
-                      x="0"
-                      y="0"
-                      z="back_hcal_startZAbso + (layer)*back_hcal_layerThick"/>
-          </physvol>
+      <physvol copynumber="quadlayers+2">
+	<volumeref ref="plastichousing_xy"/>
+	  <position name ="plastic_pos_ds" unit="mm"
+		    x="0"
+		    y="0"
+		    z="downstreamhousingz"/>
+	  <rotationref ref="identity" />
+	</physvol>
 
-          <!-- Back Hcal Strips oriented along X-axis  -->
-          <loop for="strip" from="1" to="back_hcal_numScint" step="1">
-            <physvol name="back_hcal_scintXPhysvol"
-                     copynumber="1*256*256*256 + 0*256*256 + (layer)*256 + (strip-1)">
-              <volumeref ref="back_hcal_scintXVolume"/>
-              <position name="back_hcal_scintXPos" unit="mm"
-                        x="0"
-                        y="back_hcal_startYScint + (strip-1)*hcal_scintWidth"
-                        z="back_hcal_startZScint + (layer-1)*back_hcal_layerThick"/>
-            </physvol>
-          </loop>
-
-          <!-- Back Hcal Strips oriented along Y-axis  -->
-          <loop for="strip" from="1" to="back_hcal_numScint" step="1">
-            <physvol name="back_hcal_scintYPhysvol"
-                     copynumber="1*256*256*256 + 0*256*256 + (layer+1)*256 + (strip-1)">
-              <volumeref ref="back_hcal_scintYVolume"/>
-              <position name="back_hcal_scintYPos" unit="mm"
-                        x="back_hcal_startXScint + (strip-1)*hcal_scintWidth"
-                        y="0"
-                        z="back_hcal_startZScint + (layer)*back_hcal_layerThick"/>
-            </physvol>
-          </loop>
-        </loop> <!-- Back Hcal layer  -->
-
-        <!-- SIDE HCAL layers oriented in x -->
-        <!--
-            Extra lenghts per module: ( side_hcal_length[module]-side_hcal_length[1] )/2.
-            Extra x/y per layer:
-            (odd): (layer-1)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module]
-            (even): (layer)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module]
-            Extra x/y for strips oriented in z:
-            hcal_scintWidth*(strip)
-        -->
-        <loop for="section" from="1" to="2" step="1">
-          <loop for="module" from="1" to="side_hcal_numModules" step="1">
-            <loop for="layer" from="1" to="side_hcal_numLayers[module]*2" step="2">
-              <!--
-            Absorber plates oriented in x
-            x (start): ecal_side_dx/2.0
-                       +hcal_airThick+side_hcal_absoThick ( to account for absorber in y from the other sections )
-            y (start): ecal_side_dy/2.0
-                       +hcal_airThick+side_hcal_absoThick/2.0 ( to account for air and so that absorber is centered)
-              -->
-              <physvol name="side_hcal_absoX1[section][module][layer]Physvol">
-                <volumeref ref="side_hcal_absoX[module]Volume"/>
-                <position name="side_hcal_absoX1[section][module][layer]Pos" unit="mm"
-                          x="side_hcal_startXAbso[section] + side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                          y="side_hcal_startYAbso[section] - side_hcal_sign[section]*( (layer-1)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                          z="-back_hcal_dz/2.0"/>
-              </physvol>
-
-              <!--
-            Short strips oriented in z
-            x (start): ecal_side_dx/2.0 (similar to absorber but with different sign)
-                       -hcal_scintWidth/2.0 ( so that scintillator is centered)
-            y (start): ecal_side_dy/2.0
-                       +2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0 ( to account for air,absober and so that scintillator is centered)
-              -->
-              <loop for="strip" from="1" to="side_hcal_numScintZ[module]" step="1">
-                <physvol name="side_hcal_scintZX[section][module][strip]Physvol"
-                         copynumber="1*256*256*256 + (section)*256*256 + (layer+2*side_hcal_numPrevLayers[module])*256 + (strip-1)">
-                  <volumeref ref="side_hcal_scintZXVolume"/>
-                  <position name="side_hcal_scintZX[section][module][strip]Pos" unit="mm"
-                            x="-side_hcal_sign[section]*(ecal_side_dx/2.0-hcal_scintWidth/2.0) + side_hcal_sign[section]*(strip-1)*hcal_scintWidth"
-                            y="side_hcal_startYScint[section] - side_hcal_sign[section]*( (layer-1)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module])"
-                            z="-back_hcal_dz/2.0"/>
-                </physvol>
-              </loop>
-
-              <!--
-            Absorber plates oriented in x
-            x (start): same x as in first absorber
-            y (start): same y as in first absorber but with extra y for even layer
-              -->
-              <physvol name="side_hcal_absoX2[section][module]Physvol">
-                <volumeref ref="side_hcal_absoX[module]Volume"/>
-                <position name="side_hcal_absoX2[section][module]Pos" unit="mm"
-                          x="side_hcal_startXAbso[section] + side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                          y="side_hcal_startYAbso[section] - side_hcal_sign[section]*( (layer)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                          z="-back_hcal_dz/2.0"/>
-              </physvol>
-
-              <!--
-            Long strips oriented in x
-            x (start): ecal_side_dx/2.0+hcal_airThick+side_hcal_absoThick * -1 (to be centered)
-            y (start): same as scintillator oriented in z but with extra y for even layer
-            z (start): -back_hcal_dz/2.0 - side_hcal_dz/2.0
-                                   + hcal_scintWidth/2.0 ( so that is centered)
-              -->
-              <loop for="strip" from="1" to="side_hcal_numScintXY" step="1">
-                <physvol name="side_hcal_scintX[section][module][strip]Physvol"
-                         copynumber="1*256*256*256 + (section)*256*256 + (layer+1+2*side_hcal_numPrevLayers[module])*256 + (strip-1)">
-                  <volumeref ref="side_hcal_scintX[module]Volume"/>
-                  <position name="side_hcal_scintX[section][module][strip]Pos" unit="mm"
-                            x="side_hcal_startXScint[section]*-1 + side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                            y="side_hcal_startYScint[section] - side_hcal_sign[section]*( (layer)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                            z="-back_hcal_dz/2.0 - side_hcal_dz/2.0 + hcal_scintWidth/2.0 + (strip-1)*hcal_scintWidth"/>
-                </physvol>
-              </loop>
-            </loop> <!-- X-oriented Side Hcal Layers -->
-          </loop> <!-- X-oriented Side Hcal Modules  -->
-        </loop> <!-- X-oriented Side Hcal Sections -->
-
-        <!-- SIDE HCAL layers oriented in y -->
-        <loop for="section" from="3" to="4" step="1">
-          <loop for="module" from="1" to="side_hcal_numModules" step="1">
-            <loop for="layer" from="1" to="side_hcal_numLayers[module]*2" step="2">
-
-              <!--
-            Absorber plates oriented in y
-            x (start): ecal_side_dx/2.0 + (hcal_airThick+side_hcal_absoThick/2.0)
-            y (start): ecal_side_dy ( if its ecal_side_dy/2.0, the absorber plates are not centered, use ecal_side_dy to get them centered)
-              -->
-              <physvol name="side_hcal_absoY1[section][module][layer]Physvol">
-                <volumeref ref="side_hcal_absoY[module]Volume"/>
-                <position name="side_hcal_absoY1[section][module][layer]Pos" unit="mm"
-                          x="side_hcal_startXAbso[section] + side_hcal_sign[section]*( (layer-1)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                          y="side_hcal_startYAbso[section] + side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                          z="-back_hcal_dz/2.0"/>
-              </physvol >
-
-              <!--
-            Short strips oriented in z
-            x (start): ecal_side_dx/2.0 + (2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0)
-            y (start): ecal_side_dy/2.0 - hcal_scintWidth/2.0
-              -->
-              <loop for="strip" from="1" to="side_hcal_numScintZ[module]" step="1">
-                <physvol name="side_hcal_scintZY[section][module][strip]Physvol"
-                         copynumber="1*256*256*256 + (section)*256*256 + (layer+2*side_hcal_numPrevLayers[module])*256 + (strip-1)">
-                  <volumeref ref="side_hcal_scintZYVolume"/>
-                  <position name="side_hcal_scintZY[section][module][strip]Pos" unit="mm"
-                            x="side_hcal_startXScint[section] - side_hcal_sign[section]*( (layer-1)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                            y="side_hcal_startYScint[section] - side_hcal_sign[section]*hcal_scintWidth*(strip-1)"
-                            z="-back_hcal_dz/2.0"/>
-                </physvol>
-              </loop>
-
-              <!--
-            Absorber plates oriented in y
-            x (start): same as first absorber
-            y (start): same as first absorber
-              -->
-              <physvol name="side_hcal_absoY2[section][module]Physvol">
-                <volumeref ref="side_hcal_absoY[module]Volume"/>
-                <position name="side_hcal_absoY2[section][module]Pos" unit="mm"
-                          x="side_hcal_startXAbso[section] + side_hcal_sign[section]*( (layer)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                          y="side_hcal_startYAbso[section] + side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                          z="-back_hcal_dz/2.0"/>
-              </physvol>
-
-              <!--
-            Long strips oriented in y (each strip increases in x)
-            x (start): ecal_side_dx/2.0 + (2.0*hcal_airThick+side_hcal_absoThick+hcal_scintThick/2.0)
-            y (start): ecal_side_dy
-            z (start): -back_hcal_dz/2.0 - side_hcal_dz/2.0
-                       + (strip-1)*hcal_scintWidth ( to account for different strips)
-              -->
-              <loop for="strip" from="1" to="side_hcal_numScintXY" step="1">
-                <physvol name="side_hcal_scintY[section][module][strip]Physvol"
-                         copynumber="1*256*256*256 + (section)*256*256 + (layer+1+2*side_hcal_numPrevLayers[module])*256 + (strip-1)">
-                  <volumeref ref="side_hcal_scintY[module]Volume"/>
-                  <position name="side_hcal_scintY[section][module][strip]Pos" unit="mm"
-                            x="side_hcal_startXScint[section] - side_hcal_sign[section]*( (layer)*side_hcal_layerThick + 2*side_hcal_layerThick*side_hcal_numPrevLayers[module] )"
-                            y="-side_hcal_sign[section]*ecal_side_dy - side_hcal_sign[section]*( side_hcal_length[module]-side_hcal_length[1] )/2."
-                            z="-back_hcal_dz/2.0 - side_hcal_dz/2.0 + hcal_scintWidth/2.0 + (strip-1)*hcal_scintWidth"/>
-                </physvol>
-              </loop>
-            </loop> <!-- Y-oriented Side Hcal Layers -->
-          </loop> <!-- Y-oriented Side Hcal Modules -->
-        </loop> <!-- Y-oriented Side Hcal Sections  -->
-
+      
       <auxiliary auxtype="Region" auxvalue="CalorimeterRegion"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="Hcal"/>
     </volume>
   </structure>


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This is the next step in #1880 

The HCal should be the final subsystem component which needs to be added for a full slice test geometry. This implementation features a highly simplified, but mostly dimensionally accurate, version of the slice test HCal.

The composition and dimensions of the objects directly in the beamline should be fairly accurate. This includes the 6 quad bars at ESA, plus two sides of the plastic case containing them (the sides with surfaces perpendicular to the beam direction). The other 4 sides of the casing, the 80/20 supports, the cables/electronics, and the table are not included.

In `constants.gdml`, I added new constants for the slice test HCal, but left old constants for the baseline HCal intact, because there are still pieces of `ecal.gdml` and `scoring_planes.gdml` which rely on them.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->

### Geometry validation
(along beam view)
<img width="750" height="516" alt="image" src="https://github.com/user-attachments/assets/0629c3fb-1812-4dd6-a9e4-4c79cac86e31" />
(side view)
<img width="601" height="576" alt="image" src="https://github.com/user-attachments/assets/ef7d3878-80dd-4ac1-90d6-e984771291d9" />
The orange box is the boundaries of the HCal envelope, the thin bars on the left and right side are the plastic housing, and the six bars in the center are the quad bars.
Side view of entire slice test geometry:
<img width="718" height="362" alt="image" src="https://github.com/user-attachments/assets/2846c8c0-25df-4656-9676-0de29c1b69f6" />

### Physics validation
Well, I don't really know what to expect the data to look like, but we're getting entries in all the hits collections associated with the HCal, at least, when running the reduced CI.
<img width="643" height="387" alt="image" src="https://github.com/user-attachments/assets/7445ebd0-0cb3-42c1-875c-b505c50296ee" />
<img width="622" height="393" alt="image" src="https://github.com/user-attachments/assets/6bb880f7-7318-474d-a95a-caddadcba624" />
And from the DQM histos:
<img width="635" height="382" alt="image" src="https://github.com/user-attachments/assets/867a901a-d6a6-4eb0-a0d4-563666a95783" />


