### PR TITLE
fail the format/tidy and format/lint jobs if changes were made on trunk

### DIFF
--- a/.github/workflows/apply-clang-tools.yml
+++ b/.github/workflows/apply-clang-tools.yml
@@ -1,6 +1,7 @@
 name: Apply clang tools
 on:
   pull_request:
+      types: [opened, ready_for_review]
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0'
@@ -34,6 +35,7 @@ jobs:
       run: |
         just format-cpp
         just tidy-cpp-all
+        git diff # fail job if format/tidy made a change
     - name: auto-commit changes
       if: github.ref != 'refs/heads/trunk'
       run: |

--- a/.github/workflows/apply-python-tools.yml
+++ b/.github/workflows/apply-python-tools.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         just format-python
         just lint-python-fix
+        git diff # fail job if format/lint made a change
     - name: auto-commit changes
       if: github.ref != 'refs/heads/trunk'
       run: |

--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Cache ccache
       uses: actions/cache@v5
       with:
-        path: ~/.ccache
+        path: .cache/ccache
         key: ccache-basic-${{ github.sha }}
         restore-keys: |
           ccache-basic-
@@ -39,3 +39,10 @@ jobs:
     - name: Basic Tests for Functionality
       run: just test
       shell: bash
+
+    - name: Upload Test Log
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: ldmx-sw-basic-test-log-${{ github.sha }}
+        path: build/Testing/Temporary/LastTest.log

--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -40,8 +40,10 @@ jobs:
       run: just test
       shell: bash
 
+    # always upload the last test log unless the
+    # workflow was cancelled by a user on github
     - name: Upload Test Log
-      if: always()
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
         name: ldmx-sw-basic-test-log-${{ github.sha }}

--- a/.github/workflows/compile_clang_lto.yml
+++ b/.github/workflows/compile_clang_lto.yml
@@ -36,3 +36,13 @@ jobs:
         just install-denv init configure-clang-lto-fail-on-warning
         just build
         just test
+
+    # always upload the last test log unless the
+    # workflow was cancelled by a user on github
+    - name: Upload Test Log
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ldmx-sw-clang-lto-test-log-${{ github.sha }}
+        path: build/Testing/Temporary/LastTest.log
+

--- a/Framework/src/Framework/EventFile.cxx
+++ b/Framework/src/Framework/EventFile.cxx
@@ -112,6 +112,10 @@ EventFile::~EventFile() {
     tree_->Write();
   }
 
+  // detach objects that may/may not be out of scope already
+  // by resetting branch addresses immediately before closing
+  // this is a HACK that I'm embarrased by
+  tree_->ResetBranchAddresses();
   // Close the file
   file_->Close();
 }


### PR DESCRIPTION
- fail the format/tidy and format/link jobs when run on trunk if changes were made by those tools
- only run clang tools on open/ready for review to decrease noise
  - we will want to remember to do a workflow dispatch for (clang, ruff) if (c++, python) edits are made to a branch after it is marked ready for review and before it is merged

### What are the issues that this addresses?
This is related to #2072 but does not resolve it.