### PR TITLE
add access to log performance

### DIFF
--- a/Framework/python/_process.py
+++ b/Framework/python/_process.py
@@ -75,6 +75,9 @@ class Process:
     histogram_file: str
         output file to store histograms in (optional, only needed if one of
         the processors in the sequence attempts to fill histograms)
+    log_performance: bool
+        whether to log performance timing of the difference processors into a directory
+        in the histogram file (defaults to False, requires a histogram file to be defined)
 
 
     See Also
@@ -109,6 +112,7 @@ class Process:
     random_number_seed_service: RandomNumberSeedService = field(
         init=False, default_factory=RandomNumberSeedService
     )
+    log_performance: bool = False
     __legacy__ = {
         "termLogLevel": "logger.termLevel",
         "fileLogLevel": "logger.fileLevel",


### PR DESCRIPTION
I noticed this when I went to try to use it. You can buypass the name/type checking within the python config classes by doing

```
p.__dict__['log_performance'] = True
```

but we shouldn't _have_ to do that