### PR TITLE
Fixed python formatting in LUT-related scripts to match ruff standards.

### DIFF
--- a/Tools/python/lut_making.py
+++ b/Tools/python/lut_making.py
@@ -4,22 +4,25 @@ from LDMX.Framework import Processor, processor
 
 
 @processor("tools::ClusterTripletMaker", "Tools")
-class ClusterTripletMaker(Processor) :
+class ClusterTripletMaker(Processor):
     """Configuration for cluster text file maker for Trigger Scintillators"""
 
-    cluster_input_collections: list[str] = ["TriggerPad1Clusters",
-                                            "TriggerPad2Clusters","TriggerPad3Clusters"]
+    cluster_input_collections: list[str] = [
+        "TriggerPad1Clusters",
+        "TriggerPad2Clusters",
+        "TriggerPad3Clusters",
+    ]
     pass_name: str = ""
     output_file: str = "clusters.txt"
     verbosity: int = 0
 
 
 @processor("tools::PatternLUTMaker", "Tools")
-class PatternLUTMaker(Processor) :
+class PatternLUTMaker(Processor):
     """Configuration for track-pattern LUT-writing analyzer for Trigger Scintillators"""
 
-    input_file: str ="clusters.txt"
+    input_file: str = "clusters.txt"
     input_pass_name: str = ""
-    output_file: str ="LUT.txt"
+    output_file: str = "LUT.txt"
     lut_threshold: float = 0.0008
     verbosity: int = 0

--- a/Tools/python/lut_making.py
+++ b/Tools/python/lut_making.py
@@ -1,12 +1,13 @@
 """Configuration for Cluster Triplet text file Maker and Pattern LUT Maker"""
 
-from LDMX.Framework import Processor, processor 
+from LDMX.Framework import Processor, processor
+
 
 @processor("tools::ClusterTripletMaker", "Tools")
 class ClusterTripletMaker(Processor) :
     """Configuration for cluster text file maker for Trigger Scintillators"""
-    
-    cluster_input_collections: list[str] = ["TriggerPad1Clusters", 
+
+    cluster_input_collections: list[str] = ["TriggerPad1Clusters",
                                             "TriggerPad2Clusters","TriggerPad3Clusters"]
     pass_name: str = ""
     output_file: str = "clusters.txt"

--- a/TrigScint/exampleConfigs/runLUTana.py
+++ b/TrigScint/exampleConfigs/runLUTana.py
@@ -7,10 +7,10 @@ from LDMX.Framework import ldmxcfg
 from LDMX.Tools.lut_making import PatternLUTMaker
 
 p = ldmxcfg.Process("LUTmaker")
- 
+
 make_lut = PatternLUTMaker()
 make_lut.lut_threshold = 1.0/1000 #(or whichever threshold you like)
-make_lut.input_file = "clusters.txt" #cluster triplets as produced by ClusterTripletMaker
+make_lut.input_file = "clusters.txt" #cluster triplets produced by ClusterTripletMaker
 make_lut.output_file = "LUT.txt"
 
 p.sequence = [make_lut]

--- a/TrigScint/exampleConfigs/runLUTana.py
+++ b/TrigScint/exampleConfigs/runLUTana.py
@@ -1,7 +1,7 @@
-#Script 3 of 3 to generate new lookup table
-#To use the output file, make sure to turn on LUT tracking in your config:
-#trig_scint_track.lut_tracking = True
-#Creates LUT using PatternLUTMaker for use in LUT-method tracking
+# Script 3 of 3 to generate new lookup table
+# To use the output file, make sure to turn on LUT tracking in your config:
+# trig_scint_track.lut_tracking = True
+# Creates LUT using PatternLUTMaker for use in LUT-method tracking
 
 from LDMX.Framework import ldmxcfg
 from LDMX.Tools.lut_making import PatternLUTMaker
@@ -9,8 +9,8 @@ from LDMX.Tools.lut_making import PatternLUTMaker
 p = ldmxcfg.Process("LUTmaker")
 
 make_lut = PatternLUTMaker()
-make_lut.lut_threshold = 1.0/1000 #(or whichever threshold you like)
-make_lut.input_file = "clusters.txt" #cluster triplets produced by ClusterTripletMaker
+make_lut.lut_threshold = 1.0 / 1000  # (or whichever threshold you like)
+make_lut.input_file = "clusters.txt"  # cluster triplets produced by ClusterTripletMaker
 make_lut.output_file = "LUT.txt"
 
 p.sequence = [make_lut]

--- a/TrigScint/exampleConfigs/runLUTclusterstxt.py
+++ b/TrigScint/exampleConfigs/runLUTclusterstxt.py
@@ -7,15 +7,15 @@
 from LDMX.Framework import ldmxcfg
 
 p = ldmxcfg.Process('nontruthclusters')
-p.input_files =  ["SimSamples.root"] #for a given simulation root file 
+p.input_files =  ["SimSamples.root"] #for a given simulation root file
 p.output_files = ["Clusters.root"]
 #an additional output file called clusters.txt will be created as well
 
 from LDMX.TrigScint.truth_hits import TruthHitProducer
 from LDMX.TrigScint.trig_scint import TrigScintDigiProducer
 
-truth_filtering = False #truth filtering using TruthHitProducer to isolate 
-                        #beam-originating hits/clusters, can help provide 
+truth_filtering = False #truth filtering using TruthHitProducer to isolate
+                        #beam-originating hits/clusters, can help provide
                         #"answer-sheet" LUT
 
 truth_hits = [TruthHitProducer('beamElectronsPad1'),
@@ -35,11 +35,11 @@ digis = [TrigScintDigiProducer.pad1(),
          TrigScintDigiProducer.pad3()
          ]
 
-if truth_filtering == True: 
-    for digi,hits in zip(digis, truth_hits):
+if truth_filtering:
+    for digi,hits in zip(digis, truth_hits, strict=True):
         digi.input_collection = hits.output_collection
     p.sequence = [*truth_hits, *digis]
-if truth_filtering == False: 
+if not truth_filtering:
     p.sequence = [*digis]
 
 from LDMX.TrigScint.trig_scint import TrigScintClusterProducer
@@ -50,7 +50,7 @@ clusters = [
         TrigScintClusterProducer.pad3(),
         ]
 
-for cluster, digi in zip(clusters, digis):
+for cluster, digi in zip(clusters, digis, strict=True):
     cluster.input_collection = digi.output_collection
     cluster.ampl_weighting = False #for LUT making
     cluster.clustering_threshold = 3.0 #helps remove electronics noise

--- a/TrigScint/exampleConfigs/runLUTclusterstxt.py
+++ b/TrigScint/exampleConfigs/runLUTclusterstxt.py
@@ -1,42 +1,44 @@
-#Script 2 of 3 to generate new lookup table
-#Next script is runLUTana.py
+# Script 2 of 3 to generate new lookup table
+# Next script is runLUTana.py
 
-#example config which makes digis, clusters, and writes clusters
-#to .txt file using ClusterTripletMaker
+# example config which makes digis, clusters, and writes clusters
+# to .txt file using ClusterTripletMaker
 
 from LDMX.Framework import ldmxcfg
 
-p = ldmxcfg.Process('nontruthclusters')
-p.input_files =  ["SimSamples.root"] #for a given simulation root file
+p = ldmxcfg.Process("nontruthclusters")
+p.input_files = ["SimSamples.root"]  # for a given simulation root file
 p.output_files = ["Clusters.root"]
-#an additional output file called clusters.txt will be created as well
+# an additional output file called clusters.txt will be created as well
 
 from LDMX.TrigScint.truth_hits import TruthHitProducer
 from LDMX.TrigScint.trig_scint import TrigScintDigiProducer
 
-truth_filtering = False #truth filtering using TruthHitProducer to isolate
-                        #beam-originating hits/clusters, can help provide
-                        #"answer-sheet" LUT
+truth_filtering = False  # truth filtering using TruthHitProducer to isolate
+# beam-originating hits/clusters, can help provide
+# "answer-sheet" LUT
 
-truth_hits = [TruthHitProducer('beamElectronsPad1'),
-              TruthHitProducer('beamElectronsPad2'),
-              TruthHitProducer('beamElectronsPad3')
-              ]
+truth_hits = [
+    TruthHitProducer("beamElectronsPad1"),
+    TruthHitProducer("beamElectronsPad2"),
+    TruthHitProducer("beamElectronsPad3"),
+]
 
 pad_num = 1
 
 for hits in truth_hits:
-    hits.input_collection=f"TriggerPad{pad_num}SimHits"
-    hits.output_collection=f"truthBeamElectronsPad{pad_num}"
-    pad_num+=1
+    hits.input_collection = f"TriggerPad{pad_num}SimHits"
+    hits.output_collection = f"truthBeamElectronsPad{pad_num}"
+    pad_num += 1
 
-digis = [TrigScintDigiProducer.pad1(),
-         TrigScintDigiProducer.pad2(),
-         TrigScintDigiProducer.pad3()
-         ]
+digis = [
+    TrigScintDigiProducer.pad1(),
+    TrigScintDigiProducer.pad2(),
+    TrigScintDigiProducer.pad3(),
+]
 
 if truth_filtering:
-    for digi,hits in zip(digis, truth_hits, strict=True):
+    for digi, hits in zip(digis, truth_hits, strict=True):
         digi.input_collection = hits.output_collection
     p.sequence = [*truth_hits, *digis]
 if not truth_filtering:
@@ -45,20 +47,23 @@ if not truth_filtering:
 from LDMX.TrigScint.trig_scint import TrigScintClusterProducer
 
 clusters = [
-        TrigScintClusterProducer.pad1(),
-        TrigScintClusterProducer.pad2(),
-        TrigScintClusterProducer.pad3(),
-        ]
+    TrigScintClusterProducer.pad1(),
+    TrigScintClusterProducer.pad2(),
+    TrigScintClusterProducer.pad3(),
+]
 
 for cluster, digi in zip(clusters, digis, strict=True):
     cluster.input_collection = digi.output_collection
-    cluster.ampl_weighting = False #for LUT making
-    cluster.clustering_threshold = 3.0 #helps remove electronics noise
+    cluster.ampl_weighting = False  # for LUT making
+    cluster.clustering_threshold = 3.0  # helps remove electronics noise
 
 from LDMX.Tools.lut_making import ClusterTripletMaker
 
 triplets = ClusterTripletMaker()
 
-p.sequence.extend([*clusters,
-                   triplets,
-                   ])
+p.sequence.extend(
+    [
+        *clusters,
+        triplets,
+    ]
+)

--- a/TrigScint/exampleConfigs/runLUTeventgen.py
+++ b/TrigScint/exampleConfigs/runLUTeventgen.py
@@ -1,26 +1,27 @@
-#Script 1 of 3 to generate new lookup table for TSpad tracks
-#All scripts use local paths and are intended to be executed from the same directory
+# Script 1 of 3 to generate new lookup table for TSpad tracks
+# All scripts use local paths and are intended to be executed from the same directory
 
 
-#Creates simulation sample .root file with TS info,
-#where "SimSamples.root" is then an example input file for use in runClusterstxt.py
+# Creates simulation sample .root file with TS info,
+# where "SimSamples.root" is then an example input file for use in runClusterstxt.py
 
 from LDMX.Framework import ldmxcfg
-p = ldmxcfg.Process('simulation')
+
+p = ldmxcfg.Process("simulation")
 
 from LDMX.SimCore import simulator
 from LDMX.SimCore import generators as gen
 
-my_sim = simulator.Simulator( "my_sim" )
-my_sim.set_detector( 'ldmx-det-v14-8gev', True )
-my_sim.generators = [ gen.single_8gev_e_upstream_tagger() ]
-gen.beamSpotSmear = [20.,80.,0.]
-my_sim.description = 'Basic test Simulation'
+my_sim = simulator.Simulator("my_sim")
+my_sim.set_detector("ldmx-det-v14-8gev", True)
+my_sim.generators = [gen.single_8gev_e_upstream_tagger()]
+gen.beamSpotSmear = [20.0, 80.0, 0.0]
+my_sim.description = "Basic test Simulation"
 
-p.sequence = [ my_sim ]
-p.run = 1 #different for each simulation
+p.sequence = [my_sim]
+p.run = 1  # different for each simulation
 p.max_events = 10
-p.output_files = [ 'SimSamples.root' ] #new output file name
+p.output_files = ["SimSamples.root"]  # new output file name
 
 import LDMX.Ecal.ecal_geometry
 import LDMX.Ecal.ecal_hardcoded_conditions

--- a/TrigScint/exampleConfigs/runLUTeventgen.py
+++ b/TrigScint/exampleConfigs/runLUTeventgen.py
@@ -2,7 +2,7 @@
 #All scripts use local paths and are intended to be executed from the same directory
 
 
-#Creates simulation sample .root file with TS info, 
+#Creates simulation sample .root file with TS info,
 #where "SimSamples.root" is then an example input file for use in runClusterstxt.py
 
 from LDMX.Framework import ldmxcfg
@@ -11,13 +11,13 @@ p = ldmxcfg.Process('simulation')
 from LDMX.SimCore import simulator
 from LDMX.SimCore import generators as gen
 
-mySim = simulator.Simulator( "mySim" )
-mySim.set_detector( 'ldmx-det-v14-8gev', True )
-mySim.generators = [ gen.single_8gev_e_upstream_tagger() ]
+my_sim = simulator.Simulator( "my_sim" )
+my_sim.set_detector( 'ldmx-det-v14-8gev', True )
+my_sim.generators = [ gen.single_8gev_e_upstream_tagger() ]
 gen.beamSpotSmear = [20.,80.,0.]
-mySim.description = 'Basic test Simulation'
+my_sim.description = 'Basic test Simulation'
 
-p.sequence = [ mySim ]
+p.sequence = [ my_sim ]
 p.run = 1 #different for each simulation
 p.max_events = 10
 p.output_files = [ 'SimSamples.root' ] #new output file name

--- a/TrigScint/exampleConfigs/runLUTtracking.py
+++ b/TrigScint/exampleConfigs/runLUTtracking.py
@@ -1,4 +1,4 @@
-#Performs tracking with TrigScintTrackProducer, with and without LUT method for comparison
+#Performs tracking with TrigScintTrackProducer, with+without LUT method for comparison
 from LDMX.Framework import ldmxcfg
 
 p = ldmxcfg.Process('tracking')
@@ -10,13 +10,13 @@ from LDMX.TrigScint.trig_scint import TrigScintTrackProducer
 tstp_tracks = TrigScintTrackProducer()
 lut_tracks = TrigScintTrackProducer()
 
-tstp_tracks.delta_max = 1.0 #set to 1.0 for easy comparison to lut_tracks 
+tstp_tracks.delta_max = 1.0 #set to 1.0 for easy comparison to lut_tracks
 tstp_tracks.output_collection = "maxdeltaTracks"
 
 lut_tracks.delta_max = 1.0
 lut_tracks.lut_tracking = True
 lut_tracks.output_collection = "lutTracks"
 
-p.sequence = [tstp_tracks, 
+p.sequence = [tstp_tracks,
               lut_tracks
               ]

--- a/TrigScint/exampleConfigs/runLUTtracking.py
+++ b/TrigScint/exampleConfigs/runLUTtracking.py
@@ -1,7 +1,7 @@
-#Performs tracking with TrigScintTrackProducer, with+without LUT method for comparison
+# Performs tracking with TrigScintTrackProducer, with+without LUT method for comparison
 from LDMX.Framework import ldmxcfg
 
-p = ldmxcfg.Process('tracking')
+p = ldmxcfg.Process("tracking")
 p.input_files = ["Clusters.root"]
 p.output_files = ["Tracks.root"]
 
@@ -10,13 +10,11 @@ from LDMX.TrigScint.trig_scint import TrigScintTrackProducer
 tstp_tracks = TrigScintTrackProducer()
 lut_tracks = TrigScintTrackProducer()
 
-tstp_tracks.delta_max = 1.0 #set to 1.0 for easy comparison to lut_tracks
+tstp_tracks.delta_max = 1.0  # set to 1.0 for easy comparison to lut_tracks
 tstp_tracks.output_collection = "maxdeltaTracks"
 
 lut_tracks.delta_max = 1.0
 lut_tracks.lut_tracking = True
 lut_tracks.output_collection = "lutTracks"
 
-p.sequence = [tstp_tracks,
-              lut_tracks
-              ]
+p.sequence = [tstp_tracks, lut_tracks]


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
<!--
_Hint_: Use the phrase '_This resolves #< issue number >_' so that they are linked automatically.
-->
Just a simple fix of a few files to satisfy the formatting requirements laid out by ruff.
After this, we can probably mark #2035 as closed and completed.

## Check List
- [X] I successfully compiled _ldmx-sw_ with my developments.
- [X] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [X] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
All ruff checks passed. I ran the LUT generation sequence (`runLUTeventgen.py`, `runLUTclusterstxt.py`,` runLUTana.py`) in a test configuration, and the results were identical to doing the same on trunk.