### PR TITLE
docs: fix broken online manual link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ And then you can run ldmx-sw with a configuration script of your choice.
 denv fire my-config.py
 ```
 More detail on configuration scripts and analyzing the output files
-is given in the first section of the [online manual](ldmx-software.github.io).
+is given in the first section of the [online manual](https://ldmx-software.github.io).
 
 ### Developing
 For development, we use a few more tools to help track our changes and share commands


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?

The `online manual` link in the top-level `README.md` uses a schemeless target:

```markdown
[online manual](ldmx-software.github.io)
```

Because it has no `https://` scheme, GitHub renders it as a **relative** link. Clicking it from the rendered README resolves to `https://github.com/LDMX-Software/ldmx-sw/blob/trunk/ldmx-software.github.io`, which returns **HTTP 404** instead of the live documentation site.

This PR adds the `https://` scheme so the link points at `https://ldmx-software.github.io` (**HTTP 200**), matching the scheme already used for the same site in `.github/PULL_REQUEST_TEMPLATE.md`.

Verification:

| Target | Result |
| --- | --- |
| `https://github.com/LDMX-Software/ldmx-sw/blob/trunk/ldmx-software.github.io` (old, relative) | HTTP 404 |
| `https://ldmx-software.github.io` (new) | HTTP 200 |

## Check List
- [ ] I successfully compiled _ldmx-sw_ with my developments.
  - _Not applicable: this is a documentation-only change to `README.md` and does not touch any source code._
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
- [x] I ran my developments and the following shows that they are successful.
  - The old schemeless link resolves to a 404 on github.com; the corrected `https://` link resolves to the live manual (200), as shown in the table above.