### PR TITLE
Repaired and updated the visattributes of the slice test geometry.

### DIFF
--- a/Detectors/data/ldmx-reduced-v3/detector.gdml
+++ b/Detectors/data/ldmx-reduced-v3/detector.gdml
@@ -119,7 +119,7 @@
     </auxiliary>
 
         <!--Set color mode for visualization (optional)-->
-    <auxiliary auxtype="ColorMode" auxvalue="Region"/>
+    <auxiliary auxtype="ColorMode" auxvalue="Material"/>
     
     &visattributes;
 

--- a/Detectors/data/ldmx-reduced-v3/ecal.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal.gdml
@@ -278,6 +278,8 @@
     <volume name="C_volume_CarbonCoolingPlane">
       <materialref ref="CarbonEpoxyComposite"/>
       <solidref ref="CarbonCoolingPlane"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="CarbonEpoxyCompositeMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
 
     <assembly name="PCB_motherboard_volume">
@@ -296,44 +298,58 @@
     <volume name="PCB_volume">
       <materialref ref="FR4"/>
       <solidref ref="PCB_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
+
     </volume>
   
     <volume name="Glue_volume">
       <materialref ref="Glue"/>
       <solidref ref="Glue_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   
     <volume name="Si_volume">
       <materialref ref="Silicon"/>
       <solidref ref="Si_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   
     <volume name="GlueThick_volume">
       <materialref ref="Glue"/>
       <solidref ref="GlueThick_hexagon"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="GlueMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
 
     <volume name="CarbonBasePlate_volume">
       <materialref ref="CarbonEpoxyComposite"/>
       <solidref ref="CarbonBasePlate_hexagon"/>
-      <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid" />-->
-    </volume>
+      <auxiliary auxtype="VisAttributes" auxvalue="CarbonEpoxyCompositeMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
+    </volume>      
 
     <!-- define the tungsten absorber volume corresponding to the correct-thickness solid -->
     <loop for="bilayer" from="1" to="num_bilayers-1" step="1">
       <volume name="strongback_bar_volume[bilayer]">
         <materialref ref="Aluminum" />
         <solidref ref="strongback_bar[bilayer]" />
+	<auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
       </volume>
       <volume name="W_front_volume[bilayer]">
         <materialref ref="Tungsten"/>
         <solidref ref="W_front_absorber[bilayer]"/>
-        <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
+        <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
       </volume>
       <volume name="W_cooling_volume[bilayer]">
         <materialref ref="Tungsten"/>
         <solidref ref="W_cooling_absorber[bilayer]"/>
-        <!--<auxiliary auxtype="VisAttributes" auxvalue="BlueSolid"/>-->
+        <auxiliary auxtype="VisAttributes" auxvalue="TungstenMaterialVis"/>
+        <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
       </volume>
     </loop>
 
@@ -376,7 +392,7 @@
     <volume name="em_calorimeters">
       <materialref ref="Air"/>
       <solidref ref="ECal_box"/>
-
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <!--
         the support box is not symmetric in the vertical direction but
         we center it at half its max y-coordinate because why not
@@ -625,7 +641,6 @@
       </physvol>
 
       <auxiliary auxtype="Region" auxvalue="CalorimeterRegion"/>
-          <!--<auxiliary auxtype="VisAttributes" auxvalue="GrayWireFrame"/>-->
       <auxiliary auxtype="DetElem" auxvalue="Ecal"/>
     </volume>
   </structure>

--- a/Detectors/data/ldmx-reduced-v3/ecal_motherboard5_assembly.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_motherboard5_assembly.gdml
@@ -277,6 +277,8 @@
     <volume name="nohole_motherboard5_assembly">
       <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard5_assembly-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-reduced-v3/ecal_motherboard6_assembly.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_motherboard6_assembly.gdml
@@ -363,6 +363,8 @@
     <volume name="nohole_motherboard6_assembly">
       <materialref ref="FR4"/>
       <solidref ref="nohole_motherboard6_assembly-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="FR4MaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-reduced-v3/ecal_support_box.gdml
+++ b/Detectors/data/ldmx-reduced-v3/ecal_support_box.gdml
@@ -1482,6 +1482,8 @@
     <volume name="support_box">
       <materialref ref="Aluminum"/>
       <solidref ref="support_box-SOL"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AluminumMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="EcalRegionVis"/>
     </volume>
   </structure>
 

--- a/Detectors/data/ldmx-reduced-v3/hcal.gdml
+++ b/Detectors/data/ldmx-reduced-v3/hcal.gdml
@@ -49,11 +49,15 @@
      <volume name="scint_box">
       <materialref ref="Scintillator" />
       <solidref ref="quadbarbox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="ScintillatorMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis"/>
     </volume>
 
     <volume name="plastichousing_xy">
       <materialref ref="AcrylicPMMA" />
       <solidref ref="plastichousing_xybox" />
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="HcalRegionVis"/>
     </volume>
 
     
@@ -61,6 +65,7 @@
     <volume name="hadronic_calorimeter">
       <materialref ref="Air" />
       <solidref ref="hcal_envelope" />
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
 
       <physvol copynumber="quadlayers+1">
 	<volumeref ref="plastichousing_xy"/>

--- a/Detectors/data/ldmx-reduced-v3/recoil.gdml
+++ b/Detectors/data/ldmx-reduced-v3/recoil.gdml
@@ -103,6 +103,8 @@
     <volume name="recoil_l14_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l14_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="RecoilRegionVis"/>
       <physvol name="recoil_l14_active_sensor">
         <volumeref ref="Recoil_l14_active_Sensor_vol"/>
         <position name="recoil_l14_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
@@ -116,6 +118,8 @@
     <volume name="recoil_l56_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="recoil_l56_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="RecoilRegionVis"/>
       <physvol name="recoil_l56_active_sensor">
         <volumeref ref="Recoil_l56_active_Sensor_vol"/>
         <position name="recoil_l56_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
@@ -124,6 +128,7 @@
     <volume name="recoil">
       <materialref ref="Air"/>
       <solidref ref="recoil_box_trimmed"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <loop for="i" from="1" to="2" step="1"> 
         <!-- Axial sensors --> 
         <physvol copynumber="20*i-10"> 

--- a/Detectors/data/ldmx-reduced-v3/scoring_planes.gdml
+++ b/Detectors/data/ldmx-reduced-v3/scoring_planes.gdml
@@ -229,7 +229,7 @@
     <volume name="SP_World">
       <materialref ref="Vacuum" />
       <solidref ref="world_box" />
-      
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <loop for="x2" to="2" step="1">
         <physvol copynumber="x2">
           <volumeref ref="sp_target" />

--- a/Detectors/data/ldmx-reduced-v3/tagger.gdml
+++ b/Detectors/data/ldmx-reduced-v3/tagger.gdml
@@ -65,16 +65,18 @@
     <volume name="tagger_sensor_vol">
       <materialref ref="Silicon"/>
       <solidref ref="tagger_sensor_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="SiliconMaterialVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="TaggerRegionVis"/>
       <physvol name="tagger_active_sensor">
-      <volumeref ref="Tagger_active_Sensor_vol"/>
-      <position name="tagger_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
+	<volumeref ref="Tagger_active_Sensor_vol"/>
+	<position name="tagger_active_sensor_pos" unit="mm" x="0.0" y="0.0" z="0.0"/>
       </physvol>
     </volume>
     
     <!-- define tagger physical volumes inside envelope volume --> 
     <volume name="tagger">
       <materialref ref="Air"/>
-      <solidref ref="tagger_box"/>
+      <solidref ref="tagger_box"/>      
       <!-- removing the sensors since reduced-LDMX will not have a tagger tracker --> 
       <auxiliary auxtype="Region" auxvalue="tagger"/>
       <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>

--- a/Detectors/data/ldmx-reduced-v3/target.gdml
+++ b/Detectors/data/ldmx-reduced-v3/target.gdml
@@ -39,6 +39,7 @@
     <volume name="target">
       <materialref ref="LYSO"/>
       <solidref ref="target_bar"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="LYSOMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="Target"/>
       <auxiliary auxtype="Region" auxvalue="target"/>
@@ -48,6 +49,7 @@
     <volume name="lvTargetArray1">
       <materialref ref="Air"/>
       <solidref ref="target_array1"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <loop for="x" from="1" to="number_of_target_bars1" step="1">
         <physvol>
           <volumeref ref="target"/>
@@ -63,6 +65,7 @@
     <volume name="lvTargetArray2">
       <materialref ref="Air"/>
       <solidref ref="target_array2"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <loop for="x" from="1" to="number_of_target_bars2" step="1">
         <physvol>
           <volumeref ref="target"/>
@@ -79,7 +82,7 @@
     <volume name="lvTarget">
       <materialref ref="Air"/>
       <solidref ref="target_box"/>
-      <auxiliary auxtype="VisAttributes" auxvalue="TargetRegionVis"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <auxiliary auxtype="DetElem" auxvalue="Target"/>
       <auxiliary auxtype="Region" auxvalue="target"/>
 
@@ -100,6 +103,7 @@
     <volume name="lyso_lp_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="lp3_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="LightPipe"/>
     </volume>
@@ -108,6 +112,7 @@
     <volume name="trigger_pad3_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
       <!-- keep or drop; not critical -->
@@ -117,6 +122,7 @@
     <volume name="lp_pad3_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="lp3_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="LightPipe"/>
       <auxiliary auxtype="Region" auxvalue="trig_scint"/>
@@ -126,6 +132,7 @@
     <volume name="TS_trgt">
       <materialref ref="Air"/>
       <solidref ref="target_area_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
 
       <!-- LYSO light pipes: 12 bars, glued by x-shift (same style as TS3 LPs) -->
       <loop for="x" from="1" to="number_of_bars" step="1">

--- a/Detectors/data/ldmx-reduced-v3/trig_scint.gdml
+++ b/Detectors/data/ldmx-reduced-v3/trig_scint.gdml
@@ -29,6 +29,7 @@
     <volume name="trigger_pad2_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
@@ -36,6 +37,7 @@
     <volume name="trigger_pad1_bar_volume">
       <materialref ref="Polyvinyltoluene"/>
       <solidref ref="trigger_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="PolyvinyltolueneMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem" auxvalue="TriggerPad"/>
     </volume>
@@ -44,6 +46,7 @@
     <volume name="lp_pad2_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="light_pipe_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem"       auxvalue="LightPipe"/>
     </volume>
@@ -51,6 +54,7 @@
     <volume name="lp_pad1_bar_volume">
       <materialref ref="AcrylicPMMA"/>
       <solidref ref="light_pipe_bar_box"/>
+      <auxiliary auxtype="VisAttributes" auxvalue="AcrylicPMMAMaterialVis"/>
       <auxiliary auxtype="VisAttributes" auxvalue="TriggerPadRegionVis"/>
       <auxiliary auxtype="DetElem"       auxvalue="LightPipe"/>
     </volume>
@@ -58,6 +62,7 @@
     <volume name="trig_scint_tagger">
       <materialref ref="Air"/>
       <solidref ref="trigger_pad_box" />
+      <auxiliary auxtype="VisAttributes" auxvalue="InvisibleShowDau"/>
       <loop for="x" from="1" to="number_of_bars" step="1">
         <physvol copynumber="2*x-2">  <!-- pad 2, layer 1-->
           <volumeref ref="trigger_pad2_bar_volume" />


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
This resolves #2069, which exists as a sub-issue of #1976. I initially intended to file this as a sub-issue of #1880 but changed my mind. Realizing now that I forgot to update the branch name as well... But that's fine.

Not a complicated PR, just adding visattributes in the slice test geometry where they were previously missing or outdated. I think this should mark the end of the visattributes repairs, unless someone really has demand for one of the old geometries to be updated to the current format.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
I ran the reduced CI test locally with no issues, and loaded the updated files into the visualizer without issues.

Before:
<img width="542" height="302" alt="image" src="https://github.com/user-attachments/assets/fb077ed9-3a48-4551-82fa-b8eb157573e4" />

After:
<img width="532" height="227" alt="image" src="https://github.com/user-attachments/assets/cee08e71-7915-4eb9-9d10-f90f83bbd3c3" />

The taggers aren't visible in the second picture but that's because the silicon material color is set to black... Again, hindsight 20/20, this might not have been the optimal choice for rendering. They reappear easily when color mode is set to 'region' with the new visattributes, though:

<img width="582" height="257" alt="image" src="https://github.com/user-attachments/assets/ae7881e5-80ab-4a95-aa36-32981fe88605" />
