### PR TITLE
Fix RunHeader leak in writeRunTree

### DIFF
--- a/Framework/src/Framework/EventFile.cxx
+++ b/Framework/src/Framework/EventFile.cxx
@@ -383,6 +383,9 @@ void EventFile::writeRunTree() {
   // create the branch on this tree
   ldmx::RunHeader* the_handle = nullptr;
   run_tree->Branch("RunHeader", "ldmx::RunHeader", &the_handle, 32000, 3);
+  // ROOT allocates a RunHeader when given a null pointer and leaves
+  // ownership with the caller, so take it to avoid leaking it
+  std::unique_ptr<ldmx::RunHeader> root_allocated(the_handle);
 
   // copy over the run headers into the tree
   for (auto& [num, run_header] : run_map_) {


### PR DESCRIPTION
I am updating _ldmx-sw_, here are the details.

### What are the issues that this addresses?
Resolves https://github.com/LDMX-Software/ldmx-sw/issues/2104
 (round 2)

## Check List
- [x] I successfully compiled _ldmx-sw_ with my developments.
- [x] I read, understood and follow the [coding rules](https://ldmx-software.github.io/developing/coding-rules.html).
<!-- If these coding rules are confusing or you need help, still open the PR as a _draft_ and we can help you! -->
- [x] I ran my developments and the following shows that they are successful.
<!-- put plots or some other proof that your developments work and do the intended function -->
