### PR TITLE
complete clang-tidy identifier namings

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -187,7 +187,7 @@ jobs:
 
   post-validation:
     needs: [check-comment, validation]
-    if: always() && (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-validation')))
+    if: (!cancelled()) && (github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/run-validation')))
     runs-on: ubuntu-latest
     steps:
       - name: Resolve PR number

--- a/Biasing/src/Biasing/Utility/StepPrinter.cxx
+++ b/Biasing/src/Biasing/Utility/StepPrinter.cxx
@@ -32,8 +32,8 @@ void StepPrinter::stepping(const G4Step* step) {
   std::string process_name{process ? process->GetProcessName() : "Primary"};
   // Unwrap biasing part of process name if present
   if (process_name.find("biasWrapper") != std::string::npos) {
-    std::size_t pos_ = process_name.find_first_of("(") + 1;
-    process_name = process_name.substr(pos_, process_name.size() - pos_ - 1);
+    std::size_t pos = process_name.find_first_of("(") + 1;
+    process_name = process_name.substr(pos, process_name.size() - pos - 1);
   }
 
   // This could be a negated condition, but it is easier to read this way

--- a/Conditions/include/Conditions/GeneralCSVLoader.h
+++ b/Conditions/include/Conditions/GeneralCSVLoader.h
@@ -73,7 +73,7 @@ class StringCSVLoader : public GeneralCSVLoader {
   /**
    * The separators
    */
-  const std::string linesep_;
+  const std::string LINESEP;
   /**
    * The current start and end pointers
    */

--- a/Conditions/src/Conditions/GeneralCSVLoader.cxx
+++ b/Conditions/src/Conditions/GeneralCSVLoader.cxx
@@ -67,7 +67,7 @@ bool GeneralCSVLoader::nextRow() {
 
 StringCSVLoader::StringCSVLoader(const std::string& source,
                                  const std::string lineseparators)
-    : source_{source}, linesep_{lineseparators}, row_begin_{0}, row_end_{0} {
+    : source_{source}, LINESEP{lineseparators}, row_begin_{0}, row_end_{0} {
   getNextLine();
 }
 
@@ -82,9 +82,9 @@ std::string StringCSVLoader::getNextLine() {
   }
   // now we look for the follow on.
   // find the first non-end-of-line character
-  row_begin_ = source_.find_first_not_of(linesep_, row_end_);
+  row_begin_ = source_.find_first_not_of(LINESEP, row_end_);
   if (row_begin_ != std::string::npos) {
-    row_end_ = source_.find_first_of(linesep_, row_begin_);
+    row_end_ = source_.find_first_of(LINESEP, row_begin_);
   } else {
     row_end_ = std::string::npos;
   }

--- a/DetDescr/include/DetDescr/DetectorHeader.h
+++ b/DetDescr/include/DetDescr/DetectorHeader.h
@@ -7,6 +7,8 @@
 #ifndef DETDESCR_DETECTORHEADER_H_
 #define DETDESCR_DETECTORHEADER_H_
 
+#include <string>
+
 namespace ldmx {
 
 /**

--- a/Packing/include/Packing/Utility/BufferReader.h
+++ b/Packing/include/Packing/Utility/BufferReader.h
@@ -1,9 +1,9 @@
 #ifndef PACKING_BUFFER_H_
 #define PACKING_BUFFER_H_
 
+#include <cstdint>
 #include <stdexcept>
 #include <vector>
-#include <cstdint>
 
 namespace packing {
 namespace utility {

--- a/Packing/include/Packing/Utility/BufferReader.h
+++ b/Packing/include/Packing/Utility/BufferReader.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <vector>
+#include <cstdint>
 
 namespace packing {
 namespace utility {

--- a/Packing/include/Packing/Utility/CRC.h
+++ b/Packing/include/Packing/Utility/CRC.h
@@ -2,6 +2,7 @@
 #define PACKING_UTILITY_CRC_H_
 
 #include <boost/crc.hpp>
+#include <vector>
 
 namespace packing {
 namespace utility {

--- a/Packing/include/Packing/Utility/Mask.h
+++ b/Packing/include/Packing/Utility/Mask.h
@@ -1,6 +1,8 @@
 #ifndef PACKING_UTILITY_MASK_H_
 #define PACKING_UTILITY_MASK_H_
 
+#include <cstdint>
+
 namespace packing {
 namespace utility {
 

--- a/Packing/include/Packing/Utility/Writer.h
+++ b/Packing/include/Packing/Utility/Writer.h
@@ -5,6 +5,7 @@
 #include <iostream>  //debuggin
 #include <string>
 #include <type_traits>
+#include <vector>
 
 namespace packing {
 namespace utility {

--- a/Tools/include/Tools/ElectronicsMap.h
+++ b/Tools/include/Tools/ElectronicsMap.h
@@ -13,6 +13,9 @@
 #include <sstream>
 #include <vector>
 
+#include "DetDescr/DetectorID.h"
+#include "Framework/Exception/Exception.h"
+
 namespace ldmx {
 
 /**

--- a/Tracking/include/Tracking/Digitization/PulseShape.h
+++ b/Tracking/include/Tracking/Digitization/PulseShape.h
@@ -103,7 +103,7 @@ class FourPoleShape : public PulseShape {
 
  private:
   double tp_, tp2_;
-  double A_, B_;
+  double a_, b_;
   double peak_amp_;  ///< g(t_peak), used for normalisation.
 };
 

--- a/Tracking/include/Tracking/Digitization/PulseShape.h
+++ b/Tracking/include/Tracking/Digitization/PulseShape.h
@@ -103,7 +103,7 @@ class FourPoleShape : public PulseShape {
 
  private:
   double tp_, tp2_;
-  double a_, b_;
+  double A_, B_;
   double peak_amp_;  ///< g(t_peak), used for normalisation.
 };
 

--- a/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
+++ b/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
@@ -59,6 +59,9 @@ namespace tracking::digitization {
  */
 class SiStripDigitizer {
  public:
+  // I like not having underscores for struct members,
+  // but that's not settable until a later version of clang-tidy
+  // NOLINTBEGIN(readability-identifier-naming)
   /// All parameters describing one silicon strip sensor layer.
   struct SensorParams {
     /// Sensor thickness [mm].  Must be set from the geometry before use.
@@ -112,6 +115,7 @@ class SiStripDigitizer {
     /// adjacent readout strips.  Applied to both neighbours independently.
     double sense_transfer_efficiency{SENSE_TRANSFER_EFFICIENCY};
   };
+  // NOLINTEND(readability-identifier-naming)
 
   SiStripDigitizer() = default;
 

--- a/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
+++ b/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
@@ -62,55 +62,55 @@ class SiStripDigitizer {
   /// All parameters describing one silicon strip sensor layer.
   struct SensorParams {
     /// Sensor thickness [mm].  Must be set from the geometry before use.
-    double thickness{0.0};
+    double thickness_{0.0};
     /// Sense (inner) electrode pitch [mm].
-    double sense_pitch{SENSE_PITCH_MM};
+    double sense_pitch_{SENSE_PITCH_MM};
     /// Readout strip pitch [mm].  Must be an integer multiple of sense_pitch.
-    double readout_pitch{READOUT_PITCH_MM};
+    double readout_pitch_{READOUT_PITCH_MM};
     /// Applied reverse-bias voltage [V].
-    double bias_voltage{BIAS_VOLTAGE_V};
+    double bias_voltage_{BIAS_VOLTAGE_V};
     /// Full-depletion voltage [V].
-    double depletion_voltage{DEPLETION_VOLTAGE_V};
+    double depletion_voltage_{DEPLETION_VOLTAGE_V};
     /// Operating temperature [K].
-    double temperature{TEMPERATURE_K};
+    double temperature_{TEMPERATURE_K};
     /// Electronic noise sigma [electrons ENC].
-    double noise_electrons{NOISE_ELECTRONS};
+    double noise_electrons_{NOISE_ELECTRONS};
     /// Readout threshold [electrons].  Strips below this are suppressed.
-    double threshold_electrons{THRESHOLD_ELECTRONS};
+    double threshold_electrons_{THRESHOLD_ELECTRONS};
     /// true = n-type bulk; false = p-type bulk. LDMX (and HPS) use n-type bulk.
-    bool is_n_type{true};
+    bool is_n_type_{true};
     /// Simulate and read out the electron-collection side (n-strips).
-    bool electron_side_readout{false};
+    bool electron_side_readout_{false};
     /// Simulate and read out the hole-collection side (p-strips / backplane).
-    bool hole_side_readout{true};
+    bool hole_side_readout_{true};
     /*****   lorentz angles should be calculated from sensor geometry  and
      * bfield  *********/
     /// tan(θ_Lorentz) for electrons.  Sign encodes U-shift direction.
-    double electron_lorentz_tangent{0.0};
+    double electron_lorentz_tangent_{0.0};
     /// tan(θ_Lorentz) for holes.
-    double hole_lorentz_tangent{0.0};
+    double hole_lorentz_tangent_{0.0};
     /////////////////////////////////////////////////////////////////////////////////////////
     /// Charge-trapping fraction lost per 100 µm of drift.
     /// 0.0 for unirradiated; ~0.2 is typical at 1×10¹⁵ n_eq/cm².
-    double trapping{0.0};
+    double trapping_{0.0};
     /// Adaptive segmentation granularity: max U-step as fraction of
     /// sense_pitch.  Number of segments = max(n_segments_min,
     ///   ceil(|path_length · dir_u| / (granularity · sense_pitch))).
-    double deposition_granularity{0.10};
+    double deposition_granularity_{0.10};
     /// Minimum number of track sub-segments (used when the track is close to
     /// normal incidence so the adaptive formula gives a very small count).
-    int n_segments_min{5};
+    int n_segments_min_{5};
     /// Total number of readout strips.  Strip index 0 is at the most-negative
     /// U edge; strip N−1 at the most-positive edge.
-    int n_readout_strips{N_READOUT_STRIPS};
+    int n_readout_strips_{N_READOUT_STRIPS};
     /// AC-coupling transfer efficiency from a paired sense strip (physically
     /// under a readout strip, even index within its group) to its readout
     /// strip.
-    double readout_transfer_efficiency{READOUT_TRANSFER_EFFICIENCY};
+    double readout_transfer_efficiency_{READOUT_TRANSFER_EFFICIENCY};
     /// AC-coupling transfer efficiency from an unpaired sense strip (between
     /// two readout strips, odd index within its group) to each of its two
     /// adjacent readout strips.  Applied to both neighbours independently.
-    double sense_transfer_efficiency{SENSE_TRANSFER_EFFICIENCY};
+    double sense_transfer_efficiency_{SENSE_TRANSFER_EFFICIENCY};
   };
 
   SiStripDigitizer() = default;
@@ -154,7 +154,7 @@ class SiStripDigitizer {
   SensorParams& mutableParams() { return params_; }
 
   /// Set the sensor thickness [mm] from the geometry before processing hits.
-  void setThickness(double thickness) { params_.thickness = thickness; }
+  void setThickness(double thickness) { params_.thickness_ = thickness; }
 
  private:
   /**

--- a/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
+++ b/Tracking/include/Tracking/Digitization/SiStripDigitizer.h
@@ -62,55 +62,55 @@ class SiStripDigitizer {
   /// All parameters describing one silicon strip sensor layer.
   struct SensorParams {
     /// Sensor thickness [mm].  Must be set from the geometry before use.
-    double thickness_{0.0};
+    double thickness{0.0};
     /// Sense (inner) electrode pitch [mm].
-    double sense_pitch_{SENSE_PITCH_MM};
+    double sense_pitch{SENSE_PITCH_MM};
     /// Readout strip pitch [mm].  Must be an integer multiple of sense_pitch.
-    double readout_pitch_{READOUT_PITCH_MM};
+    double readout_pitch{READOUT_PITCH_MM};
     /// Applied reverse-bias voltage [V].
-    double bias_voltage_{BIAS_VOLTAGE_V};
+    double bias_voltage{BIAS_VOLTAGE_V};
     /// Full-depletion voltage [V].
-    double depletion_voltage_{DEPLETION_VOLTAGE_V};
+    double depletion_voltage{DEPLETION_VOLTAGE_V};
     /// Operating temperature [K].
-    double temperature_{TEMPERATURE_K};
+    double temperature{TEMPERATURE_K};
     /// Electronic noise sigma [electrons ENC].
-    double noise_electrons_{NOISE_ELECTRONS};
+    double noise_electrons{NOISE_ELECTRONS};
     /// Readout threshold [electrons].  Strips below this are suppressed.
-    double threshold_electrons_{THRESHOLD_ELECTRONS};
+    double threshold_electrons{THRESHOLD_ELECTRONS};
     /// true = n-type bulk; false = p-type bulk. LDMX (and HPS) use n-type bulk.
-    bool is_n_type_{true};
+    bool is_n_type{true};
     /// Simulate and read out the electron-collection side (n-strips).
-    bool electron_side_readout_{false};
+    bool electron_side_readout{false};
     /// Simulate and read out the hole-collection side (p-strips / backplane).
-    bool hole_side_readout_{true};
+    bool hole_side_readout{true};
     /*****   lorentz angles should be calculated from sensor geometry  and
      * bfield  *********/
     /// tan(θ_Lorentz) for electrons.  Sign encodes U-shift direction.
-    double electron_lorentz_tangent_{0.0};
+    double electron_lorentz_tangent{0.0};
     /// tan(θ_Lorentz) for holes.
-    double hole_lorentz_tangent_{0.0};
+    double hole_lorentz_tangent{0.0};
     /////////////////////////////////////////////////////////////////////////////////////////
     /// Charge-trapping fraction lost per 100 µm of drift.
     /// 0.0 for unirradiated; ~0.2 is typical at 1×10¹⁵ n_eq/cm².
-    double trapping_{0.0};
+    double trapping{0.0};
     /// Adaptive segmentation granularity: max U-step as fraction of
     /// sense_pitch.  Number of segments = max(n_segments_min,
     ///   ceil(|path_length · dir_u| / (granularity · sense_pitch))).
-    double deposition_granularity_{0.10};
+    double deposition_granularity{0.10};
     /// Minimum number of track sub-segments (used when the track is close to
     /// normal incidence so the adaptive formula gives a very small count).
-    int n_segments_min_{5};
+    int n_segments_min{5};
     /// Total number of readout strips.  Strip index 0 is at the most-negative
     /// U edge; strip N−1 at the most-positive edge.
-    int n_readout_strips_{N_READOUT_STRIPS};
+    int n_readout_strips{N_READOUT_STRIPS};
     /// AC-coupling transfer efficiency from a paired sense strip (physically
     /// under a readout strip, even index within its group) to its readout
     /// strip.
-    double readout_transfer_efficiency_{READOUT_TRANSFER_EFFICIENCY};
+    double readout_transfer_efficiency{READOUT_TRANSFER_EFFICIENCY};
     /// AC-coupling transfer efficiency from an unpaired sense strip (between
     /// two readout strips, odd index within its group) to each of its two
     /// adjacent readout strips.  Applied to both neighbours independently.
-    double sense_transfer_efficiency_{SENSE_TRANSFER_EFFICIENCY};
+    double sense_transfer_efficiency{SENSE_TRANSFER_EFFICIENCY};
   };
 
   SiStripDigitizer() = default;
@@ -154,7 +154,7 @@ class SiStripDigitizer {
   SensorParams& mutableParams() { return params_; }
 
   /// Set the sensor thickness [mm] from the geometry before processing hits.
-  void setThickness(double thickness) { params_.thickness_ = thickness; }
+  void setThickness(double thickness) { params_.thickness = thickness; }
 
  private:
   /**

--- a/Tracking/include/Tracking/Digitization/StripClusterer.h
+++ b/Tracking/include/Tracking/Digitization/StripClusterer.h
@@ -47,6 +47,9 @@ namespace tracking::digitization {
  */
 class StripClusterer {
  public:
+  // I like not having underscores for struct members,
+  // but that's not settable until a later version of clang-tidy
+  // NOLINTBEGIN(readability-identifier-naming)
   struct ClusterCandidate {
     double centroid_strip{0};   ///< Charge-weighted mean strip index.
     double total_amplitude{0};  ///< Total cluster amplitude [ADC counts].
@@ -56,6 +59,7 @@ class StripClusterer {
     int layer_id{-1};
     std::vector<int> strip_ids;
   };
+  // NOLINTEND(readability-identifier-naming)
 
   /**
    * @param seed_threshold      Minimum amplitude/noise to seed a cluster

--- a/Tracking/include/Tracking/Digitization/StripClusterer.h
+++ b/Tracking/include/Tracking/Digitization/StripClusterer.h
@@ -48,13 +48,13 @@ namespace tracking::digitization {
 class StripClusterer {
  public:
   struct ClusterCandidate {
-    double centroid_strip_{0};   ///< Charge-weighted mean strip index.
-    double total_amplitude_{0};  ///< Total cluster amplitude [ADC counts].
-    double time_ns_{0};          ///< Amplitude-weighted mean hit time [ns].
-    double sigma_strip_{0};      ///< Position uncertainty [strips].
-    int n_strips_{0};
-    int layer_id_{-1};
-    std::vector<int> strip_ids_;
+    double centroid_strip{0};   ///< Charge-weighted mean strip index.
+    double total_amplitude{0};  ///< Total cluster amplitude [ADC counts].
+    double time_ns{0};          ///< Amplitude-weighted mean hit time [ns].
+    double sigma_strip{0};      ///< Position uncertainty [strips].
+    int n_strips{0};
+    int layer_id{-1};
+    std::vector<int> strip_ids;
   };
 
   /**

--- a/Tracking/include/Tracking/Digitization/StripClusterer.h
+++ b/Tracking/include/Tracking/Digitization/StripClusterer.h
@@ -48,13 +48,13 @@ namespace tracking::digitization {
 class StripClusterer {
  public:
   struct ClusterCandidate {
-    double centroid_strip{0};   ///< Charge-weighted mean strip index.
-    double total_amplitude{0};  ///< Total cluster amplitude [ADC counts].
-    double time_ns{0};          ///< Amplitude-weighted mean hit time [ns].
-    double sigma_strip{0};      ///< Position uncertainty [strips].
-    int n_strips{0};
-    int layer_id{-1};
-    std::vector<int> strip_ids;
+    double centroid_strip_{0};   ///< Charge-weighted mean strip index.
+    double total_amplitude_{0};  ///< Total cluster amplitude [ADC counts].
+    double time_ns_{0};          ///< Amplitude-weighted mean hit time [ns].
+    double sigma_strip_{0};      ///< Position uncertainty [strips].
+    int n_strips_{0};
+    int layer_id_{-1};
+    std::vector<int> strip_ids_;
   };
 
   /**

--- a/Tracking/include/Tracking/Digitization/StripPulseFitter.h
+++ b/Tracking/include/Tracking/Digitization/StripPulseFitter.h
@@ -39,6 +39,9 @@ namespace tracking::digitization {
  */
 class StripPulseFitter {
  public:
+  // I like not having underscores for struct members,
+  // but that's not settable until a later version of clang-tidy
+  // NOLINTBEGIN(readability-identifier-naming)
   struct FitResult {
     double amplitude{
         0};          ///< Fitted peak amplitude [ADC counts], ped-subtracted.
@@ -47,6 +50,7 @@ class StripPulseFitter {
     int ndf{0};      ///< Degrees of freedom = n_samples − 2.
     bool converged{false};  ///< False if no above-pedestal samples found.
   };
+  // NOLINTEND(readability-identifier-naming)
 
   /**
    * @param shape               Pulse shape function (owned externally).

--- a/Tracking/include/Tracking/Digitization/StripPulseFitter.h
+++ b/Tracking/include/Tracking/Digitization/StripPulseFitter.h
@@ -40,12 +40,12 @@ namespace tracking::digitization {
 class StripPulseFitter {
  public:
   struct FitResult {
-    double amplitude_{
-        0};           ///< Fitted peak amplitude [ADC counts], ped-subtracted.
-    double t0_{0};    ///< Fitted hit arrival time T [ns].
-    double chi2_{0};  ///< Chi-squared value at the minimum.
-    int ndf_{0};      ///< Degrees of freedom = n_samples − 2.
-    bool converged_{false};  ///< False if no above-pedestal samples found.
+    double amplitude{
+        0};          ///< Fitted peak amplitude [ADC counts], ped-subtracted.
+    double t0{0};    ///< Fitted hit arrival time T [ns].
+    double chi2{0};  ///< Chi-squared value at the minimum.
+    int ndf{0};      ///< Degrees of freedom = n_samples − 2.
+    bool converged{false};  ///< False if no above-pedestal samples found.
   };
 
   /**

--- a/Tracking/include/Tracking/Digitization/StripPulseFitter.h
+++ b/Tracking/include/Tracking/Digitization/StripPulseFitter.h
@@ -40,12 +40,12 @@ namespace tracking::digitization {
 class StripPulseFitter {
  public:
   struct FitResult {
-    double amplitude{
-        0};          ///< Fitted peak amplitude [ADC counts], ped-subtracted.
-    double t0{0};    ///< Fitted hit arrival time T [ns].
-    double chi2{0};  ///< Chi-squared value at the minimum.
-    int ndf{0};      ///< Degrees of freedom = n_samples − 2.
-    bool converged{false};  ///< False if no above-pedestal samples found.
+    double amplitude_{
+        0};           ///< Fitted peak amplitude [ADC counts], ped-subtracted.
+    double t0_{0};    ///< Fitted hit arrival time T [ns].
+    double chi2_{0};  ///< Chi-squared value at the minimum.
+    int ndf_{0};      ///< Degrees of freedom = n_samples − 2.
+    bool converged_{false};  ///< False if no above-pedestal samples found.
   };
 
   /**

--- a/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
+++ b/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
@@ -37,6 +37,9 @@ class TrackComparisonProcessor : public framework::Analyzer {
   void onProcessEnd() override;
 
  private:
+  // I like not having underscores for struct members,
+  // but that's not settable until a later version of clang-tidy
+  // NOLINTBEGIN(readability-identifier-naming)
   struct PairVars {
     int track_id{-1};
     float truth_prob_s{-1}, truth_prob_d{-1};
@@ -59,6 +62,7 @@ class TrackComparisonProcessor : public framework::Analyzer {
     float vx_t{-999}, vy_t{-999}, vz_t{-999};
     float delta_p_over_p_s{-999}, delta_p_over_p_d{-999};
   };
+  // NOLINTEND(readability-identifier-naming)
 
   void setupTree(TTree* tree, PairVars& v);
   void fillPair(const ldmx::Track& smear, const ldmx::Track& digi,

--- a/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
+++ b/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
@@ -38,26 +38,26 @@ class TrackComparisonProcessor : public framework::Analyzer {
 
  private:
   struct PairVars {
-    int track_id_{-1};
-    float truth_prob_s_{-1}, truth_prob_d_{-1};
-    int nhits_s_{-1}, nhits_d_{-1};
-    float chi2ndf_s_{-999}, chi2ndf_d_{-999};
-    float d0_s_{-999}, d0_d_{-999};
-    float z0_s_{-999}, z0_d_{-999};
-    float phi_s_{-999}, phi_d_{-999};
-    float theta_s_{-999}, theta_d_{-999};
-    float qop_s_{-999}, qop_d_{-999};
-    float p_s_{-999}, p_d_{-999};
-    float delta_d0_{-999}, delta_z0_{-999};
-    float delta_phi_{-999}, delta_theta_{-999};
-    float delta_p_over_p_{-999};
-    float px_s_{-999}, py_s_{-999}, pz_s_{-999};
-    float px_d_{-999}, py_d_{-999}, pz_d_{-999};
+    int track_id{-1};
+    float truth_prob_s{-1}, truth_prob_d{-1};
+    int nhits_s{-1}, nhits_d{-1};
+    float chi2ndf_s{-999}, chi2ndf_d{-999};
+    float d0_s{-999}, d0_d{-999};
+    float z0_s{-999}, z0_d{-999};
+    float phi_s{-999}, phi_d{-999};
+    float theta_s{-999}, theta_d{-999};
+    float qop_s{-999}, qop_d{-999};
+    float p_s{-999}, p_d{-999};
+    float delta_d0{-999}, delta_z0{-999};
+    float delta_phi{-999}, delta_theta{-999};
+    float delta_p_over_p{-999};
+    float px_s{-999}, py_s{-999}, pz_s{-999};
+    float px_d{-999}, py_d{-999}, pz_d{-999};
     // truth (SimParticle)
-    float px_t_{-999}, py_t_{-999}, pz_t_{-999};
-    float p_t_{-999};
-    float vx_t_{-999}, vy_t_{-999}, vz_t_{-999};
-    float delta_p_over_p_s_{-999}, delta_p_over_p_d_{-999};
+    float px_t{-999}, py_t{-999}, pz_t{-999};
+    float p_t{-999};
+    float vx_t{-999}, vy_t{-999}, vz_t{-999};
+    float delta_p_over_p_s{-999}, delta_p_over_p_d{-999};
   };
 
   void setupTree(TTree* tree, PairVars& v);

--- a/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
+++ b/Tracking/include/Tracking/Reco/TrackComparisonProcessor.h
@@ -38,26 +38,26 @@ class TrackComparisonProcessor : public framework::Analyzer {
 
  private:
   struct PairVars {
-    int track_id{-1};
-    float truth_prob_s{-1}, truth_prob_d{-1};
-    int nhits_s{-1}, nhits_d{-1};
-    float chi2ndf_s{-999}, chi2ndf_d{-999};
-    float d0_s{-999}, d0_d{-999};
-    float z0_s{-999}, z0_d{-999};
-    float phi_s{-999}, phi_d{-999};
-    float theta_s{-999}, theta_d{-999};
-    float qop_s{-999}, qop_d{-999};
-    float p_s{-999}, p_d{-999};
-    float delta_d0{-999}, delta_z0{-999};
-    float delta_phi{-999}, delta_theta{-999};
-    float delta_p_over_p{-999};
-    float px_s{-999}, py_s{-999}, pz_s{-999};
-    float px_d{-999}, py_d{-999}, pz_d{-999};
+    int track_id_{-1};
+    float truth_prob_s_{-1}, truth_prob_d_{-1};
+    int nhits_s_{-1}, nhits_d_{-1};
+    float chi2ndf_s_{-999}, chi2ndf_d_{-999};
+    float d0_s_{-999}, d0_d_{-999};
+    float z0_s_{-999}, z0_d_{-999};
+    float phi_s_{-999}, phi_d_{-999};
+    float theta_s_{-999}, theta_d_{-999};
+    float qop_s_{-999}, qop_d_{-999};
+    float p_s_{-999}, p_d_{-999};
+    float delta_d0_{-999}, delta_z0_{-999};
+    float delta_phi_{-999}, delta_theta_{-999};
+    float delta_p_over_p_{-999};
+    float px_s_{-999}, py_s_{-999}, pz_s_{-999};
+    float px_d_{-999}, py_d_{-999}, pz_d_{-999};
     // truth (SimParticle)
-    float px_t{-999}, py_t{-999}, pz_t{-999};
-    float p_t{-999};
-    float vx_t{-999}, vy_t{-999}, vz_t{-999};
-    float delta_p_over_p_s{-999}, delta_p_over_p_d{-999};
+    float px_t_{-999}, py_t_{-999}, pz_t_{-999};
+    float p_t_{-999};
+    float vx_t_{-999}, vy_t_{-999}, vz_t_{-999};
+    float delta_p_over_p_s_{-999}, delta_p_over_p_d_{-999};
   };
 
   void setupTree(TTree* tree, PairVars& v);

--- a/Tracking/src/Tracking/Digitization/PulseShape.cxx
+++ b/Tracking/src/Tracking/Digitization/PulseShape.cxx
@@ -13,23 +13,23 @@ FourPoleShape::FourPoleShape(double tp, double tp2) : tp_(tp), tp2_(tp2) {
     EXCEPTION_RAISE("InvalidArgument", "FourPoleShape: requires tp > tp2 > 0");
   }
 
-  A_ = (tp_ * tp_) / std::pow(tp_ - tp2_, 3.0);
-  B_ = (tp_ - tp2_) / (tp_ * tp2_);
+  a_ = (tp_ * tp_) / std::pow(tp_ - tp2_, 3.0);
+  b_ = (tp_ - tp2_) / (tp_ * tp2_);
 
   // Approximate peak time: 3·(tp·tp2³)^(1/4)
   const double t_peak = 3.0 * std::pow(tp_ * std::pow(tp2_, 3.0), 0.25);
 
   // Evaluate un-normalised amplitude at the peak for normalisation.
-  peak_amp_ = A_ * (std::exp(-t_peak / tp_) -
+  peak_amp_ = a_ * (std::exp(-t_peak / tp_) -
                     std::exp(-t_peak / tp2_) *
-                        (1.0 + t_peak * B_ + 0.5 * t_peak * t_peak * B_ * B_));
+                        (1.0 + t_peak * b_ + 0.5 * t_peak * t_peak * b_ * b_));
 }
 
 double FourPoleShape::eval(double t) const {
   if (t <= 0.0) return 0.0;
   const double g =
-      A_ * (std::exp(-t / tp_) -
-            std::exp(-t / tp2_) * (1.0 + t * B_ + 0.5 * t * t * B_ * B_));
+      a_ * (std::exp(-t / tp_) -
+            std::exp(-t / tp2_) * (1.0 + t * b_ + 0.5 * t * t * b_ * b_));
   return g / peak_amp_;
 }
 

--- a/Tracking/src/Tracking/Digitization/PulseShape.cxx
+++ b/Tracking/src/Tracking/Digitization/PulseShape.cxx
@@ -13,23 +13,23 @@ FourPoleShape::FourPoleShape(double tp, double tp2) : tp_(tp), tp2_(tp2) {
     EXCEPTION_RAISE("InvalidArgument", "FourPoleShape: requires tp > tp2 > 0");
   }
 
-  a_ = (tp_ * tp_) / std::pow(tp_ - tp2_, 3.0);
-  b_ = (tp_ - tp2_) / (tp_ * tp2_);
+  A_ = (tp_ * tp_) / std::pow(tp_ - tp2_, 3.0);
+  B_ = (tp_ - tp2_) / (tp_ * tp2_);
 
   // Approximate peak time: 3·(tp·tp2³)^(1/4)
   const double t_peak = 3.0 * std::pow(tp_ * std::pow(tp2_, 3.0), 0.25);
 
   // Evaluate un-normalised amplitude at the peak for normalisation.
-  peak_amp_ = a_ * (std::exp(-t_peak / tp_) -
+  peak_amp_ = A_ * (std::exp(-t_peak / tp_) -
                     std::exp(-t_peak / tp2_) *
-                        (1.0 + t_peak * b_ + 0.5 * t_peak * t_peak * b_ * b_));
+                        (1.0 + t_peak * B_ + 0.5 * t_peak * t_peak * B_ * B_));
 }
 
 double FourPoleShape::eval(double t) const {
   if (t <= 0.0) return 0.0;
   const double g =
-      a_ * (std::exp(-t / tp_) -
-            std::exp(-t / tp2_) * (1.0 + t * b_ + 0.5 * t * t * b_ * b_));
+      A_ * (std::exp(-t / tp_) -
+            std::exp(-t / tp2_) * (1.0 + t * B_ + 0.5 * t * t * B_ * B_));
   return g / peak_amp_;
 }
 

--- a/Tracking/src/Tracking/Digitization/SiStripDigitizer.cxx
+++ b/Tracking/src/Tracking/Digitization/SiStripDigitizer.cxx
@@ -27,18 +27,18 @@ int SiStripDigitizer::adaptiveNSegments(const Acts::Vector3& local_dir,
   // Ensure U-displacement per segment <= granularity * sense_pitch.
   // For near-normal-incidence tracks (dir_u ≈ 0) the adaptive count can be
   // very small; clamp to n_segments_min.
-  const double max_step = params_.deposition_granularity_ * params_.sense_pitch_;
+  const double max_step = params_.deposition_granularity * params_.sense_pitch;
   const double total_u = std::abs(path_length * local_dir[0]);
   const int adaptive =
       (max_step > 0.0) ? static_cast<int>(std::ceil(total_u / max_step)) : 1;
-  return std::max(params_.n_segments_min_, adaptive);
+  return std::max(params_.n_segments_min, adaptive);
 }
 
 double SiStripDigitizer::diffusionSigma(double d, bool is_minority) const {
-  const double kt_q = KT_Q_300K * params_.temperature_ / 300.0;
-  const double t = params_.thickness_;
-  const double vb = params_.bias_voltage_;
-  const double vd = params_.depletion_voltage_;
+  const double kt_q = KT_Q_300K * params_.temperature / 300.0;
+  const double t = params_.thickness;
+  const double vb = params_.bias_voltage;
+  const double vd = params_.depletion_voltage;
 
   double sigma_sq = 0.0;
 
@@ -108,15 +108,15 @@ std::map<int, double> SiStripDigitizer::computeCarrierCharges(
 
     // Drift distance to collection electrode, clamped to sensor thickness.
     const double drift =
-        std::max(0.0, std::min(params_.thickness_, std::abs(w_collect - w_seg)));
+        std::max(0.0, std::min(params_.thickness, std::abs(w_collect - w_seg)));
 
     // Charge trapping: linear model from CDFSiSensorSim.
     // trapping_ = fraction lost per 100 µm (= 0.1 mm) of drift.
     // collection_efficiency = 1 − 10·trapping·drift_mm
     double q_seg = q_per_seg;
-    if (params_.trapping_ > 0.0) {
+    if (params_.trapping > 0.0) {
       const double efficiency =
-          std::max(0.0, std::min(1.0, 1.0 - 10.0 * params_.trapping_ * drift));
+          std::max(0.0, std::min(1.0, 1.0 - 10.0 * params_.trapping * drift));
       q_seg *= efficiency;
     }
 
@@ -130,14 +130,14 @@ std::map<int, double> SiStripDigitizer::computeCarrierCharges(
 
     // Deposit charge on sense strips within 5 sigma of the charge centroid.
     const int strip_lo = static_cast<int>(
-        std::floor((u_dest - 5.0 * sigma) / params_.sense_pitch_));
+        std::floor((u_dest - 5.0 * sigma) / params_.sense_pitch));
     const int strip_hi = static_cast<int>(
-        std::ceil((u_dest + 5.0 * sigma) / params_.sense_pitch_));
+        std::ceil((u_dest + 5.0 * sigma) / params_.sense_pitch));
 
     for (int istrip = strip_lo; istrip <= strip_hi; ++istrip) {
-      const double strip_center = istrip * params_.sense_pitch_;
+      const double strip_center = istrip * params_.sense_pitch;
       const double frac =
-          stripFraction(u_dest, sigma, strip_center, params_.sense_pitch_);
+          stripFraction(u_dest, sigma, strip_center, params_.sense_pitch);
       if (frac > 1.0e-7) {
         sense_charges[istrip] += q_seg * frac;
       }
@@ -151,16 +151,16 @@ std::map<int, double> SiStripDigitizer::senseToReadout(
     const std::map<int, double>& sense_charges) const {
   const int ratio =
       std::max(1, static_cast<int>(
-                      std::round(params_.readout_pitch_ / params_.sense_pitch_)));
+                      std::round(params_.readout_pitch / params_.sense_pitch)));
 
-  const int offset = params_.n_readout_strips_ / 2;
+  const int offset = params_.n_readout_strips / 2;
   std::map<int, double> readout_charges;
 
   if (ratio == 1) {
     // No interleaving: paired strip only, apply readout transfer efficiency.
     for (const auto& [sense_strip, charge] : sense_charges) {
       readout_charges[sense_strip + offset] +=
-          charge * params_.readout_transfer_efficiency_;
+          charge * params_.readout_transfer_efficiency;
     }
     return readout_charges;
   }
@@ -185,10 +185,10 @@ std::map<int, double> SiStripDigitizer::senseToReadout(
     const int r = k + offset;
 
     if (position_in_group == 0) {
-      readout_charges[r] += charge * params_.readout_transfer_efficiency_;
+      readout_charges[r] += charge * params_.readout_transfer_efficiency;
     } else {
-      readout_charges[r] += charge * params_.sense_transfer_efficiency_;
-      readout_charges[r + 1] += charge * params_.sense_transfer_efficiency_;
+      readout_charges[r] += charge * params_.sense_transfer_efficiency;
+      readout_charges[r + 1] += charge * params_.sense_transfer_efficiency;
     }
   }
   return readout_charges;
@@ -209,28 +209,28 @@ std::map<int, double> SiStripDigitizer::computeStripCharges(
   // p-type bulk (is_n_type = false): electrons = minority, holes = majority.
   // n-type bulk (is_n_type = true):  holes     = minority, electrons =
   // majority.
-  const bool electron_is_minority = !params_.is_n_type_;
-  const bool hole_is_minority = params_.is_n_type_;
+  const bool electron_is_minority = !params_.is_n_type;
+  const bool hole_is_minority = params_.is_n_type;
 
   std::map<int, double> readout_charges;
 
   // Electron side: collection at W = +thickness/2 (n-strip side).
-  if (params_.electron_side_readout_) {
-    const double w_electron = +0.5 * params_.thickness_;
+  if (params_.electron_side_readout) {
+    const double w_electron = +0.5 * params_.thickness;
     auto sense = computeCarrierCharges(
         q_per_seg, n_seg, local_pos, local_dir, path_length, w_electron,
-        params_.electron_lorentz_tangent_, electron_is_minority);
+        params_.electron_lorentz_tangent, electron_is_minority);
     for (const auto& [strip, charge] : senseToReadout(sense)) {
       readout_charges[strip] += charge;
     }
   }
 
   // Hole side: collection at W = −thickness/2 (p-bulk / backplane side).
-  if (params_.hole_side_readout_) {
-    const double w_hole = -0.5 * params_.thickness_;
+  if (params_.hole_side_readout) {
+    const double w_hole = -0.5 * params_.thickness;
     auto sense = computeCarrierCharges(
         q_per_seg, n_seg, local_pos, local_dir, path_length, w_hole,
-        params_.hole_lorentz_tangent_, hole_is_minority);
+        params_.hole_lorentz_tangent, hole_is_minority);
     for (const auto& [strip, charge] : senseToReadout(sense)) {
       readout_charges[strip] += charge;
     }
@@ -255,12 +255,12 @@ void SiStripDigitizer::applyNoiseAndThreshold(
 
   // Add Gaussian noise to all strips.
   for (auto& [strip, charge] : strip_charges) {
-    charge += params_.noise_electrons_ * normal_(generator_);
+    charge += params_.noise_electrons * normal_(generator_);
   }
 
   // Remove strips below the readout threshold.
   for (auto it = strip_charges.begin(); it != strip_charges.end();) {
-    it = (it->second < params_.threshold_electrons_) ? strip_charges.erase(it)
+    it = (it->second < params_.threshold_electrons) ? strip_charges.erase(it)
                                                     : std::next(it);
   }
 }

--- a/Tracking/src/Tracking/Digitization/SiStripDigitizer.cxx
+++ b/Tracking/src/Tracking/Digitization/SiStripDigitizer.cxx
@@ -27,18 +27,18 @@ int SiStripDigitizer::adaptiveNSegments(const Acts::Vector3& local_dir,
   // Ensure U-displacement per segment <= granularity * sense_pitch.
   // For near-normal-incidence tracks (dir_u ≈ 0) the adaptive count can be
   // very small; clamp to n_segments_min.
-  const double max_step = params_.deposition_granularity * params_.sense_pitch;
+  const double max_step = params_.deposition_granularity_ * params_.sense_pitch_;
   const double total_u = std::abs(path_length * local_dir[0]);
   const int adaptive =
       (max_step > 0.0) ? static_cast<int>(std::ceil(total_u / max_step)) : 1;
-  return std::max(params_.n_segments_min, adaptive);
+  return std::max(params_.n_segments_min_, adaptive);
 }
 
 double SiStripDigitizer::diffusionSigma(double d, bool is_minority) const {
-  const double kt_q = KT_Q_300K * params_.temperature / 300.0;
-  const double t = params_.thickness;
-  const double vb = params_.bias_voltage;
-  const double vd = params_.depletion_voltage;
+  const double kt_q = KT_Q_300K * params_.temperature_ / 300.0;
+  const double t = params_.thickness_;
+  const double vb = params_.bias_voltage_;
+  const double vd = params_.depletion_voltage_;
 
   double sigma_sq = 0.0;
 
@@ -108,15 +108,15 @@ std::map<int, double> SiStripDigitizer::computeCarrierCharges(
 
     // Drift distance to collection electrode, clamped to sensor thickness.
     const double drift =
-        std::max(0.0, std::min(params_.thickness, std::abs(w_collect - w_seg)));
+        std::max(0.0, std::min(params_.thickness_, std::abs(w_collect - w_seg)));
 
     // Charge trapping: linear model from CDFSiSensorSim.
     // trapping_ = fraction lost per 100 µm (= 0.1 mm) of drift.
     // collection_efficiency = 1 − 10·trapping·drift_mm
     double q_seg = q_per_seg;
-    if (params_.trapping > 0.0) {
+    if (params_.trapping_ > 0.0) {
       const double efficiency =
-          std::max(0.0, std::min(1.0, 1.0 - 10.0 * params_.trapping * drift));
+          std::max(0.0, std::min(1.0, 1.0 - 10.0 * params_.trapping_ * drift));
       q_seg *= efficiency;
     }
 
@@ -130,14 +130,14 @@ std::map<int, double> SiStripDigitizer::computeCarrierCharges(
 
     // Deposit charge on sense strips within 5 sigma of the charge centroid.
     const int strip_lo = static_cast<int>(
-        std::floor((u_dest - 5.0 * sigma) / params_.sense_pitch));
+        std::floor((u_dest - 5.0 * sigma) / params_.sense_pitch_));
     const int strip_hi = static_cast<int>(
-        std::ceil((u_dest + 5.0 * sigma) / params_.sense_pitch));
+        std::ceil((u_dest + 5.0 * sigma) / params_.sense_pitch_));
 
     for (int istrip = strip_lo; istrip <= strip_hi; ++istrip) {
-      const double strip_center = istrip * params_.sense_pitch;
+      const double strip_center = istrip * params_.sense_pitch_;
       const double frac =
-          stripFraction(u_dest, sigma, strip_center, params_.sense_pitch);
+          stripFraction(u_dest, sigma, strip_center, params_.sense_pitch_);
       if (frac > 1.0e-7) {
         sense_charges[istrip] += q_seg * frac;
       }
@@ -151,16 +151,16 @@ std::map<int, double> SiStripDigitizer::senseToReadout(
     const std::map<int, double>& sense_charges) const {
   const int ratio =
       std::max(1, static_cast<int>(
-                      std::round(params_.readout_pitch / params_.sense_pitch)));
+                      std::round(params_.readout_pitch_ / params_.sense_pitch_)));
 
-  const int offset = params_.n_readout_strips / 2;
+  const int offset = params_.n_readout_strips_ / 2;
   std::map<int, double> readout_charges;
 
   if (ratio == 1) {
     // No interleaving: paired strip only, apply readout transfer efficiency.
     for (const auto& [sense_strip, charge] : sense_charges) {
       readout_charges[sense_strip + offset] +=
-          charge * params_.readout_transfer_efficiency;
+          charge * params_.readout_transfer_efficiency_;
     }
     return readout_charges;
   }
@@ -185,10 +185,10 @@ std::map<int, double> SiStripDigitizer::senseToReadout(
     const int r = k + offset;
 
     if (position_in_group == 0) {
-      readout_charges[r] += charge * params_.readout_transfer_efficiency;
+      readout_charges[r] += charge * params_.readout_transfer_efficiency_;
     } else {
-      readout_charges[r] += charge * params_.sense_transfer_efficiency;
-      readout_charges[r + 1] += charge * params_.sense_transfer_efficiency;
+      readout_charges[r] += charge * params_.sense_transfer_efficiency_;
+      readout_charges[r + 1] += charge * params_.sense_transfer_efficiency_;
     }
   }
   return readout_charges;
@@ -209,28 +209,28 @@ std::map<int, double> SiStripDigitizer::computeStripCharges(
   // p-type bulk (is_n_type = false): electrons = minority, holes = majority.
   // n-type bulk (is_n_type = true):  holes     = minority, electrons =
   // majority.
-  const bool electron_is_minority = !params_.is_n_type;
-  const bool hole_is_minority = params_.is_n_type;
+  const bool electron_is_minority = !params_.is_n_type_;
+  const bool hole_is_minority = params_.is_n_type_;
 
   std::map<int, double> readout_charges;
 
   // Electron side: collection at W = +thickness/2 (n-strip side).
-  if (params_.electron_side_readout) {
-    const double w_electron = +0.5 * params_.thickness;
+  if (params_.electron_side_readout_) {
+    const double w_electron = +0.5 * params_.thickness_;
     auto sense = computeCarrierCharges(
         q_per_seg, n_seg, local_pos, local_dir, path_length, w_electron,
-        params_.electron_lorentz_tangent, electron_is_minority);
+        params_.electron_lorentz_tangent_, electron_is_minority);
     for (const auto& [strip, charge] : senseToReadout(sense)) {
       readout_charges[strip] += charge;
     }
   }
 
   // Hole side: collection at W = −thickness/2 (p-bulk / backplane side).
-  if (params_.hole_side_readout) {
-    const double w_hole = -0.5 * params_.thickness;
+  if (params_.hole_side_readout_) {
+    const double w_hole = -0.5 * params_.thickness_;
     auto sense = computeCarrierCharges(
         q_per_seg, n_seg, local_pos, local_dir, path_length, w_hole,
-        params_.hole_lorentz_tangent, hole_is_minority);
+        params_.hole_lorentz_tangent_, hole_is_minority);
     for (const auto& [strip, charge] : senseToReadout(sense)) {
       readout_charges[strip] += charge;
     }
@@ -255,12 +255,12 @@ void SiStripDigitizer::applyNoiseAndThreshold(
 
   // Add Gaussian noise to all strips.
   for (auto& [strip, charge] : strip_charges) {
-    charge += params_.noise_electrons * normal_(generator_);
+    charge += params_.noise_electrons_ * normal_(generator_);
   }
 
   // Remove strips below the readout threshold.
   for (auto it = strip_charges.begin(); it != strip_charges.end();) {
-    it = (it->second < params_.threshold_electrons) ? strip_charges.erase(it)
+    it = (it->second < params_.threshold_electrons_) ? strip_charges.erase(it)
                                                     : std::next(it);
   }
 }

--- a/Tracking/src/Tracking/Digitization/StripClusterer.cxx
+++ b/Tracking/src/Tracking/Digitization/StripClusterer.cxx
@@ -120,7 +120,7 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
       const double amp = hit.getAmplitude();
 
       // Accumulate cluster quantities.
-      cand.strip_ids_.push_back(cur_ch);
+      cand.strip_ids.push_back(cur_ch);
       cluster_total_amp += amp;
       cluster_weighted_t += amp * hit.getT0();
       cluster_noise_sq += noise_sigma_adc_ * noise_sigma_adc_;
@@ -151,14 +151,14 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
     // Compute the charge-weighted centroid strip and timing.
     // -----------------------------------------------------------------------
     double sum_amp_strip = 0.0;
-    for (int ch : cand.strip_ids_) {
+    for (int ch : cand.strip_ids) {
       sum_amp_strip += channel_map.at(ch)->getAmplitude() * ch;
     }
 
-    cand.centroid_strip_ = sum_amp_strip / cluster_total_amp;
-    cand.total_amplitude_ = cluster_total_amp;
-    cand.time_ns_ = cluster_weighted_t / cluster_total_amp;
-    cand.n_strips_ = static_cast<int>(cand.strip_ids_.size());
+    cand.centroid_strip = sum_amp_strip / cluster_total_amp;
+    cand.total_amplitude = cluster_total_amp;
+    cand.time_ns = cluster_weighted_t / cluster_total_amp;
+    cand.n_strips = static_cast<int>(cand.strip_ids.size());
 
     // Charge-weighted RMS around the centroid [strips].
     // For multi-strip clusters this uses the actual charge-sharing profile,
@@ -166,14 +166,14 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
     // For single-strip clusters the RMS is zero, so we floor at the binary
     // single-strip uncertainty 1/√12.
     double sum_amp_dsq = 0.0;
-    for (int ch : cand.strip_ids_) {
-      double d = ch - cand.centroid_strip_;
+    for (int ch : cand.strip_ids) {
+      double d = ch - cand.centroid_strip;
       sum_amp_dsq += channel_map.at(ch)->getAmplitude() * d * d;
     }
     constexpr double k_single_strip_sigma = 1.0 / 3.4641;  // 1/√12
     const double rms = std::sqrt(sum_amp_dsq / cluster_total_amp);
-    cand.sigma_strip_ = (rms > 0.0) ? rms : k_single_strip_sigma;
-    cand.layer_id_ = channel_map.at(seed_ch)->getLayerID();
+    cand.sigma_strip = (rms > 0.0) ? rms : k_single_strip_sigma;
+    cand.layer_id = channel_map.at(seed_ch)->getLayerID();
 
     clusters.push_back(std::move(cand));
   }

--- a/Tracking/src/Tracking/Digitization/StripClusterer.cxx
+++ b/Tracking/src/Tracking/Digitization/StripClusterer.cxx
@@ -120,7 +120,7 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
       const double amp = hit.getAmplitude();
 
       // Accumulate cluster quantities.
-      cand.strip_ids.push_back(cur_ch);
+      cand.strip_ids_.push_back(cur_ch);
       cluster_total_amp += amp;
       cluster_weighted_t += amp * hit.getT0();
       cluster_noise_sq += noise_sigma_adc_ * noise_sigma_adc_;
@@ -151,14 +151,14 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
     // Compute the charge-weighted centroid strip and timing.
     // -----------------------------------------------------------------------
     double sum_amp_strip = 0.0;
-    for (int ch : cand.strip_ids) {
+    for (int ch : cand.strip_ids_) {
       sum_amp_strip += channel_map.at(ch)->getAmplitude() * ch;
     }
 
-    cand.centroid_strip = sum_amp_strip / cluster_total_amp;
-    cand.total_amplitude = cluster_total_amp;
-    cand.time_ns = cluster_weighted_t / cluster_total_amp;
-    cand.n_strips = static_cast<int>(cand.strip_ids.size());
+    cand.centroid_strip_ = sum_amp_strip / cluster_total_amp;
+    cand.total_amplitude_ = cluster_total_amp;
+    cand.time_ns_ = cluster_weighted_t / cluster_total_amp;
+    cand.n_strips_ = static_cast<int>(cand.strip_ids_.size());
 
     // Charge-weighted RMS around the centroid [strips].
     // For multi-strip clusters this uses the actual charge-sharing profile,
@@ -166,14 +166,14 @@ std::vector<StripClusterer::ClusterCandidate> StripClusterer::findClusters(
     // For single-strip clusters the RMS is zero, so we floor at the binary
     // single-strip uncertainty 1/√12.
     double sum_amp_dsq = 0.0;
-    for (int ch : cand.strip_ids) {
-      double d = ch - cand.centroid_strip;
+    for (int ch : cand.strip_ids_) {
+      double d = ch - cand.centroid_strip_;
       sum_amp_dsq += channel_map.at(ch)->getAmplitude() * d * d;
     }
     constexpr double k_single_strip_sigma = 1.0 / 3.4641;  // 1/√12
     const double rms = std::sqrt(sum_amp_dsq / cluster_total_amp);
-    cand.sigma_strip = (rms > 0.0) ? rms : k_single_strip_sigma;
-    cand.layer_id = channel_map.at(seed_ch)->getLayerID();
+    cand.sigma_strip_ = (rms > 0.0) ? rms : k_single_strip_sigma;
+    cand.layer_id_ = channel_map.at(seed_ch)->getLayerID();
 
     clusters.push_back(std::move(cand));
   }

--- a/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
+++ b/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
@@ -85,45 +85,45 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
   // Coarse scan over T to find the approximate minimum.
   // -------------------------------------------------------------------
   double best_chi2 = std::numeric_limits<double>::max();
-  double best_T = t_scan_min_ns_;
+  double best_t = t_scan_min_ns_;
   double best_amp = 0.0;
 
   // Keep track of the three-point neighbourhood for parabolic refinement.
-  double T_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
-  double T_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
+  double t_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
+  double t_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
 
-  double T_prev = t_scan_min_ns_;
+  double t_prev = t_scan_min_ns_;
   double chi2_prev = std::numeric_limits<double>::max();
 
-  for (double T = t_scan_min_ns_; T <= t_scan_max_ns_; T += t_scan_step_ns_) {
-    auto [chi2, amp] = evalAtT(samples, T);
+  for (double t = t_scan_min_ns_; t <= t_scan_max_ns_; t += t_scan_step_ns_) {
+    auto [chi2, amp] = evalAtT(samples, t);
 
     if (chi2 < best_chi2) {
       // Update neighbourhood: the previous point becomes T_lo.
-      T_lo = T_prev;
+      t_lo = t_prev;
       chi2_lo = chi2_prev;
       best_chi2 = chi2;
-      best_T = T;
+      best_t = t;
       best_amp = amp;
-    } else if (T > best_T && chi2_hi > best_chi2) {
+    } else if (t > best_t && chi2_hi > best_chi2) {
       // First point to the right of the minimum.
-      T_hi = T;
+      t_hi = t;
       chi2_hi = chi2;
     }
 
-    T_prev = T;
+    t_prev = t;
     chi2_prev = chi2;
   }
 
   // -------------------------------------------------------------------
   // Parabolic refinement around the minimum if neighbours are available.
   // -------------------------------------------------------------------
-  if (T_lo < best_T && T_hi > best_T && chi2_lo > best_chi2 &&
+  if (t_lo < best_t && t_hi > best_t && chi2_lo > best_chi2 &&
       chi2_hi > best_chi2) {
     // Fit a parabola through (T_lo, chi2_lo), (best_T, best_chi2), (T_hi,
     // chi2_hi).
-    const double d1 = best_T - T_lo;
-    const double d2 = T_hi - best_T;
+    const double d1 = best_t - t_lo;
+    const double d2 = t_hi - best_t;
     const double dc1 = best_chi2 - chi2_lo;
     const double dc2 = chi2_hi - best_chi2;
     // Vertex of parabola: ΔT = (d1²·dc2 - d2²·dc1) / (2·(d1·dc2 + d2·dc1))
@@ -132,10 +132,10 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
       const double delta = (d1 * d1 * dc2 - d2 * d2 * dc1) / denom;
       // Only accept the refinement if it stays within the bracket.
       if (std::abs(delta) < std::max(d1, d2)) {
-        const double T_refined = best_T + delta;
-        auto [chi2_ref, amp_ref] = evalAtT(samples, T_refined);
+        const double t_refined = best_t + delta;
+        auto [chi2_ref, amp_ref] = evalAtT(samples, t_refined);
         if (chi2_ref < best_chi2) {
-          best_T = T_refined;
+          best_t = t_refined;
           best_amp = amp_ref;
           best_chi2 = chi2_ref;
         }
@@ -144,7 +144,7 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
   }
 
   result.amplitude = best_amp;
-  result.t0 = best_T;
+  result.t0 = best_t;
   result.chi2 = best_chi2;
   result.converged = true;
   return result;

--- a/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
+++ b/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
@@ -67,7 +67,7 @@ std::pair<double, double> StripPulseFitter::evalAtT(
 StripPulseFitter::FitResult StripPulseFitter::fit(
     const std::vector<short>& samples) const {
   FitResult result;
-  result.ndf = static_cast<int>(samples.size()) - 2;
+  result.ndf_ = static_cast<int>(samples.size()) - 2;
 
   // Quick sanity: check that at least one sample is above pedestal.
   bool any_signal = false;
@@ -85,45 +85,45 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
   // Coarse scan over T to find the approximate minimum.
   // -------------------------------------------------------------------
   double best_chi2 = std::numeric_limits<double>::max();
-  double best_T = t_scan_min_ns_;
+  double best_t = t_scan_min_ns_;
   double best_amp = 0.0;
 
   // Keep track of the three-point neighbourhood for parabolic refinement.
-  double T_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
-  double T_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
+  double t_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
+  double t_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
 
-  double T_prev = t_scan_min_ns_;
+  double t_prev = t_scan_min_ns_;
   double chi2_prev = std::numeric_limits<double>::max();
 
-  for (double T = t_scan_min_ns_; T <= t_scan_max_ns_; T += t_scan_step_ns_) {
-    auto [chi2, amp] = evalAtT(samples, T);
+  for (double t = t_scan_min_ns_; t <= t_scan_max_ns_; t += t_scan_step_ns_) {
+    auto [chi2, amp] = evalAtT(samples, t);
 
     if (chi2 < best_chi2) {
       // Update neighbourhood: the previous point becomes T_lo.
-      T_lo = T_prev;
+      t_lo = t_prev;
       chi2_lo = chi2_prev;
       best_chi2 = chi2;
-      best_T = T;
+      best_t = t;
       best_amp = amp;
-    } else if (T > best_T && chi2_hi > best_chi2) {
+    } else if (t > best_t && chi2_hi > best_chi2) {
       // First point to the right of the minimum.
-      T_hi = T;
+      t_hi = t;
       chi2_hi = chi2;
     }
 
-    T_prev = T;
+    t_prev = t;
     chi2_prev = chi2;
   }
 
   // -------------------------------------------------------------------
   // Parabolic refinement around the minimum if neighbours are available.
   // -------------------------------------------------------------------
-  if (T_lo < best_T && T_hi > best_T && chi2_lo > best_chi2 &&
+  if (t_lo < best_t && t_hi > best_t && chi2_lo > best_chi2 &&
       chi2_hi > best_chi2) {
     // Fit a parabola through (T_lo, chi2_lo), (best_T, best_chi2), (T_hi,
     // chi2_hi).
-    const double d1 = best_T - T_lo;
-    const double d2 = T_hi - best_T;
+    const double d1 = best_t - t_lo;
+    const double d2 = t_hi - best_t;
     const double dc1 = best_chi2 - chi2_lo;
     const double dc2 = chi2_hi - best_chi2;
     // Vertex of parabola: ΔT = (d1²·dc2 - d2²·dc1) / (2·(d1·dc2 + d2·dc1))
@@ -132,10 +132,10 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
       const double delta = (d1 * d1 * dc2 - d2 * d2 * dc1) / denom;
       // Only accept the refinement if it stays within the bracket.
       if (std::abs(delta) < std::max(d1, d2)) {
-        const double T_refined = best_T + delta;
-        auto [chi2_ref, amp_ref] = evalAtT(samples, T_refined);
+        const double t_refined = best_t + delta;
+        auto [chi2_ref, amp_ref] = evalAtT(samples, t_refined);
         if (chi2_ref < best_chi2) {
-          best_T = T_refined;
+          best_t = t_refined;
           best_amp = amp_ref;
           best_chi2 = chi2_ref;
         }
@@ -143,10 +143,10 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
     }
   }
 
-  result.amplitude = best_amp;
-  result.t0 = best_T;
-  result.chi2 = best_chi2;
-  result.converged = true;
+  result.amplitude_ = best_amp;
+  result.t0_ = best_t;
+  result.chi2_ = best_chi2;
+  result.converged_ = true;
   return result;
 }
 

--- a/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
+++ b/Tracking/src/Tracking/Digitization/StripPulseFitter.cxx
@@ -67,7 +67,7 @@ std::pair<double, double> StripPulseFitter::evalAtT(
 StripPulseFitter::FitResult StripPulseFitter::fit(
     const std::vector<short>& samples) const {
   FitResult result;
-  result.ndf_ = static_cast<int>(samples.size()) - 2;
+  result.ndf = static_cast<int>(samples.size()) - 2;
 
   // Quick sanity: check that at least one sample is above pedestal.
   bool any_signal = false;
@@ -85,45 +85,45 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
   // Coarse scan over T to find the approximate minimum.
   // -------------------------------------------------------------------
   double best_chi2 = std::numeric_limits<double>::max();
-  double best_t = t_scan_min_ns_;
+  double best_T = t_scan_min_ns_;
   double best_amp = 0.0;
 
   // Keep track of the three-point neighbourhood for parabolic refinement.
-  double t_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
-  double t_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
+  double T_lo = t_scan_min_ns_, chi2_lo = std::numeric_limits<double>::max();
+  double T_hi = t_scan_min_ns_, chi2_hi = std::numeric_limits<double>::max();
 
-  double t_prev = t_scan_min_ns_;
+  double T_prev = t_scan_min_ns_;
   double chi2_prev = std::numeric_limits<double>::max();
 
-  for (double t = t_scan_min_ns_; t <= t_scan_max_ns_; t += t_scan_step_ns_) {
-    auto [chi2, amp] = evalAtT(samples, t);
+  for (double T = t_scan_min_ns_; T <= t_scan_max_ns_; T += t_scan_step_ns_) {
+    auto [chi2, amp] = evalAtT(samples, T);
 
     if (chi2 < best_chi2) {
       // Update neighbourhood: the previous point becomes T_lo.
-      t_lo = t_prev;
+      T_lo = T_prev;
       chi2_lo = chi2_prev;
       best_chi2 = chi2;
-      best_t = t;
+      best_T = T;
       best_amp = amp;
-    } else if (t > best_t && chi2_hi > best_chi2) {
+    } else if (T > best_T && chi2_hi > best_chi2) {
       // First point to the right of the minimum.
-      t_hi = t;
+      T_hi = T;
       chi2_hi = chi2;
     }
 
-    t_prev = t;
+    T_prev = T;
     chi2_prev = chi2;
   }
 
   // -------------------------------------------------------------------
   // Parabolic refinement around the minimum if neighbours are available.
   // -------------------------------------------------------------------
-  if (t_lo < best_t && t_hi > best_t && chi2_lo > best_chi2 &&
+  if (T_lo < best_T && T_hi > best_T && chi2_lo > best_chi2 &&
       chi2_hi > best_chi2) {
     // Fit a parabola through (T_lo, chi2_lo), (best_T, best_chi2), (T_hi,
     // chi2_hi).
-    const double d1 = best_t - t_lo;
-    const double d2 = t_hi - best_t;
+    const double d1 = best_T - T_lo;
+    const double d2 = T_hi - best_T;
     const double dc1 = best_chi2 - chi2_lo;
     const double dc2 = chi2_hi - best_chi2;
     // Vertex of parabola: ΔT = (d1²·dc2 - d2²·dc1) / (2·(d1·dc2 + d2·dc1))
@@ -132,10 +132,10 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
       const double delta = (d1 * d1 * dc2 - d2 * d2 * dc1) / denom;
       // Only accept the refinement if it stays within the bracket.
       if (std::abs(delta) < std::max(d1, d2)) {
-        const double t_refined = best_t + delta;
-        auto [chi2_ref, amp_ref] = evalAtT(samples, t_refined);
+        const double T_refined = best_T + delta;
+        auto [chi2_ref, amp_ref] = evalAtT(samples, T_refined);
         if (chi2_ref < best_chi2) {
-          best_t = t_refined;
+          best_T = T_refined;
           best_amp = amp_ref;
           best_chi2 = chi2_ref;
         }
@@ -143,10 +143,10 @@ StripPulseFitter::FitResult StripPulseFitter::fit(
     }
   }
 
-  result.amplitude_ = best_amp;
-  result.t0_ = best_t;
-  result.chi2_ = best_chi2;
-  result.converged_ = true;
+  result.amplitude = best_amp;
+  result.t0 = best_T;
+  result.chi2 = best_chi2;
+  result.converged = true;
   return result;
 }
 

--- a/Tracking/src/Tracking/Reco/DigitizationProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/DigitizationProcessor.cxx
@@ -25,18 +25,18 @@ void DigitizationProcessor::onProcessStart() {
                    << "  sense_pitch=" << tracking::digitization::SENSE_PITCH_MM
                    << " mm" << "  readout_pitch="
                    << tracking::digitization::READOUT_PITCH_MM << " mm"
-                   << "  Vbias=" << sensor_params_.bias_voltage_ << " V"
-                   << "  Vdep=" << sensor_params_.depletion_voltage_ << " V"
-                   << "  bulk=" << (sensor_params_.is_n_type_ ? "n" : "p")
+                   << "  Vbias=" << sensor_params_.bias_voltage << " V"
+                   << "  Vdep=" << sensor_params_.depletion_voltage << " V"
+                   << "  bulk=" << (sensor_params_.is_n_type ? "n" : "p")
                    << "-type" << "  e_lorentz_tan="
-                   << sensor_params_.electron_lorentz_tangent_
-                   << "  h_lorentz_tan=" << sensor_params_.hole_lorentz_tangent_
-                   << "  trapping=" << sensor_params_.trapping_
-                   << "  noise=" << sensor_params_.noise_electrons_ << " e-"
-                   << "  threshold=" << sensor_params_.threshold_electrons_
+                   << sensor_params_.electron_lorentz_tangent
+                   << "  h_lorentz_tan=" << sensor_params_.hole_lorentz_tangent
+                   << "  trapping=" << sensor_params_.trapping
+                   << "  noise=" << sensor_params_.noise_electrons << " e-"
+                   << "  threshold=" << sensor_params_.threshold_electrons
                    << " e-"
-                   << "  n_segments_min=" << sensor_params_.n_segments_min_
-                   << "  granularity=" << sensor_params_.deposition_granularity_;
+                   << "  n_segments_min=" << sensor_params_.n_segments_min
+                   << "  granularity=" << sensor_params_.deposition_granularity;
 
     pulse_shape_ = tracking::digitization::PulseShape::make(
         std::string(tracking::digitization::PULSE_SHAPE_NAME),
@@ -103,28 +103,28 @@ void DigitizationProcessor::configure(
       parameters.get<bool>("use_charge_digitization", false);
 
   if (use_charge_digitization_) {
-    sensor_params_.bias_voltage_ = parameters.get<double>("bias_voltage", 200.0);
-    sensor_params_.depletion_voltage_ =
+    sensor_params_.bias_voltage = parameters.get<double>("bias_voltage", 200.0);
+    sensor_params_.depletion_voltage =
         parameters.get<double>("depletion_voltage", 70.0);
-    sensor_params_.temperature_ = parameters.get<double>("temperature", 300.0);
-    sensor_params_.noise_electrons_ =
+    sensor_params_.temperature = parameters.get<double>("temperature", 300.0);
+    sensor_params_.noise_electrons =
         parameters.get<double>("noise_electrons", 1000.0);
-    sensor_params_.threshold_electrons_ =
+    sensor_params_.threshold_electrons =
         parameters.get<double>("threshold_electrons", 3000.0);
     // Fixed sensor properties — not user-configurable.
     // LDMX (and HPS) use n-type bulk with hole-side readout.
-    sensor_params_.is_n_type_ = true;
-    sensor_params_.electron_side_readout_ = false;
-    sensor_params_.hole_side_readout_ = true;
+    sensor_params_.is_n_type = true;
+    sensor_params_.electron_side_readout = false;
+    sensor_params_.hole_side_readout = true;
     use_lorentz_ = parameters.get<bool>("use_lorentz", true);
-    sensor_params_.electron_lorentz_tangent_ =
+    sensor_params_.electron_lorentz_tangent =
         parameters.get<double>("electron_lorentz_tangent", 0.0);
-    sensor_params_.hole_lorentz_tangent_ =
+    sensor_params_.hole_lorentz_tangent =
         parameters.get<double>("hole_lorentz_tangent", 0.0);
-    sensor_params_.trapping_ = parameters.get<double>("trapping", 0.0);
-    sensor_params_.deposition_granularity_ =
+    sensor_params_.trapping = parameters.get<double>("trapping", 0.0);
+    sensor_params_.deposition_granularity =
         parameters.get<double>("deposition_granularity", 0.10);
-    sensor_params_.n_segments_min_ = parameters.get<int>("n_segments_min", 5);
+    sensor_params_.n_segments_min = parameters.get<int>("n_segments_min", 5);
     // n_readout_strips is fixed by the sensor geometry constant
     // N_READOUT_STRIPS.
 
@@ -144,7 +144,7 @@ void DigitizationProcessor::buildLorentzCache() {
     loadBField(field_map_);
 
   // Low-field (Hall) mobility from the Canali model [cm²/(V·s)] → [m²/(V·s)]
-  const double t = sensor_params_.temperature_;
+  const double t = sensor_params_.temperature;
   auto carrier_e = tracking::digitization::getCarrier(-1);
   auto carrier_h = tracking::digitization::getCarrier(1);
   const double mu_e = carrier_e.mu0(t) * 1.0e-4;  // m²/(V·s)
@@ -438,9 +438,9 @@ std::vector<ldmx::Measurement> DigitizationProcessor::digitizeHits(
       if (use_lorentz_) {
         auto lorentz_it = lorentz_tan_cache_.find(layer_id);
         if (lorentz_it != lorentz_tan_cache_.end()) {
-          strip_digitizer_->mutableParams().electron_lorentz_tangent_ =
+          strip_digitizer_->mutableParams().electron_lorentz_tangent =
               lorentz_it->second.first;
-          strip_digitizer_->mutableParams().hole_lorentz_tangent_ =
+          strip_digitizer_->mutableParams().hole_lorentz_tangent =
               lorentz_it->second.second;
         }
       }

--- a/Tracking/src/Tracking/Reco/DigitizationProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/DigitizationProcessor.cxx
@@ -25,18 +25,18 @@ void DigitizationProcessor::onProcessStart() {
                    << "  sense_pitch=" << tracking::digitization::SENSE_PITCH_MM
                    << " mm" << "  readout_pitch="
                    << tracking::digitization::READOUT_PITCH_MM << " mm"
-                   << "  Vbias=" << sensor_params_.bias_voltage << " V"
-                   << "  Vdep=" << sensor_params_.depletion_voltage << " V"
-                   << "  bulk=" << (sensor_params_.is_n_type ? "n" : "p")
+                   << "  Vbias=" << sensor_params_.bias_voltage_ << " V"
+                   << "  Vdep=" << sensor_params_.depletion_voltage_ << " V"
+                   << "  bulk=" << (sensor_params_.is_n_type_ ? "n" : "p")
                    << "-type" << "  e_lorentz_tan="
-                   << sensor_params_.electron_lorentz_tangent
-                   << "  h_lorentz_tan=" << sensor_params_.hole_lorentz_tangent
-                   << "  trapping=" << sensor_params_.trapping
-                   << "  noise=" << sensor_params_.noise_electrons << " e-"
-                   << "  threshold=" << sensor_params_.threshold_electrons
+                   << sensor_params_.electron_lorentz_tangent_
+                   << "  h_lorentz_tan=" << sensor_params_.hole_lorentz_tangent_
+                   << "  trapping=" << sensor_params_.trapping_
+                   << "  noise=" << sensor_params_.noise_electrons_ << " e-"
+                   << "  threshold=" << sensor_params_.threshold_electrons_
                    << " e-"
-                   << "  n_segments_min=" << sensor_params_.n_segments_min
-                   << "  granularity=" << sensor_params_.deposition_granularity;
+                   << "  n_segments_min=" << sensor_params_.n_segments_min_
+                   << "  granularity=" << sensor_params_.deposition_granularity_;
 
     pulse_shape_ = tracking::digitization::PulseShape::make(
         std::string(tracking::digitization::PULSE_SHAPE_NAME),
@@ -103,28 +103,28 @@ void DigitizationProcessor::configure(
       parameters.get<bool>("use_charge_digitization", false);
 
   if (use_charge_digitization_) {
-    sensor_params_.bias_voltage = parameters.get<double>("bias_voltage", 200.0);
-    sensor_params_.depletion_voltage =
+    sensor_params_.bias_voltage_ = parameters.get<double>("bias_voltage", 200.0);
+    sensor_params_.depletion_voltage_ =
         parameters.get<double>("depletion_voltage", 70.0);
-    sensor_params_.temperature = parameters.get<double>("temperature", 300.0);
-    sensor_params_.noise_electrons =
+    sensor_params_.temperature_ = parameters.get<double>("temperature", 300.0);
+    sensor_params_.noise_electrons_ =
         parameters.get<double>("noise_electrons", 1000.0);
-    sensor_params_.threshold_electrons =
+    sensor_params_.threshold_electrons_ =
         parameters.get<double>("threshold_electrons", 3000.0);
     // Fixed sensor properties — not user-configurable.
     // LDMX (and HPS) use n-type bulk with hole-side readout.
-    sensor_params_.is_n_type = true;
-    sensor_params_.electron_side_readout = false;
-    sensor_params_.hole_side_readout = true;
+    sensor_params_.is_n_type_ = true;
+    sensor_params_.electron_side_readout_ = false;
+    sensor_params_.hole_side_readout_ = true;
     use_lorentz_ = parameters.get<bool>("use_lorentz", true);
-    sensor_params_.electron_lorentz_tangent =
+    sensor_params_.electron_lorentz_tangent_ =
         parameters.get<double>("electron_lorentz_tangent", 0.0);
-    sensor_params_.hole_lorentz_tangent =
+    sensor_params_.hole_lorentz_tangent_ =
         parameters.get<double>("hole_lorentz_tangent", 0.0);
-    sensor_params_.trapping = parameters.get<double>("trapping", 0.0);
-    sensor_params_.deposition_granularity =
+    sensor_params_.trapping_ = parameters.get<double>("trapping", 0.0);
+    sensor_params_.deposition_granularity_ =
         parameters.get<double>("deposition_granularity", 0.10);
-    sensor_params_.n_segments_min = parameters.get<int>("n_segments_min", 5);
+    sensor_params_.n_segments_min_ = parameters.get<int>("n_segments_min", 5);
     // n_readout_strips is fixed by the sensor geometry constant
     // N_READOUT_STRIPS.
 
@@ -144,7 +144,7 @@ void DigitizationProcessor::buildLorentzCache() {
     loadBField(field_map_);
 
   // Low-field (Hall) mobility from the Canali model [cm²/(V·s)] → [m²/(V·s)]
-  const double t = sensor_params_.temperature;
+  const double t = sensor_params_.temperature_;
   auto carrier_e = tracking::digitization::getCarrier(-1);
   auto carrier_h = tracking::digitization::getCarrier(1);
   const double mu_e = carrier_e.mu0(t) * 1.0e-4;  // m²/(V·s)
@@ -438,9 +438,9 @@ std::vector<ldmx::Measurement> DigitizationProcessor::digitizeHits(
       if (use_lorentz_) {
         auto lorentz_it = lorentz_tan_cache_.find(layer_id);
         if (lorentz_it != lorentz_tan_cache_.end()) {
-          strip_digitizer_->mutableParams().electron_lorentz_tangent =
+          strip_digitizer_->mutableParams().electron_lorentz_tangent_ =
               lorentz_it->second.first;
-          strip_digitizer_->mutableParams().hole_lorentz_tangent =
+          strip_digitizer_->mutableParams().hole_lorentz_tangent_ =
               lorentz_it->second.second;
         }
       }

--- a/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
@@ -102,9 +102,9 @@ void StripClusterProcessor::produce(framework::Event& event) {
       // µm, etc.
       // -------------------------------------------------------------------
       using namespace tracking::digitization;
-      const int n_int_ = N_READOUT_STRIPS / 2;  // integer division = 383
-      const double offset_ = static_cast<double>(n_int_);
-      const double local_u = (cl.centroid_strip - offset_) * READOUT_PITCH_MM;
+      const int n_int = N_READOUT_STRIPS / 2;  // integer division = 383
+      const double offset = static_cast<double>(n_int);
+      const double local_u = (cl.centroid_strip - offset) * READOUT_PITCH_MM;
 
       // Cluster-size-dependent position uncertainty using sense pitch (30 µm).
       // Divisors follow the HPS convention: 1/√12 for single-strip (binary

--- a/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
@@ -102,15 +102,15 @@ void StripClusterProcessor::produce(framework::Event& event) {
       // µm, etc.
       // -------------------------------------------------------------------
       using namespace tracking::digitization;
-      const int n_int = N_READOUT_STRIPS / 2;  // integer division = 383
-      const double offset = static_cast<double>(n_int);
-      const double local_u = (cl.centroid_strip_ - offset) * READOUT_PITCH_MM;
+      const int n_int_ = N_READOUT_STRIPS / 2;  // integer division = 383
+      const double offset_ = static_cast<double>(n_int_);
+      const double local_u = (cl.centroid_strip - offset_) * READOUT_PITCH_MM;
 
       // Cluster-size-dependent position uncertainty using sense pitch (30 µm).
       // Divisors follow the HPS convention: 1/√12 for single-strip (binary
       // resolution), 1/5 for 2-strip (best charge-sharing), then degrading.
       double sigma_u;
-      switch (cl.n_strips_) {
+      switch (cl.n_strips) {
         case 1:
           sigma_u = SENSE_PITCH_MM / std::sqrt(12.0);
           break;  // 8.7 µm
@@ -150,9 +150,9 @@ void StripClusterProcessor::produce(framework::Event& event) {
       meas.setGlobalPosition(static_cast<float>(global_pos[0]),
                              static_cast<float>(global_pos[1]),
                              static_cast<float>(global_pos[2]));
-      meas.setTime(static_cast<float>(cl.time_ns_));
-      meas.setNStrips(cl.n_strips_);
-      meas.setClusterAmplitude(static_cast<float>(cl.total_amplitude_));
+      meas.setTime(static_cast<float>(cl.time_ns));
+      meas.setNStrips(cl.n_strips);
+      meas.setClusterAmplitude(static_cast<float>(cl.total_amplitude));
 
       // -------------------------------------------------------------------
       // Reconstructed energy: convert total cluster amplitude to edep using
@@ -161,14 +161,14 @@ void StripClusterProcessor::produce(framework::Event& event) {
       //                                × ENERGY_PER_EHP_MEV [MeV/e]
       // -------------------------------------------------------------------
       const float reco_edep = static_cast<float>(
-          cl.total_amplitude_ * ADC_ELECTRONS_PER_COUNT * ENERGY_PER_EHP_MEV);
+          cl.total_amplitude * ADC_ELECTRONS_PER_COUNT * ENERGY_PER_EHP_MEV);
       meas.setEdep(reco_edep);
 
       // -------------------------------------------------------------------
       // Truth matching: collect unique track IDs from constituent strips.
       // -------------------------------------------------------------------
       std::unordered_set<int> seen_track_ids;
-      for (const int strip : cl.strip_ids_) {
+      for (const int strip : cl.strip_ids) {
         auto it = strip_hit_map.find(strip);
         if (it != strip_hit_map.end()) {
           const int tid = it->second->getTrackID();
@@ -179,9 +179,9 @@ void StripClusterProcessor::produce(framework::Event& event) {
       }
 
       ldmx_log(trace) << "  cluster: layer=" << layer_id
-                      << " strips=" << cl.n_strips_ << " u=" << local_u << " mm"
-                      << " sigma_u=" << sigma_u << " mm" << " t=" << cl.time_ns_
-                      << " ns" << " amp=" << cl.total_amplitude_ << " ADC"
+                      << " strips=" << cl.n_strips << " u=" << local_u << " mm"
+                      << " sigma_u=" << sigma_u << " mm" << " t=" << cl.time_ns
+                      << " ns" << " amp=" << cl.total_amplitude << " ADC"
                       << " n_track_ids=" << seen_track_ids.size();
 
       measurements.push_back(meas);

--- a/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/StripClusterProcessor.cxx
@@ -102,15 +102,15 @@ void StripClusterProcessor::produce(framework::Event& event) {
       // µm, etc.
       // -------------------------------------------------------------------
       using namespace tracking::digitization;
-      const int n_int_ = N_READOUT_STRIPS / 2;  // integer division = 383
-      const double offset_ = static_cast<double>(n_int_);
-      const double local_u = (cl.centroid_strip - offset_) * READOUT_PITCH_MM;
+      const int n_int = N_READOUT_STRIPS / 2;  // integer division = 383
+      const double offset = static_cast<double>(n_int);
+      const double local_u = (cl.centroid_strip_ - offset) * READOUT_PITCH_MM;
 
       // Cluster-size-dependent position uncertainty using sense pitch (30 µm).
       // Divisors follow the HPS convention: 1/√12 for single-strip (binary
       // resolution), 1/5 for 2-strip (best charge-sharing), then degrading.
       double sigma_u;
-      switch (cl.n_strips) {
+      switch (cl.n_strips_) {
         case 1:
           sigma_u = SENSE_PITCH_MM / std::sqrt(12.0);
           break;  // 8.7 µm
@@ -150,9 +150,9 @@ void StripClusterProcessor::produce(framework::Event& event) {
       meas.setGlobalPosition(static_cast<float>(global_pos[0]),
                              static_cast<float>(global_pos[1]),
                              static_cast<float>(global_pos[2]));
-      meas.setTime(static_cast<float>(cl.time_ns));
-      meas.setNStrips(cl.n_strips);
-      meas.setClusterAmplitude(static_cast<float>(cl.total_amplitude));
+      meas.setTime(static_cast<float>(cl.time_ns_));
+      meas.setNStrips(cl.n_strips_);
+      meas.setClusterAmplitude(static_cast<float>(cl.total_amplitude_));
 
       // -------------------------------------------------------------------
       // Reconstructed energy: convert total cluster amplitude to edep using
@@ -161,14 +161,14 @@ void StripClusterProcessor::produce(framework::Event& event) {
       //                                × ENERGY_PER_EHP_MEV [MeV/e]
       // -------------------------------------------------------------------
       const float reco_edep = static_cast<float>(
-          cl.total_amplitude * ADC_ELECTRONS_PER_COUNT * ENERGY_PER_EHP_MEV);
+          cl.total_amplitude_ * ADC_ELECTRONS_PER_COUNT * ENERGY_PER_EHP_MEV);
       meas.setEdep(reco_edep);
 
       // -------------------------------------------------------------------
       // Truth matching: collect unique track IDs from constituent strips.
       // -------------------------------------------------------------------
       std::unordered_set<int> seen_track_ids;
-      for (const int strip : cl.strip_ids) {
+      for (const int strip : cl.strip_ids_) {
         auto it = strip_hit_map.find(strip);
         if (it != strip_hit_map.end()) {
           const int tid = it->second->getTrackID();
@@ -179,9 +179,9 @@ void StripClusterProcessor::produce(framework::Event& event) {
       }
 
       ldmx_log(trace) << "  cluster: layer=" << layer_id
-                      << " strips=" << cl.n_strips << " u=" << local_u << " mm"
-                      << " sigma_u=" << sigma_u << " mm" << " t=" << cl.time_ns
-                      << " ns" << " amp=" << cl.total_amplitude << " ADC"
+                      << " strips=" << cl.n_strips_ << " u=" << local_u << " mm"
+                      << " sigma_u=" << sigma_u << " mm" << " t=" << cl.time_ns_
+                      << " ns" << " amp=" << cl.total_amplitude_ << " ADC"
                       << " n_track_ids=" << seen_track_ids.size();
 
       measurements.push_back(meas);

--- a/Tracking/src/Tracking/Reco/StripFitProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/StripFitProcessor.cxx
@@ -56,14 +56,14 @@ void StripFitProcessor::produce(framework::Event& event) {
   for (const auto& raw : raw_hits) {
     const auto result = fitter_->fit(raw.getSamples());
 
-    if (!result.converged_) {
+    if (!result.converged) {
       ldmx_log(trace) << "Fit did not converge for layer=" << raw.getLayerID()
                       << " strip=" << raw.getStripID() << " — skipping";
       continue;
     }
 
-    if (max_chi2_ndf_ > 0.0 && result.ndf_ > 0) {
-      const double reduced_chi2 = result.chi2_ / result.ndf_;
+    if (max_chi2_ndf_ > 0.0 && result.ndf > 0) {
+      const double reduced_chi2 = result.chi2 / result.ndf;
       if (reduced_chi2 > max_chi2_ndf_) {
         ldmx_log(trace) << "χ²/ndf=" << reduced_chi2
                         << " exceeds cut=" << max_chi2_ndf_ << " — skipping";
@@ -73,15 +73,15 @@ void StripFitProcessor::produce(framework::Event& event) {
 
     fitted_hits.emplace_back(
         raw.getLayerID(), raw.getStripID(),
-        static_cast<float>(result.amplitude_), static_cast<float>(result.t0_),
-        static_cast<float>(result.chi2_), result.ndf_, raw.getTrackID(),
+        static_cast<float>(result.amplitude), static_cast<float>(result.t0),
+        static_cast<float>(result.chi2), result.ndf, raw.getTrackID(),
         raw.getPdgID(), raw.getSimHitID(), raw.getEdep());
 
     ldmx_log(trace) << "Fitted: layer=" << raw.getLayerID()
                     << " strip=" << raw.getStripID()
-                    << " amp=" << result.amplitude_ << " t0=" << result.t0_
-                    << " ns" << " chi2/ndf=" << result.chi2_ << "/"
-                    << result.ndf_;
+                    << " amp=" << result.amplitude << " t0=" << result.t0
+                    << " ns" << " chi2/ndf=" << result.chi2 << "/"
+                    << result.ndf;
   }
 
   ldmx_log(debug) << "Produced " << fitted_hits.size() << " FittedSiStripHits";

--- a/Tracking/src/Tracking/Reco/StripFitProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/StripFitProcessor.cxx
@@ -56,14 +56,14 @@ void StripFitProcessor::produce(framework::Event& event) {
   for (const auto& raw : raw_hits) {
     const auto result = fitter_->fit(raw.getSamples());
 
-    if (!result.converged) {
+    if (!result.converged_) {
       ldmx_log(trace) << "Fit did not converge for layer=" << raw.getLayerID()
                       << " strip=" << raw.getStripID() << " — skipping";
       continue;
     }
 
-    if (max_chi2_ndf_ > 0.0 && result.ndf > 0) {
-      const double reduced_chi2 = result.chi2 / result.ndf;
+    if (max_chi2_ndf_ > 0.0 && result.ndf_ > 0) {
+      const double reduced_chi2 = result.chi2_ / result.ndf_;
       if (reduced_chi2 > max_chi2_ndf_) {
         ldmx_log(trace) << "χ²/ndf=" << reduced_chi2
                         << " exceeds cut=" << max_chi2_ndf_ << " — skipping";
@@ -73,15 +73,15 @@ void StripFitProcessor::produce(framework::Event& event) {
 
     fitted_hits.emplace_back(
         raw.getLayerID(), raw.getStripID(),
-        static_cast<float>(result.amplitude), static_cast<float>(result.t0),
-        static_cast<float>(result.chi2), result.ndf, raw.getTrackID(),
+        static_cast<float>(result.amplitude_), static_cast<float>(result.t0_),
+        static_cast<float>(result.chi2_), result.ndf_, raw.getTrackID(),
         raw.getPdgID(), raw.getSimHitID(), raw.getEdep());
 
     ldmx_log(trace) << "Fitted: layer=" << raw.getLayerID()
                     << " strip=" << raw.getStripID()
-                    << " amp=" << result.amplitude << " t0=" << result.t0
-                    << " ns" << " chi2/ndf=" << result.chi2 << "/"
-                    << result.ndf;
+                    << " amp=" << result.amplitude_ << " t0=" << result.t0_
+                    << " ns" << " chi2/ndf=" << result.chi2_ << "/"
+                    << result.ndf_;
   }
 
   ldmx_log(debug) << "Produced " << fitted_hits.size() << " FittedSiStripHits";

--- a/Tracking/src/Tracking/Reco/TrackComparisonProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TrackComparisonProcessor.cxx
@@ -36,45 +36,45 @@ void TrackComparisonProcessor::configure(
 }
 
 void TrackComparisonProcessor::setupTree(TTree* tree, PairVars& v) {
-  tree->Branch("track_id", &v.track_id_);
-  tree->Branch("truth_prob_s", &v.truth_prob_s_);
-  tree->Branch("truth_prob_d", &v.truth_prob_d_);
-  tree->Branch("nhits_s", &v.nhits_s_);
-  tree->Branch("nhits_d", &v.nhits_d_);
-  tree->Branch("chi2ndf_s", &v.chi2ndf_s_);
-  tree->Branch("chi2ndf_d", &v.chi2ndf_d_);
-  tree->Branch("d0_s", &v.d0_s_);
-  tree->Branch("d0_d", &v.d0_d_);
-  tree->Branch("z0_s", &v.z0_s_);
-  tree->Branch("z0_d", &v.z0_d_);
-  tree->Branch("phi_s", &v.phi_s_);
-  tree->Branch("phi_d", &v.phi_d_);
-  tree->Branch("theta_s", &v.theta_s_);
-  tree->Branch("theta_d", &v.theta_d_);
-  tree->Branch("qop_s", &v.qop_s_);
-  tree->Branch("qop_d", &v.qop_d_);
-  tree->Branch("p_s", &v.p_s_);
-  tree->Branch("p_d", &v.p_d_);
-  tree->Branch("delta_d0", &v.delta_d0_);
-  tree->Branch("delta_z0", &v.delta_z0_);
-  tree->Branch("delta_phi", &v.delta_phi_);
-  tree->Branch("delta_theta", &v.delta_theta_);
-  tree->Branch("delta_p_over_p", &v.delta_p_over_p_);
-  tree->Branch("px_s", &v.px_s_);
-  tree->Branch("py_s", &v.py_s_);
-  tree->Branch("pz_s", &v.pz_s_);
-  tree->Branch("px_d", &v.px_d_);
-  tree->Branch("py_d", &v.py_d_);
-  tree->Branch("pz_d", &v.pz_d_);
-  tree->Branch("px_t", &v.px_t_);
-  tree->Branch("py_t", &v.py_t_);
-  tree->Branch("pz_t", &v.pz_t_);
-  tree->Branch("p_t", &v.p_t_);
-  tree->Branch("vx_t", &v.vx_t_);
-  tree->Branch("vy_t", &v.vy_t_);
-  tree->Branch("vz_t", &v.vz_t_);
-  tree->Branch("delta_p_over_p_s", &v.delta_p_over_p_s_);
-  tree->Branch("delta_p_over_p_d", &v.delta_p_over_p_d_);
+  tree->Branch("track_id", &v.track_id);
+  tree->Branch("truth_prob_s", &v.truth_prob_s);
+  tree->Branch("truth_prob_d", &v.truth_prob_d);
+  tree->Branch("nhits_s", &v.nhits_s);
+  tree->Branch("nhits_d", &v.nhits_d);
+  tree->Branch("chi2ndf_s", &v.chi2ndf_s);
+  tree->Branch("chi2ndf_d", &v.chi2ndf_d);
+  tree->Branch("d0_s", &v.d0_s);
+  tree->Branch("d0_d", &v.d0_d);
+  tree->Branch("z0_s", &v.z0_s);
+  tree->Branch("z0_d", &v.z0_d);
+  tree->Branch("phi_s", &v.phi_s);
+  tree->Branch("phi_d", &v.phi_d);
+  tree->Branch("theta_s", &v.theta_s);
+  tree->Branch("theta_d", &v.theta_d);
+  tree->Branch("qop_s", &v.qop_s);
+  tree->Branch("qop_d", &v.qop_d);
+  tree->Branch("p_s", &v.p_s);
+  tree->Branch("p_d", &v.p_d);
+  tree->Branch("delta_d0", &v.delta_d0);
+  tree->Branch("delta_z0", &v.delta_z0);
+  tree->Branch("delta_phi", &v.delta_phi);
+  tree->Branch("delta_theta", &v.delta_theta);
+  tree->Branch("delta_p_over_p", &v.delta_p_over_p);
+  tree->Branch("px_s", &v.px_s);
+  tree->Branch("py_s", &v.py_s);
+  tree->Branch("pz_s", &v.pz_s);
+  tree->Branch("px_d", &v.px_d);
+  tree->Branch("py_d", &v.py_d);
+  tree->Branch("pz_d", &v.pz_d);
+  tree->Branch("px_t", &v.px_t);
+  tree->Branch("py_t", &v.py_t);
+  tree->Branch("pz_t", &v.pz_t);
+  tree->Branch("p_t", &v.p_t);
+  tree->Branch("vx_t", &v.vx_t);
+  tree->Branch("vy_t", &v.vy_t);
+  tree->Branch("vz_t", &v.vz_t);
+  tree->Branch("delta_p_over_p_s", &v.delta_p_over_p_s);
+  tree->Branch("delta_p_over_p_d", &v.delta_p_over_p_d);
 }
 
 void TrackComparisonProcessor::onProcessStart() {
@@ -145,73 +145,73 @@ void TrackComparisonProcessor::fillPair(const ldmx::Track& smear,
                                         const ldmx::SimParticle& truth,
                                         PairVars& v,
                                         const std::string& prefix) {
-  v.track_id_ = smear.getTrackID();
-  v.truth_prob_s_ = smear.getTruthProb();
-  v.truth_prob_d_ = digi.getTruthProb();
-  v.nhits_s_ = smear.getNhits();
-  v.nhits_d_ = digi.getNhits();
-  v.chi2ndf_s_ = (smear.getNdf() > 0) ? smear.getChi2() / smear.getNdf() : -1;
-  v.chi2ndf_d_ = (digi.getNdf() > 0) ? digi.getChi2() / digi.getNdf() : -1;
-  v.d0_s_ = smear.getD0();
-  v.d0_d_ = digi.getD0();
-  v.z0_s_ = smear.getZ0();
-  v.z0_d_ = digi.getZ0();
-  v.phi_s_ = smear.getPhi();
-  v.phi_d_ = digi.getPhi();
-  v.theta_s_ = smear.getTheta();
-  v.theta_d_ = digi.getTheta();
-  v.qop_s_ = smear.getQoP();
-  v.qop_d_ = digi.getQoP();
+  v.track_id = smear.getTrackID();
+  v.truth_prob_s = smear.getTruthProb();
+  v.truth_prob_d = digi.getTruthProb();
+  v.nhits_s = smear.getNhits();
+  v.nhits_d = digi.getNhits();
+  v.chi2ndf_s = (smear.getNdf() > 0) ? smear.getChi2() / smear.getNdf() : -1;
+  v.chi2ndf_d = (digi.getNdf() > 0) ? digi.getChi2() / digi.getNdf() : -1;
+  v.d0_s = smear.getD0();
+  v.d0_d = digi.getD0();
+  v.z0_s = smear.getZ0();
+  v.z0_d = digi.getZ0();
+  v.phi_s = smear.getPhi();
+  v.phi_d = digi.getPhi();
+  v.theta_s = smear.getTheta();
+  v.theta_d = digi.getTheta();
+  v.qop_s = smear.getQoP();
+  v.qop_d = digi.getQoP();
   // QoP is in e/GeV (ACTS units); convert to MeV so p_s/p_d match SimParticle
   // units.
-  v.p_s_ = (v.qop_s_ != 0) ? std::abs(1000.0 / v.qop_s_) : -1;
-  v.p_d_ = (v.qop_d_ != 0) ? std::abs(1000.0 / v.qop_d_) : -1;
-  v.delta_d0_ = v.d0_d_ - v.d0_s_;
-  v.delta_z0_ = v.z0_d_ - v.z0_s_;
-  v.delta_phi_ = v.phi_d_ - v.phi_s_;
-  v.delta_theta_ = v.theta_d_ - v.theta_s_;
-  v.delta_p_over_p_ = (v.p_s_ > 0) ? (v.p_d_ - v.p_s_) / v.p_s_ : -999;
+  v.p_s = (v.qop_s != 0) ? std::abs(1000.0 / v.qop_s) : -1;
+  v.p_d = (v.qop_d != 0) ? std::abs(1000.0 / v.qop_d) : -1;
+  v.delta_d0 = v.d0_d - v.d0_s;
+  v.delta_z0 = v.z0_d - v.z0_s;
+  v.delta_phi = v.phi_d - v.phi_s;
+  v.delta_theta = v.theta_d - v.theta_s;
+  v.delta_p_over_p = (v.p_s > 0) ? (v.p_d - v.p_s) / v.p_s : -999;
 
   auto mom_s = smear.getMomentumAtTarget();
   if (mom_s.size() == 3) {
-    v.px_s_ = mom_s[0];
-    v.py_s_ = mom_s[1];
-    v.pz_s_ = mom_s[2];
+    v.px_s = mom_s[0];
+    v.py_s = mom_s[1];
+    v.pz_s = mom_s[2];
   }
   auto mom_d = digi.getMomentumAtTarget();
   if (mom_d.size() == 3) {
-    v.px_d_ = mom_d[0];
-    v.py_d_ = mom_d[1];
-    v.pz_d_ = mom_d[2];
+    v.px_d = mom_d[0];
+    v.py_d = mom_d[1];
+    v.pz_d = mom_d[2];
   }
 
   auto mom_t = truth.getMomentum();
-  v.px_t_ = mom_t[0];
-  v.py_t_ = mom_t[1];
-  v.pz_t_ = mom_t[2];
-  v.p_t_ = std::sqrt(v.px_t_ * v.px_t_ + v.py_t_ * v.py_t_ + v.pz_t_ * v.pz_t_);
+  v.px_t = mom_t[0];
+  v.py_t = mom_t[1];
+  v.pz_t = mom_t[2];
+  v.p_t = std::sqrt(v.px_t * v.px_t + v.py_t * v.py_t + v.pz_t * v.pz_t);
   auto vtx = truth.getVertex();
-  v.vx_t_ = vtx[0];
-  v.vy_t_ = vtx[1];
-  v.vz_t_ = vtx[2];
+  v.vx_t = vtx[0];
+  v.vy_t = vtx[1];
+  v.vz_t = vtx[2];
 
-  v.delta_p_over_p_s_ = (v.p_t_ > 0) ? (v.p_s_ - v.p_t_) / v.p_t_ : -999;
-  v.delta_p_over_p_d_ = (v.p_t_ > 0) ? (v.p_d_ - v.p_t_) / v.p_t_ : -999;
+  v.delta_p_over_p_s = (v.p_t > 0) ? (v.p_s - v.p_t) / v.p_t : -999;
+  v.delta_p_over_p_d = (v.p_t > 0) ? (v.p_d - v.p_t) / v.p_t : -999;
 
-  histograms_.fill(prefix + "delta_d0", v.delta_d0_);
-  histograms_.fill(prefix + "delta_z0", v.delta_z0_);
-  histograms_.fill(prefix + "delta_phi", v.delta_phi_);
-  histograms_.fill(prefix + "delta_theta", v.delta_theta_);
-  histograms_.fill(prefix + "delta_p_over_p", v.delta_p_over_p_);
-  histograms_.fill(prefix + "nhits_s", v.nhits_s_);
-  histograms_.fill(prefix + "nhits_d", v.nhits_d_);
-  histograms_.fill(prefix + "chi2ndf_s", v.chi2ndf_s_);
-  histograms_.fill(prefix + "chi2ndf_d", v.chi2ndf_d_);
-  histograms_.fill(prefix + "p_s", v.p_s_);
-  histograms_.fill(prefix + "p_d", v.p_d_);
-  histograms_.fill(prefix + "p_t", v.p_t_);
-  histograms_.fill(prefix + "delta_p_over_p_s", v.delta_p_over_p_s_);
-  histograms_.fill(prefix + "delta_p_over_p_d", v.delta_p_over_p_d_);
+  histograms_.fill(prefix + "delta_d0", v.delta_d0);
+  histograms_.fill(prefix + "delta_z0", v.delta_z0);
+  histograms_.fill(prefix + "delta_phi", v.delta_phi);
+  histograms_.fill(prefix + "delta_theta", v.delta_theta);
+  histograms_.fill(prefix + "delta_p_over_p", v.delta_p_over_p);
+  histograms_.fill(prefix + "nhits_s", v.nhits_s);
+  histograms_.fill(prefix + "nhits_d", v.nhits_d);
+  histograms_.fill(prefix + "chi2ndf_s", v.chi2ndf_s);
+  histograms_.fill(prefix + "chi2ndf_d", v.chi2ndf_d);
+  histograms_.fill(prefix + "p_s", v.p_s);
+  histograms_.fill(prefix + "p_d", v.p_d);
+  histograms_.fill(prefix + "p_t", v.p_t);
+  histograms_.fill(prefix + "delta_p_over_p_s", v.delta_p_over_p_s);
+  histograms_.fill(prefix + "delta_p_over_p_d", v.delta_p_over_p_d);
 }
 
 void TrackComparisonProcessor::processTracker(const framework::Event& event,

--- a/Tracking/src/Tracking/Reco/TrackComparisonProcessor.cxx
+++ b/Tracking/src/Tracking/Reco/TrackComparisonProcessor.cxx
@@ -36,45 +36,45 @@ void TrackComparisonProcessor::configure(
 }
 
 void TrackComparisonProcessor::setupTree(TTree* tree, PairVars& v) {
-  tree->Branch("track_id", &v.track_id);
-  tree->Branch("truth_prob_s", &v.truth_prob_s);
-  tree->Branch("truth_prob_d", &v.truth_prob_d);
-  tree->Branch("nhits_s", &v.nhits_s);
-  tree->Branch("nhits_d", &v.nhits_d);
-  tree->Branch("chi2ndf_s", &v.chi2ndf_s);
-  tree->Branch("chi2ndf_d", &v.chi2ndf_d);
-  tree->Branch("d0_s", &v.d0_s);
-  tree->Branch("d0_d", &v.d0_d);
-  tree->Branch("z0_s", &v.z0_s);
-  tree->Branch("z0_d", &v.z0_d);
-  tree->Branch("phi_s", &v.phi_s);
-  tree->Branch("phi_d", &v.phi_d);
-  tree->Branch("theta_s", &v.theta_s);
-  tree->Branch("theta_d", &v.theta_d);
-  tree->Branch("qop_s", &v.qop_s);
-  tree->Branch("qop_d", &v.qop_d);
-  tree->Branch("p_s", &v.p_s);
-  tree->Branch("p_d", &v.p_d);
-  tree->Branch("delta_d0", &v.delta_d0);
-  tree->Branch("delta_z0", &v.delta_z0);
-  tree->Branch("delta_phi", &v.delta_phi);
-  tree->Branch("delta_theta", &v.delta_theta);
-  tree->Branch("delta_p_over_p", &v.delta_p_over_p);
-  tree->Branch("px_s", &v.px_s);
-  tree->Branch("py_s", &v.py_s);
-  tree->Branch("pz_s", &v.pz_s);
-  tree->Branch("px_d", &v.px_d);
-  tree->Branch("py_d", &v.py_d);
-  tree->Branch("pz_d", &v.pz_d);
-  tree->Branch("px_t", &v.px_t);
-  tree->Branch("py_t", &v.py_t);
-  tree->Branch("pz_t", &v.pz_t);
-  tree->Branch("p_t", &v.p_t);
-  tree->Branch("vx_t", &v.vx_t);
-  tree->Branch("vy_t", &v.vy_t);
-  tree->Branch("vz_t", &v.vz_t);
-  tree->Branch("delta_p_over_p_s", &v.delta_p_over_p_s);
-  tree->Branch("delta_p_over_p_d", &v.delta_p_over_p_d);
+  tree->Branch("track_id", &v.track_id_);
+  tree->Branch("truth_prob_s", &v.truth_prob_s_);
+  tree->Branch("truth_prob_d", &v.truth_prob_d_);
+  tree->Branch("nhits_s", &v.nhits_s_);
+  tree->Branch("nhits_d", &v.nhits_d_);
+  tree->Branch("chi2ndf_s", &v.chi2ndf_s_);
+  tree->Branch("chi2ndf_d", &v.chi2ndf_d_);
+  tree->Branch("d0_s", &v.d0_s_);
+  tree->Branch("d0_d", &v.d0_d_);
+  tree->Branch("z0_s", &v.z0_s_);
+  tree->Branch("z0_d", &v.z0_d_);
+  tree->Branch("phi_s", &v.phi_s_);
+  tree->Branch("phi_d", &v.phi_d_);
+  tree->Branch("theta_s", &v.theta_s_);
+  tree->Branch("theta_d", &v.theta_d_);
+  tree->Branch("qop_s", &v.qop_s_);
+  tree->Branch("qop_d", &v.qop_d_);
+  tree->Branch("p_s", &v.p_s_);
+  tree->Branch("p_d", &v.p_d_);
+  tree->Branch("delta_d0", &v.delta_d0_);
+  tree->Branch("delta_z0", &v.delta_z0_);
+  tree->Branch("delta_phi", &v.delta_phi_);
+  tree->Branch("delta_theta", &v.delta_theta_);
+  tree->Branch("delta_p_over_p", &v.delta_p_over_p_);
+  tree->Branch("px_s", &v.px_s_);
+  tree->Branch("py_s", &v.py_s_);
+  tree->Branch("pz_s", &v.pz_s_);
+  tree->Branch("px_d", &v.px_d_);
+  tree->Branch("py_d", &v.py_d_);
+  tree->Branch("pz_d", &v.pz_d_);
+  tree->Branch("px_t", &v.px_t_);
+  tree->Branch("py_t", &v.py_t_);
+  tree->Branch("pz_t", &v.pz_t_);
+  tree->Branch("p_t", &v.p_t_);
+  tree->Branch("vx_t", &v.vx_t_);
+  tree->Branch("vy_t", &v.vy_t_);
+  tree->Branch("vz_t", &v.vz_t_);
+  tree->Branch("delta_p_over_p_s", &v.delta_p_over_p_s_);
+  tree->Branch("delta_p_over_p_d", &v.delta_p_over_p_d_);
 }
 
 void TrackComparisonProcessor::onProcessStart() {
@@ -145,73 +145,73 @@ void TrackComparisonProcessor::fillPair(const ldmx::Track& smear,
                                         const ldmx::SimParticle& truth,
                                         PairVars& v,
                                         const std::string& prefix) {
-  v.track_id = smear.getTrackID();
-  v.truth_prob_s = smear.getTruthProb();
-  v.truth_prob_d = digi.getTruthProb();
-  v.nhits_s = smear.getNhits();
-  v.nhits_d = digi.getNhits();
-  v.chi2ndf_s = (smear.getNdf() > 0) ? smear.getChi2() / smear.getNdf() : -1;
-  v.chi2ndf_d = (digi.getNdf() > 0) ? digi.getChi2() / digi.getNdf() : -1;
-  v.d0_s = smear.getD0();
-  v.d0_d = digi.getD0();
-  v.z0_s = smear.getZ0();
-  v.z0_d = digi.getZ0();
-  v.phi_s = smear.getPhi();
-  v.phi_d = digi.getPhi();
-  v.theta_s = smear.getTheta();
-  v.theta_d = digi.getTheta();
-  v.qop_s = smear.getQoP();
-  v.qop_d = digi.getQoP();
+  v.track_id_ = smear.getTrackID();
+  v.truth_prob_s_ = smear.getTruthProb();
+  v.truth_prob_d_ = digi.getTruthProb();
+  v.nhits_s_ = smear.getNhits();
+  v.nhits_d_ = digi.getNhits();
+  v.chi2ndf_s_ = (smear.getNdf() > 0) ? smear.getChi2() / smear.getNdf() : -1;
+  v.chi2ndf_d_ = (digi.getNdf() > 0) ? digi.getChi2() / digi.getNdf() : -1;
+  v.d0_s_ = smear.getD0();
+  v.d0_d_ = digi.getD0();
+  v.z0_s_ = smear.getZ0();
+  v.z0_d_ = digi.getZ0();
+  v.phi_s_ = smear.getPhi();
+  v.phi_d_ = digi.getPhi();
+  v.theta_s_ = smear.getTheta();
+  v.theta_d_ = digi.getTheta();
+  v.qop_s_ = smear.getQoP();
+  v.qop_d_ = digi.getQoP();
   // QoP is in e/GeV (ACTS units); convert to MeV so p_s/p_d match SimParticle
   // units.
-  v.p_s = (v.qop_s != 0) ? std::abs(1000.0 / v.qop_s) : -1;
-  v.p_d = (v.qop_d != 0) ? std::abs(1000.0 / v.qop_d) : -1;
-  v.delta_d0 = v.d0_d - v.d0_s;
-  v.delta_z0 = v.z0_d - v.z0_s;
-  v.delta_phi = v.phi_d - v.phi_s;
-  v.delta_theta = v.theta_d - v.theta_s;
-  v.delta_p_over_p = (v.p_s > 0) ? (v.p_d - v.p_s) / v.p_s : -999;
+  v.p_s_ = (v.qop_s_ != 0) ? std::abs(1000.0 / v.qop_s_) : -1;
+  v.p_d_ = (v.qop_d_ != 0) ? std::abs(1000.0 / v.qop_d_) : -1;
+  v.delta_d0_ = v.d0_d_ - v.d0_s_;
+  v.delta_z0_ = v.z0_d_ - v.z0_s_;
+  v.delta_phi_ = v.phi_d_ - v.phi_s_;
+  v.delta_theta_ = v.theta_d_ - v.theta_s_;
+  v.delta_p_over_p_ = (v.p_s_ > 0) ? (v.p_d_ - v.p_s_) / v.p_s_ : -999;
 
   auto mom_s = smear.getMomentumAtTarget();
   if (mom_s.size() == 3) {
-    v.px_s = mom_s[0];
-    v.py_s = mom_s[1];
-    v.pz_s = mom_s[2];
+    v.px_s_ = mom_s[0];
+    v.py_s_ = mom_s[1];
+    v.pz_s_ = mom_s[2];
   }
   auto mom_d = digi.getMomentumAtTarget();
   if (mom_d.size() == 3) {
-    v.px_d = mom_d[0];
-    v.py_d = mom_d[1];
-    v.pz_d = mom_d[2];
+    v.px_d_ = mom_d[0];
+    v.py_d_ = mom_d[1];
+    v.pz_d_ = mom_d[2];
   }
 
   auto mom_t = truth.getMomentum();
-  v.px_t = mom_t[0];
-  v.py_t = mom_t[1];
-  v.pz_t = mom_t[2];
-  v.p_t = std::sqrt(v.px_t * v.px_t + v.py_t * v.py_t + v.pz_t * v.pz_t);
+  v.px_t_ = mom_t[0];
+  v.py_t_ = mom_t[1];
+  v.pz_t_ = mom_t[2];
+  v.p_t_ = std::sqrt(v.px_t_ * v.px_t_ + v.py_t_ * v.py_t_ + v.pz_t_ * v.pz_t_);
   auto vtx = truth.getVertex();
-  v.vx_t = vtx[0];
-  v.vy_t = vtx[1];
-  v.vz_t = vtx[2];
+  v.vx_t_ = vtx[0];
+  v.vy_t_ = vtx[1];
+  v.vz_t_ = vtx[2];
 
-  v.delta_p_over_p_s = (v.p_t > 0) ? (v.p_s - v.p_t) / v.p_t : -999;
-  v.delta_p_over_p_d = (v.p_t > 0) ? (v.p_d - v.p_t) / v.p_t : -999;
+  v.delta_p_over_p_s_ = (v.p_t_ > 0) ? (v.p_s_ - v.p_t_) / v.p_t_ : -999;
+  v.delta_p_over_p_d_ = (v.p_t_ > 0) ? (v.p_d_ - v.p_t_) / v.p_t_ : -999;
 
-  histograms_.fill(prefix + "delta_d0", v.delta_d0);
-  histograms_.fill(prefix + "delta_z0", v.delta_z0);
-  histograms_.fill(prefix + "delta_phi", v.delta_phi);
-  histograms_.fill(prefix + "delta_theta", v.delta_theta);
-  histograms_.fill(prefix + "delta_p_over_p", v.delta_p_over_p);
-  histograms_.fill(prefix + "nhits_s", v.nhits_s);
-  histograms_.fill(prefix + "nhits_d", v.nhits_d);
-  histograms_.fill(prefix + "chi2ndf_s", v.chi2ndf_s);
-  histograms_.fill(prefix + "chi2ndf_d", v.chi2ndf_d);
-  histograms_.fill(prefix + "p_s", v.p_s);
-  histograms_.fill(prefix + "p_d", v.p_d);
-  histograms_.fill(prefix + "p_t", v.p_t);
-  histograms_.fill(prefix + "delta_p_over_p_s", v.delta_p_over_p_s);
-  histograms_.fill(prefix + "delta_p_over_p_d", v.delta_p_over_p_d);
+  histograms_.fill(prefix + "delta_d0", v.delta_d0_);
+  histograms_.fill(prefix + "delta_z0", v.delta_z0_);
+  histograms_.fill(prefix + "delta_phi", v.delta_phi_);
+  histograms_.fill(prefix + "delta_theta", v.delta_theta_);
+  histograms_.fill(prefix + "delta_p_over_p", v.delta_p_over_p_);
+  histograms_.fill(prefix + "nhits_s", v.nhits_s_);
+  histograms_.fill(prefix + "nhits_d", v.nhits_d_);
+  histograms_.fill(prefix + "chi2ndf_s", v.chi2ndf_s_);
+  histograms_.fill(prefix + "chi2ndf_d", v.chi2ndf_d_);
+  histograms_.fill(prefix + "p_s", v.p_s_);
+  histograms_.fill(prefix + "p_d", v.p_d_);
+  histograms_.fill(prefix + "p_t", v.p_t_);
+  histograms_.fill(prefix + "delta_p_over_p_s", v.delta_p_over_p_s_);
+  histograms_.fill(prefix + "delta_p_over_p_d", v.delta_p_over_p_d_);
 }
 
 void TrackComparisonProcessor::processTracker(const framework::Event& event,

--- a/Tracking/src/Tracking/dqm/TrackingRecoDQM.cxx
+++ b/Tracking/src/Tracking/dqm/TrackingRecoDQM.cxx
@@ -353,12 +353,12 @@ void TrackingRecoDQM::trackMonitoring(
         const auto& meas = measurements.at(measurement_idxs[i]);
         int layer = meas.getLayer();
         float meas_u = meas.getLocalPosition()[0];
-        float V = meas.getLocalCovariance()[0];  // cov_uu
-        float C = sm_cov[i];                     // smoothed cov[loc0, loc0]
-        float denom = V - C;
+        float v = meas.getLocalCovariance()[0];  // cov_uu
+        float c = sm_cov[i];                     // smoothed cov[loc0, loc0]
+        float denom = v - c;
         if (denom <= 0.f) continue;  // degenerate — skip
         float r_smooth = meas_u - sm_loc0[i];
-        float res_ubs = r_smooth * V / denom;
+        float res_ubs = r_smooth * v / denom;
         float pull_ubs = r_smooth / std::sqrt(denom);
         histograms_.fill(title_ + "unbiased_res_u_l" + std::to_string(layer),
                          res_ubs);

--- a/Tracking/src/Tracking/dqm/TrackingRecoDQM.cxx
+++ b/Tracking/src/Tracking/dqm/TrackingRecoDQM.cxx
@@ -353,12 +353,12 @@ void TrackingRecoDQM::trackMonitoring(
         const auto& meas = measurements.at(measurement_idxs[i]);
         int layer = meas.getLayer();
         float meas_u = meas.getLocalPosition()[0];
-        float v = meas.getLocalCovariance()[0];  // cov_uu
-        float c = sm_cov[i];                     // smoothed cov[loc0, loc0]
-        float denom = v - c;
+        float V = meas.getLocalCovariance()[0];  // cov_uu
+        float C = sm_cov[i];                     // smoothed cov[loc0, loc0]
+        float denom = V - C;
         if (denom <= 0.f) continue;  // degenerate — skip
         float r_smooth = meas_u - sm_loc0[i];
-        float res_ubs = r_smooth * v / denom;
+        float res_ubs = r_smooth * V / denom;
         float pull_ubs = r_smooth / std::sqrt(denom);
         histograms_.fill(title_ + "unbiased_res_u_l" + std::to_string(layer),
                          res_ubs);


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
This resolves #2072 by completing the to-do's from clang-tidy. There are still warnings emitted by clang-tidy, but they reference dead code in `EventDisplay` or Acts internals that we don't have access to.
The periodic `clang-tidy` run over all of the files will only fail if clang-tidy is able to fix the warnings/errors it detects which is not always the case, so we should still periodically check the output from that weekly run.
