### PR TITLE
Fix potential out-of-bounds memory in IdealClusterBuilder

### DIFF
--- a/Trigger/Algo/src/Trigger/IdealClusterBuilder.cxx
+++ b/Trigger/Algo/src/Trigger/IdealClusterBuilder.cxx
@@ -9,14 +9,8 @@ void ClusterGeometry::addTp(int tid, int cell_id, int module_id, float x,
   positions_[tid] = std::make_pair(x, y);
 }
 void ClusterGeometry::addNeighbor(int id1, int id2) {
-  if (neighbors_.count(id1))
-    neighbors_[id1].push_back(id2);
-  else
-    neighbors_[id1] = {id2};
-  if (neighbors_.count(id2))
-    neighbors_[id2].push_back(id1);
-  else
-    neighbors_[id2] = {id1};
+  neighbors_[id1].push_back(id2);
+  neighbors_[id2].push_back(id1);
   // cout << "Nbs: " << id1 << " " << id2 << endl;
 }
 bool ClusterGeometry::checkNeighbor(int id1, int id2) {
@@ -118,10 +112,7 @@ std::vector<Cluster> IdealClusterBuilder::build2dClustersLayer(
       auto iclus = clus2hit_id.first;
       auto& hit_i_ds = clus2hit_id.second;
       for (const auto& hit_id : hit_i_ds) {
-        if (assoc_hit_i_d2clusters.count(hit_id))
-          assoc_hit_i_d2clusters[hit_id].push_back(iclus);
-        else
-          assoc_hit_i_d2clusters[hit_id] = {iclus};
+        assoc_hit_i_d2clusters[hit_id].push_back(iclus);
       }
     }
 
@@ -271,7 +262,7 @@ void IdealClusterBuilder::build3dClusters() {
           }
           // cout << "got seed" << endl;
           //  found seed
-          cluster3d.clusters2d_ = {clusters2d[0]};
+          cluster3d.clusters2d_.push_back(clusters2d[0]);
           cluster3d.first_layer_ = test_layer;
           cluster3d.last_layer_ = test_layer;
           cluster3d.depth_ = 1;

--- a/Trigger/Algo/src/Trigger/IdealClusterBuilder.cxx
+++ b/Trigger/Algo/src/Trigger/IdealClusterBuilder.cxx
@@ -262,6 +262,7 @@ void IdealClusterBuilder::build3dClusters() {
           }
           // cout << "got seed" << endl;
           //  found seed
+          cluster3d.clusters2d_.clear();
           cluster3d.clusters2d_.push_back(clusters2d[0]);
           cluster3d.first_layer_ = test_layer;
           cluster3d.last_layer_ = test_layer;


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

Replace initializer-list vector assignments (= {val}) with push_back to avoid a compiler/ASAN warning about potential out-of-bounds memmove; this works because std::map::operator[] default-constructs an empty vector when the key doesn't exist, so push_back on it is safe without an explicit count check.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/1707

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
