### PR TITLE
2072 clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ CheckOptions:
   readability-identifier-naming.StructCase: CamelCase
   readability-identifier-naming.VariableCase: lower_case
   readability-identifier-naming.GlobalConstantCase: UPPER_CASE
-  readability-identifier-naming.ClassMemberCase: lower_case
-  readability-identifier-naming.ClassMemberSuffix: "_"
-  readability-identifier-naming.StructMemberCase: lower_case
+  readability-identifier-naming.MemberCase: lower_case
+  readability-identifier-naming.MemberSuffix: "_"
   readability-identifier-naming.ConstantMemberCase: UPPER_CASE

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ CheckOptions:
   readability-identifier-naming.StructCase: CamelCase
   readability-identifier-naming.VariableCase: lower_case
   readability-identifier-naming.GlobalConstantCase: UPPER_CASE
-  readability-identifier-naming.MemberCase: lower_case
+  readability-identifier-naming.ClassMemberCase: lower_case
   readability-identifier-naming.ClassMemberSuffix: "_"
+  readability-identifier-naming.StructMemberCase: lower_case
   readability-identifier-naming.ConstantMemberCase: UPPER_CASE

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,5 @@
+# use format defined in .clang-format
+FormatStyle: "file"
 # comma-separated list of globs to enable or disable (`-` prefix)
 # this one disables all and then enables readability-identifier-naming
 Checks: "-*,readability-identifier-naming"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,5 +10,5 @@ CheckOptions:
   readability-identifier-naming.VariableCase: lower_case
   readability-identifier-naming.GlobalConstantCase: UPPER_CASE
   readability-identifier-naming.MemberCase: lower_case
-  readability-identifier-naming.MemberSuffix: "_"
+  readability-identifier-naming.ClassMemberSuffix: "_"
   readability-identifier-naming.ConstantMemberCase: UPPER_CASE

--- a/.github/workflows/apply-clang-tools.yml
+++ b/.github/workflows/apply-clang-tools.yml
@@ -32,5 +32,5 @@ jobs:
         just format-cpp-diff
         just tidy-cpp-diff
         echo $?
-        git diff
+        git diff --exit-code
         echo $?

--- a/.github/workflows/apply-clang-tools.yml
+++ b/.github/workflows/apply-clang-tools.yml
@@ -1,5 +1,6 @@
 name: Apply clang tools
 on:
+  push: # TEMP, do not merge
   pull_request:
       types: [opened, ready_for_review]
   workflow_dispatch:
@@ -30,18 +31,6 @@ jobs:
       run: |
         just format-cpp-diff
         just tidy-cpp-diff
-    - name: run clang-format and clang-tidy on all C++ files
-      if: github.ref == 'refs/heads/trunk'
-      run: |
-        set -e
-        just format-cpp
-        just tidy-cpp-all
-        git diff # fail job if format/tidy made a change
-    - name: auto-commit changes
-      if: github.ref != 'refs/heads/trunk'
-      run: |
-        git config user.name 'github-actions[bot]'
-        git config user.email 'github-actions[bot]@users.noreply.github.com'
-        git add .
-        git commit -m "Apply clang-format and clang-tidy" || exit 0
-        git push origin HEAD:${GITHUB_HEAD_REF}
+        echo $?
+        git diff
+        echo $?

--- a/.github/workflows/apply-clang-tools.yml
+++ b/.github/workflows/apply-clang-tools.yml
@@ -1,6 +1,5 @@
 name: Apply clang tools
 on:
-  push: # TEMP, do not merge
   pull_request:
       types: [opened, ready_for_review]
   workflow_dispatch:
@@ -26,11 +25,19 @@ jobs:
         git remote set-branches origin trunk
         git fetch --depth=1 --no-tags
     - run: just install-denv init configure
-    - name: run clang-format and clang-tidy on the changed C++ files
+    - name: format and tidy the changed C++ files
       if: github.ref != 'refs/heads/trunk'
       run: |
         just format-cpp-diff
         just tidy-cpp-diff
-        echo $?
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add .
+        git commit -m "apply clang-format and clang-tidy" || exit 0
+        git push origin HEAD:${GITHUB_HEAD_REF}
+    - name: check format and tidy on all C++ files
+      if: github.ref == 'refs/heads/trunk'
+      run: |
+        just format-cpp-all
+        just tidy-cpp-all
         git diff --exit-code
-        echo $?

--- a/.github/workflows/apply-python-tools.yml
+++ b/.github/workflows/apply-python-tools.yml
@@ -30,18 +30,14 @@ jobs:
       run: |
         just format-python-diff
         just lint-python-fix
-    - name: format and lint all Python files
-      if: github.ref == 'refs/heads/trunk'
-      run: |
-        set -e
-        just format-python
-        just lint-python-fix
-        git diff # fail job if format/lint made a change
-    - name: auto-commit changes
-      if: github.ref != 'refs/heads/trunk'
-      run: |
         git config user.name 'github-actions[bot]'
         git config user.email 'github-actions[bot]@users.noreply.github.com'
         git add .
-        git commit -m "Apply ruff formatting and linting" || exit 0
+        git commit -m "apply ruff formatting and linting" || exit 0
         git push origin HEAD:${GITHUB_HEAD_REF}
+    - name: check format and lint all Python files
+      if: github.ref == 'refs/heads/trunk'
+      run: |
+        just format-python
+        just lint-python-fix
+        git diff --exit-code

--- a/SimCore/include/SimCore/MagneticFieldStore.h
+++ b/SimCore/include/SimCore/MagneticFieldStore.h
@@ -9,6 +9,7 @@
 
 // Geant4
 #include "G4MagneticField.hh"
+#include <map>
 
 namespace simcore {
 
@@ -21,7 +22,7 @@ class MagneticFieldStore {
   /**
    * Map of names to magnetic fields.
    */
-  typedef std::max<std::string, G4MagneticField*>; MagFieldMap;
+  using MagFieldMap = std::map<std::string, G4MagneticField*>;
 
   /**
    * Get the global instance of the magnetic field store.

--- a/SimCore/include/SimCore/MagneticFieldStore.h
+++ b/SimCore/include/SimCore/MagneticFieldStore.h
@@ -21,7 +21,7 @@ class MagneticFieldStore {
   /**
    * Map of names to magnetic fields.
    */
-  typedef std::map<std::string, G4MagneticField*> MagFieldMap;
+  typedef std::max<std::string, G4MagneticField*>; MagFieldMap;
 
   /**
    * Get the global instance of the magnetic field store.

--- a/SimCore/include/SimCore/MagneticFieldStore.h
+++ b/SimCore/include/SimCore/MagneticFieldStore.h
@@ -8,8 +8,9 @@
 #define SIMCORE_MAGNETICFIELDSTORE_H_
 
 // Geant4
-#include "G4MagneticField.hh"
 #include <map>
+
+#include "G4MagneticField.hh"
 
 namespace simcore {
 
@@ -39,8 +40,8 @@ class MagneticFieldStore {
    * Cleans up all stored G4MagneticFields
    */
   ~MagneticFieldStore() {
-    for (auto& nameField : mag_fields_) {
-      delete nameField.second;
+    for (auto& name_field : mag_fields_) {
+      delete name_field.second;
     }
     mag_fields_.clear();
   }


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
I think with some additional testing I was able to resolve a part of #2072 and get the scheduled jobs on `trunk` to fail **if** changes would be made to source files by format/tidy/lint.

The requirement that changes be made to source files is one that I'm not happy with. I'm hoping we can enable more clang-tidy checks and some of them do not have a "auto-fix" option that change the file, but - for now at least - this will at least alert us when there are "auto-fixes" available for files on `trunk`.

I made a small change to a header file to trigger the apply clang tools on a changed file to see how it performs in CI. It should update the destructor to use the correct style for the local variable name `lower_case` instead of `camelBack`.
